### PR TITLE
Correct the way transformers are added to YBus; the indexes seem flipped

### DIFF
--- a/uqgrid/models/network.py
+++ b/uqgrid/models/network.py
@@ -45,14 +45,14 @@ def createYbusComplex(psys):
 
         # charging susceptance
 
-        ybus_dict[to][to] += ((1j*0.5*branch.sh)/(tap*tap))
-        ybus_dict[fr][fr] += 1j*0.5*branch.sh
+        ybus_dict[fr][fr] += ((1j*0.5*branch.sh)/(tap*tap))
+        ybus_dict[to][to] += 1j*0.5*branch.sh
 
     for shunt in psys.shunts:
 
         if shunt.bus not in ybus_dict:
-            ybus_dict[to] = {}
-            ybus_dict[to][to] = 0.0
+            ybus_dict[shunt.bus] = {}
+            ybus_dict[shunt.bus][shunt.bus] = 0.0
 
         ybus_dict[shunt.bus][shunt.bus] += shunt.gsh + 1j*shunt.bsh
 

--- a/uqgrid/simulation/pflow.py
+++ b/uqgrid/simulation/pflow.py
@@ -351,7 +351,15 @@ def runpf(psys, verbose=False):
 
     # https://github.com/scipy/scipy/blob/main/scipy/optimize/_nonlin.py#L116
     # The only solver in SciPy that allowed me to pass a sparse Jacobian
+    if verbose:
+        initial_residual = fun(x0)
+        print(f"[Power Flow] Initial residual norm: {np.linalg.norm(initial_residual):.6e}")
+    
     sol, info = nonlin_solve(fun, x0, jacobian=jac, full_output=True, f_tol=1e-9)
+    
+    if verbose:
+        final_residual = fun(sol)
+        print(f"[Power Flow] Final residual norm: {np.linalg.norm(final_residual):.6e}")
 
     if info["success"]:
         if verbose: print("Power flow converged.")


### PR DESCRIPTION
Looking at difference with the formulation in the Go competition document there seems to be a disageement on how transformers are incorporated in the Ybus. 

This PR corrects the way transformers are added to YBus; the indexes seem flipped. Also, correcting the iterator on the shunt bus