### PR TITLE
Refactor metadata and TSI_analysis

### DIFF
--- a/bin/TSI_analysis.py
+++ b/bin/TSI_analysis.py
@@ -243,16 +243,17 @@ def ComputeTSI():
     
     # 1) find all (device_number, bus_num) pairs for GenGENROU δ-states
     gen_pairs = {
-        (str(data['device_number']), data['bus_num'])  # Note: device_number should work with new metadata
+        (str(data['device_number']), data['bus_num'])
         for data in state_metadata.values()
-        if data.get('model')     == 'GenGENROU'
+        if data.get('model') == 'GenGENROU'
         and data.get('state_name') == 'delta'
     }
 
     # sort so results are deterministic
-    gen_list = sorted(gen_pairs, key=lambda x: (x[1], x[0]))  # sort by bus, then device
+    gen_list = sorted(gen_pairs, key=lambda x: (x[1], x[0]))
 
-    # 2) pull the raw dict for each generator
+    # 2) Load each generator's data ONCE (like original), but don't store all in 3D array
+    print("⟳ Loading generator delta data...")
     delta_dicts = {}
     for device_number, bus_num in gen_list:
         print(f"⟳ loading δ for GenGENROU device {device_number} on bus {bus_num}")
@@ -265,87 +266,89 @@ def ComputeTSI():
             state_name='delta',
             diverged=False
         )
-
         delta_dicts[(bus_num, device_number)] = d
 
     if not delta_dicts:
         raise RuntimeError("No generator deltas were loaded!")
 
     # find common scenarios
-    scenario_sets    = [ set(d.keys()) for d in delta_dicts.values() ]
+    scenario_sets = [set(d.keys()) for d in delta_dicts.values()]
     common_scenarios = sorted(set.intersection(*scenario_sets))
     if not common_scenarios:
         raise RuntimeError("No scenario is common to all generators!")
 
-    # pick one generator‐key and one scenario 
-    first_key      = next(iter(delta_dicts))                # t(bus_num, device_number)
-    first_scenario = next(iter(delta_dicts[first_key]))     # scenario_id string
+    print(f"Found {len(common_scenarios)} common scenarios")
 
-    # get tvec safely
+    # Get dimensions
+    first_key = next(iter(delta_dicts))
+    first_scenario = next(iter(delta_dicts[first_key]))
     tvec = delta_dicts[first_key][first_scenario]['tvec']
-    T    = len(tvec)
-    G    = len(delta_dicts)
-    S    = len(common_scenarios)
+    T = len(tvec)
+    G = len(delta_dicts)
 
-    # build 3D δ-array
-    delta_arr = np.zeros((G, T, S))
-    for g_idx, key in enumerate(delta_dicts):
-        for s_idx, scen in enumerate(common_scenarios):
-            delta_arr[g_idx, :, s_idx] = delta_dicts[key][scen]['values']
-
-     # sampled pg, pl, ql for each scenario 
+    # Initialize result dictionaries
+    tsi_per_scenario = {}
+    tsi_ts_per_scenario = {}
     pg_per_scenario = {}
     pl_per_scenario = {}
     ql_per_scenario = {}
+
+    # 3) Process scenarios one by one (memory efficient)
+    print("⟳ Processing scenarios...")
     for s_idx, scenario_id in enumerate(common_scenarios):
+        if s_idx % 100 == 0:  # Progress indicator
+            print(f"   Processing scenario {s_idx + 1}/{len(common_scenarios)}")
+        
+        # Load scenario data once for pg, pl, ql
         try:
             scenario_data = load_scenario_data(scenario_id, simulation_log)
             pg_per_scenario[scenario_id] = scenario_data['p_gen_scaled']
             pl_per_scenario[scenario_id] = scenario_data['p_load_scaled']
             ql_per_scenario[scenario_id] = scenario_data['q_load_scaled']
+            del scenario_data  # Free immediately
         except Exception as e:
             print(f"Error loading scenario {scenario_id}: {e}")
+            continue
 
-    # TSI (scalar) for each scenario 
-    tsi_per_scenario = {}
-    for s_idx, scen in enumerate(common_scenarios):
-        spread_ts   = delta_arr[:, :, s_idx].max(axis=0) - delta_arr[:, :, s_idx].min(axis=0)
-        Delta_max       = spread_ts.max()                      # maximum spread (radians) over time
-        tsi_scalar  = (2*np.pi - Delta_max) / (2*np.pi + Delta_max) * 100
-        tsi_per_scenario[scen] = tsi_scalar
+        # Extract delta values for this scenario from pre-loaded data
+        delta_values = np.zeros((G, T))
+        for g_idx, key in enumerate(delta_dicts):
+            delta_values[g_idx, :] = delta_dicts[key][scenario_id]['values']
 
-    # TSI time-series for each scenario 
-    tsi_ts_per_scenario = {}
-    for s_idx, scen in enumerate(common_scenarios):
-        spread_ts = delta_arr[:, :, s_idx].max(axis=0) - delta_arr[:, :, s_idx].min(axis=0)
-        tsi_ts    = (2*np.pi - spread_ts) / (2*np.pi + spread_ts) * 100  # shape (T,)
-        tsi_ts_per_scenario[scen] = tsi_ts
+        # Compute TSI for this scenario only
+        spread_ts = delta_values.max(axis=0) - delta_values.min(axis=0)
+        Delta_max = spread_ts.max()
+        tsi_scalar = (2*np.pi - Delta_max) / (2*np.pi + Delta_max) * 100
+        tsi_ts = (2*np.pi - spread_ts) / (2*np.pi + spread_ts) * 100
 
-    # TSI for all scenarios (scalar array) 
-    tsi_all        = np.array([tsi_per_scenario[sc] for sc in common_scenarios])  # shape (S,) in the same order
+        tsi_per_scenario[scenario_id] = tsi_scalar
+        tsi_ts_per_scenario[scenario_id] = tsi_ts
 
-    # TSI time-series for all scenarios (2D array)
-    # shape (S, T), row s is the time-series for scenario common_scenarios
-    tsi_all_time   = np.vstack([tsi_ts_per_scenario[sc] for sc in common_scenarios])
+        # Free memory for this scenario
+        del delta_values, spread_ts, tsi_ts
 
-    #  tsi_per_scenario    : dict { scenario_id -> scalar TSI }
-    #  tsi_ts_per_scenario : dict { scenario_id -> array of TSI over time }
-    #  tsi_all             : np.ndarray, shape (S,), all scalar TSI in order
-    #  tsi_all_time        : np.ndarray, shape (S, T), all TSI time-series in order   
-    post_data={}
-    post_data['tsi_per_scenario']=tsi_per_scenario
-    post_data['tsi_ts_per_scenario']=tsi_ts_per_scenario
-    post_data['tsi_all']=tsi_all
-    post_data['tsi_all_time']=tsi_all_time
-    post_data['pg_per_scenario']=pg_per_scenario
-    post_data['pl_per_scenario']=pl_per_scenario
-    post_data['ql_per_scenario']=ql_per_scenario
+    # Clear the delta_dicts to free memory before creating final arrays
+    del delta_dicts
+
+    # 4) Create final arrays  
+    tsi_all = np.array([tsi_per_scenario[sc] for sc in common_scenarios])
+    tsi_all_time = np.vstack([tsi_ts_per_scenario[sc] for sc in common_scenarios])
+
+    # Package results
+    post_data = {}
+    post_data['tsi_per_scenario'] = tsi_per_scenario
+    post_data['tsi_ts_per_scenario'] = tsi_ts_per_scenario
+    post_data['tsi_all'] = tsi_all
+    post_data['tsi_all_time'] = tsi_all_time
+    post_data['pg_per_scenario'] = pg_per_scenario
+    post_data['pl_per_scenario'] = pl_per_scenario
+    post_data['ql_per_scenario'] = ql_per_scenario
 
     print(f'TSI for all scenarios: {tsi_all.shape}')
     print(f'TSI for all time scenarios: {tsi_all_time.shape}')
     
+    # Plotting code (unchanged)
     try:
-        # Plotting the TSI
         import seaborn as sns
         plt.figure(figsize=(10,5))
         plt.subplot(1,2,1)
@@ -360,7 +363,6 @@ def ComputeTSI():
         for i in range(2):
             plt.subplot(1,2,i+1)
             plt.axvline(0, color='k', ls='--', lw=1.5)  
-
             plt.text(-1, plt.ylim()[1] * 0.95, 'unstable', ha='right', va='top', fontsize=10)
             plt.text(1, plt.ylim()[1] * 0.95, 'stable', ha='left', va='top', fontsize=10)
 

--- a/bin/TSI_analysis.py
+++ b/bin/TSI_analysis.py
@@ -17,7 +17,7 @@ def load_state_metadata(file_path: str = 'state_metadata.json') -> Dict:
 
 def filter_scenarios(
     simulation_log: Dict, 
-    base_load: Optional[float] = None, 
+    sample_idx: Optional[int] = None,
     fault_location: Optional[int] = None,
     fault_impedance: Optional[float] = None,
     diverged: Optional[bool] = None
@@ -28,7 +28,7 @@ def filter_scenarios(
     for scenario_id, data in simulation_log.items():
         match = True
         
-        if base_load is not None and data['base_load'] != base_load:
+        if sample_idx is not None and data.get('sample_idx') != sample_idx:
             match = False
         if fault_location is not None and data['fault_location'] != fault_location:
             match = False
@@ -45,7 +45,7 @@ def filter_scenarios(
 def find_state_index(
     state_metadata: Dict, 
     model: Optional[str] = None, 
-    device_id: Optional[str] = None,
+    device_number: Optional[str] = None,
     bus_num: Optional[int] = None,
     state_name: Optional[str] = None
 ) -> List[int]:
@@ -57,7 +57,7 @@ def find_state_index(
         
         if model is not None and data.get('model') != model:
             match = False
-        if device_id is not None and str(data.get('device_id')) != str(device_id):
+        if device_number is not None and str(data.get('device_number')) != str(device_number):
             match = False
         if bus_num is not None and data.get('bus_num') != bus_num:
             match = False
@@ -103,10 +103,10 @@ def get_state_timeseries_all(
     simulation_log: Dict,
     state_metadata: Dict,
     model: Optional[str] = None,
-    device_id: Optional[str] = None,
+    device_number: Optional[str] = None,
     bus_num: Optional[int] = None,
     state_name: Optional[str] = None,
-    base_load: Optional[float] = None,
+    sample_idx: Optional[int] = None,
     fault_location: Optional[int] = None,
     fault_impedance: Optional[float] = None,
     diverged: Optional[bool] = False
@@ -115,7 +115,7 @@ def get_state_timeseries_all(
     # Filter scenarios
     filtered_scenarios = filter_scenarios(
         simulation_log, 
-        base_load, 
+        sample_idx,
         fault_location,
         fault_impedance,
         diverged
@@ -125,13 +125,13 @@ def get_state_timeseries_all(
     state_indices = find_state_index(
         state_metadata, 
         model, 
-        device_id, 
+        device_number, 
         bus_num,
         state_name
     )
     
     if not state_indices:
-        raise ValueError(f"No states found matching criteria: model={model}, device_id={device_id}, state_name={state_name}")
+        raise ValueError(f"No states found matching criteria: model={model}, device_number={device_number}, state_name={state_name}")
     
     state_idx = state_indices[0]  # Take the first match if multiple
     
@@ -157,7 +157,7 @@ def plot_state_comparison(
     title: str = None,
     xlabel: str = 'Time (s)',
     ylabel: str = None,
-    legend_key: str = 'base_load'
+    legend_key: str = 'fault_location'
 ):
     """Plot comparison of state variables from multiple scenarios."""
     plt.figure(figsize=(10, 6))
@@ -194,7 +194,7 @@ def example_gen1_speed_deviation():
         simulation_log,
         state_metadata,
         model='GenGENROU',
-        device_id='1',
+        device_number='1',
         state_name='w',
         diverged=False
     )
@@ -216,23 +216,23 @@ def example_gen1_speed_deviation():
         simulation_log,
         state_metadata,
         model='GenGENROU',
-        device_id='1',
+        device_number='1',
         state_name='w',
-        base_load=1.0,
+        sample_idx=1,
         diverged=False
     )
     
     plt = plot_state_comparison(
         results_filtered,
-        title='Generator 1 Speed Deviation (Load Level = 1.0)',
+        title='Generator 1 Speed Deviation (Sample Index = 1)',
         ylabel='Speed Deviation (pu)',
         legend_key='fault_location'
     )
     
-    plt.savefig('gen1_speed_comparison_load1.png')
+    plt.savefig('gen1_speed_comparison_sample1.png')
     
     print(f"Found {len(results)} non-diverged scenarios")
-    print(f"Found {len(results_filtered)} non-diverged scenarios at base_load=1.0")
+    print(f"Found {len(results_filtered)} non-diverged scenarios at sample_idx=1")
     
     return results
 
@@ -241,9 +241,9 @@ def ComputeTSI():
     simulation_log = load_simulation_log()
     state_metadata = load_state_metadata()
     
-    # 1) find all (device_id, bus_num) pairs for GenGENROU δ-states
+    # 1) find all (device_number, bus_num) pairs for GenGENROU δ-states
     gen_pairs = {
-        (str(data['device_id']), data['bus_num'])
+        (str(data['device_number']), data['bus_num'])  # Note: device_number should work with new metadata
         for data in state_metadata.values()
         if data.get('model')     == 'GenGENROU'
         and data.get('state_name') == 'delta'
@@ -254,19 +254,19 @@ def ComputeTSI():
 
     # 2) pull the raw dict for each generator
     delta_dicts = {}
-    for device_id, bus_num in gen_list:
-        print(f"⟳ loading δ for GenGENROU device {device_id} on bus {bus_num}")
+    for device_number, bus_num in gen_list:
+        print(f"⟳ loading δ for GenGENROU device {device_number} on bus {bus_num}")
         d = get_state_timeseries_all(
             simulation_log,
             state_metadata,
             model='GenGENROU',
-            device_id=device_id,
+            device_number=device_number,
             bus_num=bus_num,
             state_name='delta',
             diverged=False
         )
 
-        delta_dicts[(bus_num, device_id)] = d
+        delta_dicts[(bus_num, device_number)] = d
 
     if not delta_dicts:
         raise RuntimeError("No generator deltas were loaded!")
@@ -278,7 +278,7 @@ def ComputeTSI():
         raise RuntimeError("No scenario is common to all generators!")
 
     # pick one generator‐key and one scenario 
-    first_key      = next(iter(delta_dicts))                # t(bus_num, device_id)
+    first_key      = next(iter(delta_dicts))                # t(bus_num, device_number)
     first_scenario = next(iter(delta_dicts[first_key]))     # scenario_id string
 
     # get tvec safely

--- a/bin/dynamics_driver.py
+++ b/bin/dynamics_driver.py
@@ -92,14 +92,11 @@ def main():
     # Run integration
     results = integrate_system(psys, config)
 
-    # Further processing or plotting can be done here
-    # Example:
-    # plt.plot(results["tvec"], results["values"])
-    # plt.xlabel('Time (s)')
-    # plt.ylabel('Sensitivity Value')
-    # plt.title('Load Sensitivities Over Time')
-    # plt.legend(['Parameter 1', 'Parameter 2', ...])
-    # plt.show()
+    bus_idx = psys.genspeed_idx_set()
 
+    for bus in bus_idx:
+        label = "generator at bus %d" % (bus)
+        plt.plot(results["tvec"], results["history"][bus,:], label=label, color='blue')
+    plt.show()
 if __name__ == "__main__":
     main()

--- a/bin/generate_scenarios.py
+++ b/bin/generate_scenarios.py
@@ -173,6 +173,13 @@ def run_simulation_driver_batched(
 
 def main():
     PowerGridModel = "IEEE-9"
+
+    # Scenario sampling configuration
+    SAMPLES_PER_FAULT_LOCATION = 10     # Samples per fault location
+    FAULT_IMPEDANCES = [0.0001]         # Fault impedance values [p.u]
+    N_JOBS = 10
+    BATCH_SIZE = 10
+
     if PowerGridModel == "IEEE-9":
         raw = "data/ieee9_v33.raw"
         dyr = "data/ieee9bus_gov.dyr"
@@ -184,12 +191,17 @@ def main():
     else:
         raise RuntimeError(f"{PowerGridModel} is an invalid model!")
 
-    number_of_samples = 50             
     fault_locations   = list(range(1, n_bus + 1))
-    fault_impedances  = [0.0001]
+
+    # Calculate total scenarios
+    total_scenarios = SAMPLES_PER_FAULT_LOCATION * len(fault_locations) * len(FAULT_IMPEDANCES)
+    print(f"Configuration: {total_scenarios} total scenarios")
+    print(f"  - {SAMPLES_PER_FAULT_LOCATION} noise samples per fault location")
+    print(f"  - {len(fault_locations)} fault locations.")
+    print(f"  - {len(FAULT_IMPEDANCES)} fault impedances: {FAULT_IMPEDANCES}")
 
     scenarios = sample_scenarios(
-        number_of_samples, fault_locations, fault_impedances)
+        SAMPLES_PER_FAULT_LOCATION, fault_locations, FAULT_IMPEDANCES)
     metadata  = generate_metadata(scenarios)
 
     # noise settings
@@ -203,8 +215,7 @@ def main():
         raw, dyr, metadata,
         noise_type=noise_type, noise_var=noise_var,
         balance_generation=balance_generation,
-        n_jobs=5, batch_size=10)
-
+        n_jobs=N_JOBS, batch_size=BATCH_SIZE)
 
 if __name__ == "__main__":
     main()

--- a/bin/retrieve_scenarios.py
+++ b/bin/retrieve_scenarios.py
@@ -16,9 +16,9 @@ def load_state_metadata(file_path: str = 'state_metadata.json') -> Dict:
 
 def filter_scenarios(
     simulation_log: Dict, 
-    base_load: Optional[float] = None, 
     fault_location: Optional[int] = None,
     fault_impedance: Optional[float] = None,
+    sample_idx: Optional[int] = None,
     diverged: Optional[bool] = None
 ) -> Dict:
     """Filter scenarios based on criteria."""
@@ -27,11 +27,11 @@ def filter_scenarios(
     for scenario_id, data in simulation_log.items():
         match = True
         
-        if base_load is not None and data['base_load'] != base_load:
-            match = False
         if fault_location is not None and data['fault_location'] != fault_location:
             match = False
         if fault_impedance is not None and data['fault_impedance'] != fault_impedance:
+            match = False
+        if sample_idx is not None and data['sample_idx'] != sample_idx:
             match = False
         if diverged is not None and data['diverged'] != diverged:
             match = False
@@ -44,7 +44,7 @@ def filter_scenarios(
 def find_state_index(
     state_metadata: Dict, 
     model: Optional[str] = None, 
-    device_id: Optional[str] = None,
+    device_number: Optional[str] = None,
     state_name: Optional[str] = None,
     bus_num: Optional[int] = None
 ) -> List[int]:
@@ -56,7 +56,7 @@ def find_state_index(
         
         if model is not None and data.get('model') != model:
             match = False
-        if device_id is not None and str(data.get('device_id')) != str(device_id):
+        if device_number is not None and str(data.get('device_number')) != str(device_number):
             match = False
         if state_name is not None and data.get('state_name') != state_name:
             match = False
@@ -99,21 +99,21 @@ def get_state_timeseries_all(
     simulation_log: Dict,
     state_metadata: Dict,
     model: Optional[str] = None,
-    device_id: Optional[str] = None,
+    device_number: Optional[str] = None,
     state_name: Optional[str] = None,
     bus_num: Optional[int] = None,
-    base_load: Optional[float] = None,
     fault_location: Optional[int] = None,
     fault_impedance: Optional[float] = None,
+    sample_idx: Optional[int] = None,
     diverged: Optional[bool] = False
 ) -> Dict[str, Dict[str, Union[np.ndarray, Any]]]:
     """Extract a state variable from multiple scenarios with filtering."""
     # Filter scenarios
     filtered_scenarios = filter_scenarios(
         simulation_log, 
-        base_load, 
         fault_location,
         fault_impedance,
+        sample_idx,
         diverged
     )
     
@@ -121,7 +121,7 @@ def get_state_timeseries_all(
     state_indices = find_state_index(
         state_metadata, 
         model, 
-        device_id, 
+        device_number, 
         state_name,
         bus_num
     )
@@ -129,7 +129,7 @@ def get_state_timeseries_all(
     if not state_indices:
         criteria = {k: v for k, v in {
             "model": model, 
-            "device_id": device_id, 
+            "device_number": device_number, 
             "state_name": state_name,
             "bus_num": bus_num
         }.items() if v is not None}
@@ -160,7 +160,7 @@ def plot_state_comparison(
     title: str = None,
     xlabel: str = 'Time (s)',
     ylabel: str = None,
-    legend_key: str = 'base_load'
+    legend_key: str = 'fault_location'  # Changed from 'base_load' to 'fault_location'
 ):
     """Plot comparison of state variables from multiple scenarios."""
     plt.figure(figsize=(10, 6))
@@ -245,112 +245,101 @@ def get_states_by_bus(
     
     return results
 
-# Example usage
-def example_gen1_speed_deviation():
-    """Example that extracts generator 1 speed deviation for all scenarios."""
-    # Load metadata
+def example_all_generator_speeds():
+    """Example that plots speed deviations for all generators."""
     simulation_log = load_simulation_log()
     state_metadata = load_state_metadata()
     
-    # Get all generator 1 speed deviations from non-diverged simulations
+    # Get speed deviations for all generators from non-diverged simulations
     results = get_state_timeseries_all(
         simulation_log,
         state_metadata,
         model='GenGENROU',
-        device_id='1',
         state_name='w',
-        diverged=False
-    )
-    
-    # Plot results grouped by base load
-    plt = plot_state_comparison(
-        results,
-        title='Generator 1 Speed Deviation',
-        ylabel='Speed Deviation (pu)',
-        legend_key='base_load'
-    )
-    
-    # Save figure
-    plt.savefig('gen1_speed_comparison.png')
-    plt.close()
-    
-    # Now filter by fault location and show for a specific load level
-    results_filtered = get_state_timeseries_all(
-        simulation_log,
-        state_metadata,
-        model='GenGENROU',
-        device_id='1',
-        state_name='w',
-        base_load=1.0,
         diverged=False
     )
     
     plt = plot_state_comparison(
-        results_filtered,
-        title='Generator 1 Speed Deviation (Load Level = 1.0)',
+        results,
+        title='All Generator Speed Deviations',
         ylabel='Speed Deviation (pu)',
         legend_key='fault_location'
     )
     
-    plt.savefig('gen1_speed_comparison_load1.png')
+    plt.savefig('all_generator_speeds.png')
+    plt.close()
     
-    print(f"Found {len(results)} non-diverged scenarios")
-    print(f"Found {len(results_filtered)} non-diverged scenarios at base_load=1.0")
-    
+    print(f"Found {len(results)} non-diverged scenarios with generator speed data")
     return results
 
-def example_bus_analysis():
-    """Plot generator speed deviations at bus 2."""
+def example_generator4_states():
+    """Example that plots speed and angle for generator with device ID 4."""
     simulation_log = load_simulation_log()
     state_metadata = load_state_metadata()
-
-    # Find all generator speed deviation states at bus 2
-    speed_states = {}
-    for state_idx, data in state_metadata.items():
-        # Ensure bus_num is an int and matches 2
-        try:
-            bus_match = int(data.get('bus_num', -1)) == 2
-        except Exception:
-            bus_match = False
-
-        # Flexible generator and speed state matching
-        is_generator = 'model' in data and 'gen' in data['model'].lower()
-        is_speed = 'state_name' in data and any(
-            key in data['state_name'].lower() for key in ['w', 'omega', 'speed', 'dw', 'delta_omega']
-        )
-
-        if bus_match and is_generator and is_speed:
-            speed_states[state_idx] = data
-
-    if not speed_states:
-        print("No speed deviation states found for generators at bus 2")
-        return
-
-    # Use the first non-diverged scenario
-    filtered_scenarios = filter_scenarios(simulation_log, diverged=False)
-    if not filtered_scenarios:
-        print("No suitable scenarios found")
-        return
-
-    import matplotlib.pyplot as plt
-    plt.figure(figsize=(10, 6))
-
-    for scenario_id in filtered_scenarios:
-        scenario_data = load_scenario_data(scenario_id, simulation_log)
-        for state_idx, state_info in speed_states.items():
-            tvec, values = get_state_timeseries(scenario_data, int(state_idx))
-            label = f"{state_info.get('model', 'Unknown')} {state_info.get('device_id', 'Unknown')} ({state_info.get('state_name', 'Unknown')}) | Scenario {scenario_id}"
-            plt.plot(tvec, values, label=label, alpha=0.5, color='gray')
-
-    plt.title("Generator Speed Deviations at Bus 2 (All Scenarios)")
-    plt.xlabel("Time (s)")
-    plt.ylabel("Speed Deviation")
-    plt.grid(True)
+    
+    # Get speed (w) and angle (delta) for generator 4
+    speed_results = get_state_timeseries_all(
+        simulation_log,
+        state_metadata,
+        model='GenGENROU',
+        device_number='4',
+        state_name='w',
+        diverged=False
+    )
+    
+    angle_results = get_state_timeseries_all(
+        simulation_log,
+        state_metadata,
+        model='GenGENROU',
+        device_number='4',
+        state_name='delta',
+        diverged=False
+    )
+    
+    # Create subplot figure
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 10))
+    
+    # Plot speed deviations
+    plt.sca(ax1)
+    for scenario_id, data in speed_results.items():
+        tvec = data['tvec']
+        values = data['values']
+        if len(tvec) > 0 and len(values) > 0:
+            ax1.plot(tvec, values, color='blue', alpha=0.3)
+    
+    ax1.set_title('Generator 4 Speed Deviation')
+    ax1.set_ylabel('Speed Deviation (pu)')
+    ax1.grid(True)
+    
+    # Plot rotor angles
+    plt.sca(ax2)
+    for scenario_id, data in angle_results.items():
+        tvec = data['tvec']
+        values = data['values']
+        if len(tvec) > 0 and len(values) > 0:
+            ax2.plot(tvec, values, color='red', alpha=0.3)
+    
+    ax2.set_title('Generator 4 Rotor Angle')
+    ax2.set_xlabel('Time (s)')
+    ax2.set_ylabel('Rotor Angle (rad)')
+    ax2.grid(True)
+    
     plt.tight_layout()
-    plt.savefig('bus2_speed_deviations_all_scenarios.png')
-    print(f"Plotted speed deviations for {len(filtered_scenarios)} scenarios and {len(speed_states)} states.")
-    return speed_states
+    plt.savefig('generator4_speed_angle.png')
+    plt.close()
+    
+    print(f"Found {len(speed_results)} scenarios with Generator 4 speed data")
+    print(f"Found {len(angle_results)} scenarios with Generator 4 angle data")
+    
+    return speed_results, angle_results
 
 if __name__ == "__main__":
-    example_gen1_speed_deviation()
-    example_bus_analysis()
+    print("Running generator analysis examples...")
+    
+    print("1. All generator speed deviations")
+    example_all_generator_speeds()
+    
+    print("2. Generator 4 speed and angle analysis")
+    example_generator4_states()
+    
+    print("Analysis complete! Check the generated PNG files.")

--- a/uqgrid/core/psydef.py
+++ b/uqgrid/core/psydef.py
@@ -834,7 +834,8 @@ class Psystem:
         # Process differential states
         for device in self.devices:
             model_name = device.__class__.__name__
-            device_id = device.id_tag
+            device_number = device.ndev
+            bus = self.buses[device.bus].id
             
             # Handle differential states
             for i in range(device.dif_dim):
@@ -847,17 +848,18 @@ class Psystem:
                 metadata[str(state_idx)] = {
                     'type': 'Differential',
                     'model': model_name,
-                    'device_id': device_id,
+                    'device_number': device_number,
+                    'bus_num': self.buses[device.bus].id,
                     'state_name': state_name,
-                    'description': f"{model_name} {device_id} {state_name}",
-                    'bus_num': self.buses[device.bus].id
+                    'description': f"{model_name} {device_number} {state_name}"
                 }
                 state_idx += 1
         
         # Process algebraic states
         for device in self.devices:
             model_name = device.__class__.__name__
-            device_id = device.id_tag
+            device_number = device.ndev
+            bus = self.buses[device.bus].id
             
             # Handle algebraic states
             for i in range(device.alg_dim):
@@ -870,9 +872,10 @@ class Psystem:
                 metadata[str(state_idx)] = {
                     'type': 'Algebraic',
                     'model': model_name,
-                    'device_id': device_id,
+                    'device_number': device_number,
+                    'bus_num': bus,
                     'state_name': state_name,
-                    'description': f"{model_name} {device_id} {state_name}"
+                    'description': f"{model_name} {device_number} {state_name}"
                 }
                 state_idx += 1
         


### PR DESCRIPTION
In this PR:

- I added `device_number` and `bus_num` fields to the dynamic devices in state_metadata. Before devices were only distinguished by id but the id is just a local tag. The device number is a global id number that identifies each dynamic device (e.g., you can have GEN - 0, LOAD - 1, LOAD -2, GEN - 3, etc.

- I have updated retrieve_scenarios.py and TSI_analysis.py with the new metadata. I have also removed obsolete references to the `base_load` field.

- I have refactored TSI_analysis to not load every scenario in memory but delete scenarios as the TSI index is computed.