### PR TITLE
Scenario load stress diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,6 @@ Thumbs.db
 *.pdf
 *.swo
 
+
 # Documentation builds
 site/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "networkx>=2.6.0",
     "pydantic>=2.0.0",
     "numdifftools>=0.9.41",
+    "joblib>=1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/run/README.md
+++ b/scripts/run/README.md
@@ -13,9 +13,9 @@ scripts/run/
 ├── recovery_tool.py         # Recovery utilities for failed scenarios
 └── config/                  # Configuration files
     ├── config_IEEE-9.json
+    ├── config_IEEE-9_stress.json
     ├── config_IEEE-39.json
-    ├── config_ACTIVSg200.json
-    └── config_ACTIVSg500.json
+    └── config_IEEE-39_stress.json
 ```
 
 ## Quick Start
@@ -28,7 +28,7 @@ python generate_scenarios.py config/config_IEEE-9.json
 python monitor.py
 
 # 3. Analyze results and compute TSI
-python TSI_analysis.py
+python ../postprocess/TSI_analysis.py
 ```
 
 ---
@@ -43,8 +43,15 @@ Main script for generating perturbed scenarios and running transient stability s
 - Multiplicative perturbations with configurable noise distributions (normal/uniform)
 - Independent control over load and generator perturbations
 - Power factor preservation
+- Deterministic load stress via `load_scale` and `load_mean_shift`
 - Generator limit enforcement (clamping)
 - Generation-load balance maintenance
+- Optional PF-aware operating-point preparation before dynamics
+- Optional non-slack generation rebalance and slack mismatch redistribution
+- Optional PF-loss compensation using automatic generator participation policies
+- Optional rejection of non-converged or over-stressed operating points
+- Optional accepted operating-point target mode with complete fault grids
+- Per-scenario diagnostics for voltage, slack burden, generator limits, branch loading, and PF residual
 - Parallel execution with checkpointing
 - Continuation mode to add more samples to existing runs
 - Configurable integration parameters (simulation time, fault timing, solver options)
@@ -66,6 +73,8 @@ python generate_scenarios.py config/config_IEEE-9.json --continue --additional-s
 - `simulation_data/scenario_*.npz` - Per-scenario simulation results
 - `simulation_log.json` - Simulation outcomes and metadata
 - `scenario_metadata.json` - Scenario parameter definitions
+- `scenario_diagnostics.jsonl` - Per-scenario operating-point diagnostics when stress/PF screening is active
+- `scenario_diagnostics_summary.json` - Compact summary of diagnostics and rejection reasons
 
 ---
 
@@ -115,7 +124,7 @@ python recovery_tool.py
 
 ### TSI_analysis.py
 
-Is located in `/scripts/postprocessing`
+Located in `scripts/postprocess/`.
 
 Computes Transient Stability Index (TSI) from simulation results and exports datasets for machine learning.
 
@@ -132,16 +141,16 @@ where Δ_max is the maximum spread between generator rotor angles.
 
 ```bash
 # Default: use final TSI (steady-state stability)
-python TSI_analysis.py
+python ../postprocess/TSI_analysis.py
 
 # Use minimum TSI across all time steps (worst-case stability)
-python TSI_analysis.py --tsi-mode min
+python ../postprocess/TSI_analysis.py --tsi-mode min
 
 # Custom output path
-python TSI_analysis.py -o my_dataset.npz --tsi-mode min
+python ../postprocess/TSI_analysis.py -o my_dataset.npz --tsi-mode min
 
 # Show all options
-python TSI_analysis.py --help
+python ../postprocess/TSI_analysis.py --help
 ```
 
 **Output:**
@@ -152,8 +161,23 @@ python TSI_analysis.py --help
 ## Configuration
 
 Configuration files are stored in `config/` and define all simulation parameters.
+The baseline configs, such as `config_IEEE-9.json` and `config_IEEE-39.json`,
+intentionally keep the original minimal schema. They do not need the newer
+`operating_point`, `load_scale`, `target_accepted_scenarios`, or related stress
+keys because `generate_scenarios.py` supplies backward-compatible defaults.
+
+Use separate `*_stress.json` configs when you want to opt into the newer
+PF-aware workflow: deterministic load scaling, AC PF screening, loss
+compensation, Q-limit mitigation, diagnostics, and accepted operating-point
+target mode. Keeping both files is recommended:
+
+- `config_*.json`: legacy/default behavior and broad compatibility.
+- `config_*_stress.json`: explicit stressed operating-point generation.
 
 ### Structure
+
+The example below shows the expanded schema with optional stress/PF fields. A
+baseline config may omit those optional fields and still run.
 
 ```json
 {
@@ -166,7 +190,9 @@ Configuration files are stored in `config/` and define all simulation parameters
     "scenarios": {
         "samples_per_fault_location": 5,
         "fault_impedances": [0.00001],
-        "fault_locations": "all"
+        "fault_locations": "all",
+        "target_accepted_scenarios": null,
+        "max_total_attempts": null
     },
     "execution": {
         "n_jobs": 5,
@@ -182,7 +208,35 @@ Configuration files are stored in `config/` and define all simulation parameters
         "perturb_loads": true,
         "perturb_gens": true,
         "keep_power_factor": true,
-        "clamp_gens": true
+        "clamp_gens": true,
+        "load_scale": 1.0,
+        "load_mean_shift": 0.0,
+        "generation_dispatch_init": "perturbed"
+    },
+    "operating_point": {
+        "enabled": false,
+        "run_power_flow": true,
+        "rebalance_non_slack": true,
+        "redistribute_slack_mismatch": true,
+        "rebalance_policy": "headroom",
+        "loss_compensation": false,
+        "loss_compensation_tolerance_pu": 1e-4,
+        "loss_compensation_policy": "headroom",
+        "q_limit_mitigation": false,
+        "q_limit_mitigation_tolerance_pu": 1e-6,
+        "q_limit_mitigation_max_passes": 10,
+        "q_limit_mitigation_top_n": 10,
+        "max_iterations": 5,
+        "max_attempts_per_scenario": 50,
+        "pf_residual_tol": 1e-8,
+        "slack_p_tolerance_pu": 1e-4,
+        "max_slack_p_deviation_fraction_of_load": 0.02,
+        "voltage_min": 0.90,
+        "voltage_max": 1.10,
+        "gen_limit_tolerance": 1e-6,
+        "branch_loading_max": 1.0,
+        "diagnostics_file": "scenario_diagnostics.jsonl",
+        "diagnostics_summary_file": "scenario_diagnostics_summary.json"
     },
     "integration": {
         "tend": 10.0,
@@ -207,6 +261,8 @@ Configuration files are stored in `config/` and define all simulation parameters
 | **scenarios** | `samples_per_fault_location` | Number of perturbation samples per fault |
 | | `fault_impedances` | List of fault impedance values [p.u.] |
 | | `fault_locations` | `"all"` or list of bus indices |
+| | `target_accepted_scenarios` | Optional target count of complete accepted operating-point groups |
+| | `max_total_attempts` | Optional cap on candidate operating-point attempts in target mode |
 | **execution** | `n_jobs` | Number of parallel workers |
 | | `batch_size` | Scenarios per batch |
 | | `checkpoint_interval` | Checkpoint every N batches |
@@ -219,6 +275,32 @@ Configuration files are stored in `config/` and define all simulation parameters
 | | `perturb_gens` | Apply perturbations to generators |
 | | `keep_power_factor` | Maintain Q/P ratio |
 | | `clamp_gens` | Enforce generator limits |
+| | `load_scale` | Deterministic multiplicative load scaling before random perturbations |
+| | `load_mean_shift` | Deterministic relative load shift before random perturbations |
+| | `generation_dispatch_init` | `"perturbed"` or `"base"` generator dispatch before rebalance |
+| **operating_point** | `enabled` | Enable PF-aware operating-point preparation and rejection |
+| | `run_power_flow` | Run UQGrid PF before dynamics |
+| | `rebalance_non_slack` | Rebalance active power on non-slack generators only |
+| | `redistribute_slack_mismatch` | Move residual active slack burden to available non-slack generators |
+| | `rebalance_policy` | Automatic participation policy for initial non-slack rebalance |
+| | `loss_compensation` | Redistribute PF-estimated active losses away from slack before final screening |
+| | `loss_compensation_tolerance_pu` | Stop loss compensation when `abs(slack_p_solved - slack_p_target)` is below this [p.u.]; strict generator P screening also caps the effective tolerance |
+| | `loss_compensation_policy` | Automatic participation policy for loss compensation |
+| | `q_limit_mitigation` | Clamp violating non-slack PV generator Q and switch those buses to PQ before final screening |
+| | `q_limit_mitigation_tolerance_pu` | Q-limit tolerance used before PV-to-PQ switching [p.u.] |
+| | `q_limit_mitigation_max_passes` | Maximum PV-to-PQ mitigation passes per scenario attempt |
+| | `q_limit_mitigation_top_n` | Number of generator Q violators stored in diagnostics |
+| | `max_iterations` | PF/rebalance iterations per attempt |
+| | `max_attempts_per_scenario` | Resampling attempts before rejecting a scenario |
+| | `pf_residual_tol` | Maximum accepted AC PF residual norm |
+| | `slack_p_tolerance_pu` | Absolute slack active-power mismatch tolerance [p.u.] |
+| | `max_slack_p_deviation_fraction_of_load` | Slack active mismatch tolerance as fraction of total load |
+| | `voltage_min` | Minimum accepted bus voltage [p.u.] |
+| | `voltage_max` | Maximum accepted bus voltage [p.u.] |
+| | `gen_limit_tolerance` | Maximum accepted generator P/Q limit violation [p.u.] |
+| | `branch_loading_max` | Maximum accepted branch loading ratio using `rateA` |
+| | `diagnostics_file` | JSONL path for per-scenario diagnostics |
+| | `diagnostics_summary_file` | JSON path for aggregate diagnostics summary |
 | **integration** | `tend` | Simulation end time [s] |
 | | `dt` | Integration time step [s] (default: 1/120) |
 | | `power_injection` | Use power injection model |
@@ -226,6 +308,159 @@ Configuration files are stored in `config/` and define all simulation parameters
 | | `toff` | Fault clearing time [s] |
 | | `verbose` | Enable verbose solver output |
 | | `petsc` | Use PETSc solver |
+
+### Perturbation and Operating-Point Workflow
+
+The script builds one pre-fault operating point per `sample_idx`. That same
+operating point is reused across all fault locations and fault impedances for
+that sample. This is why diagnostics often repeat for multiple fault locations.
+
+For each scenario attempt, the script does the following:
+
+1. Load a fresh RAW/DYR model.
+2. Read base load and generator schedules from the RAW file.
+3. Apply deterministic load stress:
+   ```text
+   load_factor = load_scale * (1 + load_mean_shift)
+   P_load_center = P_load_base * load_factor
+   Q_load_center = Q_load_base * load_factor
+   ```
+4. If `perturb_loads=true`, apply random load perturbations around the stressed
+   load center. If `keep_power_factor=true`, `P_load` and `Q_load` use the same
+   multiplicative perturbation so the load `Q/P` ratio is preserved.
+5. Initialize generator active-power dispatch:
+   - `"perturbed"`: start from randomly perturbed generator `P`.
+   - `"base"`: start from the RAW-file generator `P`.
+6. If `clamp_gens=true`, clamp scheduled generator `P` to `Pmin/Pmax`.
+7. If `operating_point.enabled=false`, use the legacy behavior:
+   - if `balance_generation=true`, rebalance total generation across all
+     generators to match total load;
+   - compute generator `Q` from the generator `Q/P` ratio when
+     `keep_power_factor=true`;
+   - run the dynamic simulation.
+8. If `operating_point.enabled=true`, use the PF-aware behavior:
+   - rebalance active power across non-slack generators only;
+   - run UQGrid AC power flow;
+   - measure slack active/reactive burden, PF residual, voltage range,
+     generator limit violations, and branch loading;
+   - optionally redistribute residual active slack mismatch to non-slack
+     generators with available headroom/footroom;
+   - optionally compensate PF-estimated active losses by redistributing
+     `slack_p_solved - slack_p_target` to non-slack generators before final
+     generator-limit screening;
+   - repeat until tolerances are met or `max_iterations` is reached;
+   - reject and resample the scenario up to `max_attempts_per_scenario`.
+9. For accepted operating points, run the transient simulation with the
+   configured fault onset (`ton`), clearing time (`toff`), and fault impedance.
+
+### Accepted Operating-Point Target Mode
+
+If `scenarios.target_accepted_scenarios` is set, the script switches from a
+fixed fault-level grid to target mode. In this mode, one scenario means one
+accepted load/generator operating point. Each accepted operating point is then
+run through every configured `fault_locations × fault_impedances` combination
+using the same `P_load`, `Q_load`, `P_gen`, and `Q_gen` arrays.
+
+- PF-rejected candidates do not run any faults and do not count toward the
+  target.
+- A candidate counts only if every fault simulation succeeds and writes a
+  trajectory file.
+- The script starts with sample indices `0..samples_per_fault_location-1`, then
+  continues with higher sample indices until the target is reached or
+  `max_total_attempts` is exhausted.
+- With `--continue`, `target_accepted_scenarios` is interpreted as the desired
+  total number of complete accepted operating points, not the number of new
+  operating points to add. Existing complete operating-point groups in
+  `simulation_log.json` count toward the target.
+- Fault-level `scenario_metadata.json` and `simulation_log.json` stay compatible
+  with postprocessing; each row also records `operating_point_id` and
+  `accepted_operating_point_index`.
+
+### Power Factor Behavior
+
+`keep_power_factor=true` preserves the load and generator `Q/P` ratio while
+building the scheduled operating point. It does not force generator `Q` to stay
+fixed after AC PF. During PF:
+
+- PV-bus generator `P` is fixed and generator `Q` is solved.
+- Slack generator `P` and `Q` are solved.
+- PQ-bus load `P` and `Q` are fixed.
+
+Therefore, a scenario can pass PF convergence but still violate generator
+reactive limits. Those violations are reported as `gen_q_violation_max` and are
+rejected when they exceed `gen_limit_tolerance`.
+
+### Feasibility Screening
+
+The operating-point filter is a screening tool, not an ACOPF solver. It checks
+whether the prepared operating point satisfies AC PF and user-defined stress
+limits. It does not optimize generation cost or solve an OPF.
+
+Common interpretations:
+
+- `pf_residual` near zero means the AC PF equations converged.
+- `voltage_min < voltage_min` rejects as `voltage_low`.
+- `voltage_max > voltage_max` rejects as `voltage_high`.
+- `gen_p_violation_max` or `gen_q_violation_max` above
+  `gen_limit_tolerance` rejects as a generator limit violation.
+- `branch_loading_max > branch_loading_max` rejects as `branch_overload`.
+- `slack_p_deviation` above the slack tolerance rejects as
+  `slack_p_deviation`.
+
+For ACOPF-like feasibility screening, use strict limits:
+
+```json
+"operating_point": {
+    "enabled": true,
+    "voltage_min": 0.90,
+    "voltage_max": 1.10,
+    "gen_limit_tolerance": 1e-6,
+    "branch_loading_max": 1.0
+}
+```
+
+Some RAW cases may already violate strict reactive-power or branch-rating
+limits under AC PF. In that case, strict screening can reject every scenario
+even when PF converges.
+
+For stressed dynamic simulations where you want PF-converged but overloaded
+points, loosen the stress limits deliberately:
+
+```json
+"operating_point": {
+    "enabled": true,
+    "voltage_min": 0.85,
+    "voltage_max": 1.10,
+    "gen_limit_tolerance": 10.0,
+    "branch_loading_max": 2.0
+}
+```
+
+This accepts points with larger voltage stress, generator reactive violations,
+or up to 200% branch loading. These points are useful for stress testing, but
+they should not be described as ACOPF-feasible.
+
+### Automatic Participation Policies
+
+`rebalance_policy` and `loss_compensation_policy` use automatic weights only:
+
+- `headroom`: increases use `Pmax - Pg`; decreases use `Pg - Pmin`.
+- `capacity`: uses `Pmax - Pmin`, clipped iteratively to available margin.
+- `current_dispatch`: uses current `Pg`, clipped iteratively.
+- `base_dispatch`: uses RAW/base-case `Pg`, clipped iteratively.
+- `equal`: splits equally across eligible non-slack generators, then clips.
+
+`headroom` is the default because it maximizes the chance of staying inside
+generator active-power limits. These policies do not solve ACOPF; they only
+prepare and screen AC PF operating points.
+
+### Q-Limit Mitigation
+
+`q_limit_mitigation=true` applies a local PF heuristic before final screening:
+non-slack PV generators that exceed `Qmin/Qmax` are clamped at the violated
+limit, and their buses are temporarily switched from PV to PQ for the next PF
+solve. This trades fixed voltage control for fixed reactive output at the
+generator limit. It is not ACOPF and does not modify core UQGrid PF behavior.
 
 ### Available Models
 
@@ -275,6 +510,59 @@ For longer transient analysis (e.g., 20 seconds with smaller time step):
 }
 ```
 
+### Load-Stress Scenario Generation
+
+To create a stressed-load run, copy an existing config and change only the
+fields you need:
+
+```bash
+cp config/config_IEEE-9.json config/config_IEEE-9_stress.json
+```
+
+Example: increase all loads by 25%, preserve load power factor, and screen the
+resulting operating point before dynamics:
+
+```json
+"perturbation": {
+    "load_scale": 1.25,
+    "load_mean_shift": 0.0,
+    "perturb_loads": true,
+    "keep_power_factor": true,
+    "generation_dispatch_init": "perturbed"
+},
+"operating_point": {
+    "enabled": true,
+    "run_power_flow": true,
+    "rebalance_non_slack": true,
+    "redistribute_slack_mismatch": true,
+    "rebalance_policy": "headroom",
+    "loss_compensation": true,
+    "loss_compensation_tolerance_pu": 1e-4,
+    "loss_compensation_policy": "headroom",
+    "voltage_min": 0.90,
+    "voltage_max": 1.10,
+    "gen_limit_tolerance": 1e-6,
+    "branch_loading_max": 1.0
+}
+```
+
+Then run:
+
+```bash
+python generate_scenarios.py config/config_IEEE-9_stress.json
+```
+
+The random perturbation is still applied when `perturb_loads=true`. To run only
+the deterministic load scaling, set:
+
+```json
+"perturbation": {
+    "load_scale": 1.25,
+    "load_mean_shift": 0.0,
+    "perturb_loads": false
+}
+```
+
 ---
 
 ## Workflow Examples
@@ -292,7 +580,7 @@ python monitor.py
 python recovery_tool.py
 
 # 4. Compute TSI and export dataset
-python TSI_analysis.py -o ieee39_dataset.npz
+python ../postprocess/TSI_analysis.py -o ieee39_dataset.npz
 ```
 
 ### Adding More Samples to Existing Run
@@ -307,6 +595,17 @@ python generate_scenarios.py config/config_IEEE-9.json --continue --additional-s
 # Add another 20 samples
 python generate_scenarios.py config/config_IEEE-9.json --continue --additional-samples 20
 ```
+
+For legacy fixed-grid mode, `--additional-samples` controls how many new sample
+indices are appended per fault location.
+
+For target accepted operating-point mode, keep
+`scenarios.target_accepted_scenarios` at the desired final total. The script
+counts existing complete operating-point groups from `simulation_log.json`,
+starts new candidate sampling at the next `sample_idx`, and stops when the
+configured total is reached. `--additional-samples` is still required by the CLI
+when using `--continue`, but target mode uses `target_accepted_scenarios` and
+`max_total_attempts` to decide how much additional sampling to perform.
 
 ### Excluding Problematic Buses
 
@@ -333,7 +632,18 @@ If certain buses cause failures, specify fault locations explicitly in the confi
         "fault_location": 5,
         "fault_impedance": 0.00001,
         "file": "simulation_data/scenario_xxx.npz",
-        "diverged": false
+        "diverged": false,
+        "rejected": false,
+        "diagnostics": {
+            "accepted": true,
+            "attempts": 1,
+            "pf_residual": 1.0e-12,
+            "voltage_min": 0.95,
+            "voltage_max": 1.04,
+            "slack_p_deviation": 0.001,
+            "gen_q_violation_max": 0.0,
+            "branch_loading_max": 0.80
+        }
     }
 }
 ```
@@ -341,10 +651,72 @@ If certain buses cause failures, specify fault locations explicitly in the confi
 ### scenario_*.npz
 
 Each scenario file contains:
-- `state_history` - Time series of all state variables
-- `time` - Time vector
+- `history` - Time series of all state variables
+- `tvec` - Time vector
 - `p_load_scaled`, `q_load_scaled` - Perturbed load values
 - `p_gen_scaled`, `q_gen_scaled` - Perturbed generator values
+- `p_load_noise`, `q_load_noise` - Effective load perturbation factors
+- `p_gen_noise`, `q_gen_noise` - Effective generator perturbation factors
+- `load_scale`, `load_mean_shift` - Deterministic load-stress settings
+
+### scenario_diagnostics.jsonl
+
+When deterministic load stress or operating-point screening is active, the
+script writes one JSON object per line. Resampling attempts are recorded
+individually, so rejection summaries include failed internal attempts rather
+than only the final accepted/rejected scenario. JSONL is used because large
+Monte Carlo runs can append diagnostics incrementally without rewriting one huge
+JSON array. If a run stops early, all completed lines are still readable.
+
+Typical fields:
+
+- `scenario_id`, `sample_idx`, `fault_location`, `fault_impedance`
+- `record_type`, `operating_point_id`, `accepted_operating_point_index`
+- `accepted`, `reject_reason`, `attempts`, `rebalance_iterations`
+- target mode only: `target_accepted_scenarios`, `total_candidate_attempts`,
+  `faults_required`, `faults_attempted`, `faults_successful`
+- `load_scale`, `load_mean_shift`, `total_p_load`, `total_q_load`
+- `pf_converged`, `pf_residual`
+- `slack_p_target`, `slack_p_solved`, `slack_p_deviation`
+- `slack_q_target`, `slack_q_solved`, `slack_q_deviation`
+- `slack_p_limit_violation`
+- `loss_compensation_enabled`, `loss_compensation_policy`
+- `loss_compensation_requested_pu`, `loss_compensation_applied_pu`,
+  `loss_compensation_unresolved_pu`, `loss_compensation_iterations`
+- `loss_compensation_effective_tolerance_pu`
+- `q_limit_mitigation_enabled`, `q_limit_mitigation_applied`,
+  `q_limit_mitigation_passes`
+- `q_limit_mitigation_switched_buses`,
+  `q_limit_mitigation_switched_generators`, `q_limit_mitigation_events`
+- `non_slack_headroom_remaining`, `non_slack_footroom_remaining`
+- `voltage_min`, `voltage_max`
+- `gen_p_violation_max`, `gen_q_violation_max`
+- `gen_q_violation_count`, `gen_q_violation_total_abs`,
+  `gen_q_violation_argmax`, `gen_q_violation_top`
+- `branch_loading_available`, `branch_loading_max`,
+  `branch_overloaded_count`, `branch_loading_argmax`
+
+You can inspect it quickly with:
+
+```bash
+# Count accepted/rejected records
+python - <<'PY'
+import json
+from collections import Counter
+with open("scenario_diagnostics.jsonl") as f:
+    records = [json.loads(line) for line in f]
+print("records:", len(records))
+print("accepted:", sum(r["accepted"] for r in records))
+print("reject reasons:", Counter(r.get("reject_reason") for r in records))
+PY
+```
+
+### scenario_diagnostics_summary.json
+
+This file contains aggregate counts and min/mean/max values for key stress
+metrics. It is the fastest place to check acceptance rate, dominant rejection
+reason, voltage range, maximum PF residual, maximum branch loading, and target
+mode candidate/fault counts when enabled.
 
 ### TSI Dataset (.npz)
 
@@ -374,6 +746,73 @@ Each scenario file contains:
 2. Reduce noise variance (`load_noise_var`, `gen_noise_var`)
 3. Try excluding problematic fault locations
 4. Increase fault clearing time (`toff`) in the integration config
+
+### Zero Accepted Operating Points
+
+If `operating_point.enabled=true` and every scenario is rejected:
+
+1. Open `scenario_diagnostics_summary.json`.
+2. Check `reject_reasons`.
+3. If the reason is `voltage_low` or `voltage_high`, inspect
+   `voltage_min`/`voltage_max` and adjust voltage thresholds only if those
+   voltage levels are acceptable for your study.
+4. If the reason is `gen_q_limit`, the AC PF solution requires generator
+   reactive power outside RAW-file Q limits. This can happen even in the base
+   case for some systems. Use strict tolerance for ACOPF-like feasibility, or
+   loosen `gen_limit_tolerance` only for stressed dynamic simulations.
+5. If the reason is `branch_overload`, compare `branch_loading_max` to your
+   acceptable thermal loading level. `1.0` means 100% of `rateA`.
+6. If the reason is `slack_p_deviation`, there was not enough non-slack
+   generator headroom/footroom to move active-power mismatch away from slack.
+7. If the reason is `gen_p_limit` and `slack_p_limit_violation` is also high,
+   enable `loss_compensation=true` or inspect `non_slack_headroom_remaining`.
+   If unresolved loss compensation remains nonzero, the non-slack generators
+   do not have enough active-power margin under the selected policy.
+
+Remember: loosening limits makes the dynamic simulation run, but it does not
+make the operating point ACOPF-feasible.
+
+### Repeated Diagnostics Across Fault Locations
+
+This is expected. The pre-fault operating point is generated per `sample_idx`.
+Fault location and impedance affect the dynamic fault simulation, not the
+pre-fault PF operating point. Therefore, diagnostics can repeat for every bus
+fault associated with the same sample.
+
+### Common Warnings
+
+- `Transformer Magnetizing Impedance not Implemented`: existing parser warning;
+  the branch transformer magnetizing impedance is ignored.
+- SciPy `_nonlin.py` warnings during PF iterations: usually harmless if the
+  final `pf_residual` is small and `pf_converged=true`.
+
+### Suppress Known Parser Warnings
+
+By default, warnings are shown. For production runs where the transformer
+magnetizing-impedance warning is expected and too noisy, suppress just that
+warning with Python's warning filter:
+
+```bash
+PYTHONWARNINGS="ignore:Transformer Magnetizing Impedance not Implemented:UserWarning:uqgrid.io.parse" \
+python generate_scenarios.py config/config_ACTIVSg500_stress.json
+```
+
+If the module-specific filter does not catch it in your environment, use the
+same message-level filter without the module qualifier:
+
+```bash
+PYTHONWARNINGS="ignore:Transformer Magnetizing Impedance not Implemented:UserWarning" \
+python generate_scenarios.py config/config_ACTIVSg500_stress.json
+```
+
+For repeated production runs, export the filter for the session and unset it
+afterward:
+
+```bash
+export PYTHONWARNINGS="ignore:Transformer Magnetizing Impedance not Implemented:UserWarning:uqgrid.io.parse"
+python generate_scenarios.py config/config_ACTIVSg500_stress.json
+unset PYTHONWARNINGS
+```
 
 ### Out of Memory
 

--- a/scripts/run/README.md
+++ b/scripts/run/README.md
@@ -793,7 +793,7 @@ magnetizing-impedance warning is expected and too noisy, suppress just that
 warning with Python's warning filter:
 
 ```bash
-PYTHONWARNINGS="ignore:Transformer Magnetizing Impedance not Implemented:UserWarning:uqgrid.io.parse" \
+PYTHONWARNINGS="ignore:Transformer Magnetizing Impedance not Implemented:UserWarning:uqgrid.io.parse,ignore:invalid value encountered in scalar divide::scipy.optimize._nonlin" \
 python generate_scenarios.py config/config_ACTIVSg500_stress.json
 ```
 
@@ -801,7 +801,7 @@ If the module-specific filter does not catch it in your environment, use the
 same message-level filter without the module qualifier:
 
 ```bash
-PYTHONWARNINGS="ignore:Transformer Magnetizing Impedance not Implemented:UserWarning" \
+PYTHONWARNINGS="ignore:Transformer Magnetizing Impedance not Implemented:UserWarning,ignore:invalid value encountered in scalar divide::scipy.optimize._nonlin" \
 python generate_scenarios.py config/config_ACTIVSg500_stress.json
 ```
 
@@ -809,7 +809,7 @@ For repeated production runs, export the filter for the session and unset it
 afterward:
 
 ```bash
-export PYTHONWARNINGS="ignore:Transformer Magnetizing Impedance not Implemented:UserWarning:uqgrid.io.parse"
+export PYTHONWARNINGS="ignore:Transformer Magnetizing Impedance not Implemented:UserWarning:uqgrid.io.parse,ignore:invalid value encountered in scalar divide::scipy.optimize._nonlin"
 python generate_scenarios.py config/config_ACTIVSg500_stress.json
 unset PYTHONWARNINGS
 ```

--- a/scripts/run/README.md
+++ b/scripts/run/README.md
@@ -1,6 +1,7 @@
 # Power Grid Simulation Scripts
 
 This folder contains scripts for generating, monitoring, and recovering power grid transient stability simulation scenarios.
+The commands below assume they are run from `scripts/run/`.
 
 ## Overview
 
@@ -40,7 +41,7 @@ python ../postprocess/TSI_analysis.py
 Main script for generating perturbed scenarios and running transient stability simulations.
 
 **Features:**
-- Multiplicative perturbations with configurable noise distributions (normal/uniform)
+- Multiplicative perturbations with configurable noise distributions (`normal`, `uniform`, or `none`)
 - Independent control over load and generator perturbations
 - Power factor preservation
 - Deterministic load stress via `load_scale` and `load_mean_shift`
@@ -73,8 +74,9 @@ python generate_scenarios.py config/config_IEEE-9.json --continue --additional-s
 - `simulation_data/scenario_*.npz` - Per-scenario simulation results
 - `simulation_log.json` - Simulation outcomes and metadata
 - `scenario_metadata.json` - Scenario parameter definitions
-- `scenario_diagnostics.jsonl` - Per-scenario operating-point diagnostics when stress/PF screening is active
-- `scenario_diagnostics_summary.json` - Compact summary of diagnostics and rejection reasons
+- `scenario_diagnostics.jsonl` - Per-scenario operating-point diagnostics when stress/PF screening is active; name is configurable
+- `scenario_diagnostics_summary.json` - Compact summary of diagnostics and rejection reasons; name is configurable
+- `simulation_checkpoint.json` - Temporary checkpoint for interrupted fixed-grid runs; removed after successful completion
 
 ---
 
@@ -183,8 +185,8 @@ baseline config may omit those optional fields and still run.
 {
     "model": {
         "name": "IEEE-9",
-        "raw": "../data/ieee9_v33.raw",
-        "dyr": "../data/ieee9bus_gov.dyr",
+        "raw": "../../data/ieee9_v33.raw",
+        "dyr": "../../data/ieee9bus_gov.dyr",
         "n_bus": 9
     },
     "scenarios": {
@@ -266,10 +268,10 @@ baseline config may omit those optional fields and still run.
 | **execution** | `n_jobs` | Number of parallel workers |
 | | `batch_size` | Scenarios per batch |
 | | `checkpoint_interval` | Checkpoint every N batches |
-| **perturbation** | `load_noise_type` | `"normal"` or `"uniform"` |
-| | `load_noise_var` | Noise variance for loads |
-| | `gen_noise_type` | `"normal"` or `"uniform"` |
-| | `gen_noise_var` | Noise variance for generators |
+| **perturbation** | `load_noise_type` | `"normal"`, `"uniform"`, or `"none"` |
+| | `load_noise_var` | Load noise parameter: standard deviation for `"normal"`, target variance for `"uniform"` |
+| | `gen_noise_type` | `"normal"`, `"uniform"`, or `"none"` |
+| | `gen_noise_var` | Generator noise parameter: standard deviation for `"normal"`, target variance for `"uniform"` |
 | | `balance_generation` | Rebalance Pg to match Pl |
 | | `perturb_loads` | Apply perturbations to loads |
 | | `perturb_gens` | Apply perturbations to generators |
@@ -365,13 +367,16 @@ using the same `P_load`, `Q_load`, `P_gen`, and `Q_gen` arrays.
   target.
 - A candidate counts only if every fault simulation succeeds and writes a
   trajectory file.
-- The script starts with sample indices `0..samples_per_fault_location-1`, then
-  continues with higher sample indices until the target is reached or
-  `max_total_attempts` is exhausted.
+- A fresh target-mode run samples candidate operating points sequentially from
+  sample index `0`, then continues with higher sample indices until the target
+  is reached or `max_total_attempts` is exhausted. In target mode,
+  `samples_per_fault_location` is retained for configuration compatibility and
+  summary display; the stopping criterion is `target_accepted_scenarios`.
 - With `--continue`, `target_accepted_scenarios` is interpreted as the desired
   total number of complete accepted operating points, not the number of new
   operating points to add. Existing complete operating-point groups in
-  `simulation_log.json` count toward the target.
+  `simulation_log.json` count toward the target, and new sampling starts after
+  the largest existing `sample_idx`.
 - Fault-level `scenario_metadata.json` and `simulation_log.json` stay compatible
   with postprocessing; each row also records `operating_point_id` and
   `accepted_operating_point_index`.
@@ -460,7 +465,8 @@ prepare and screen AC PF operating points.
 non-slack PV generators that exceed `Qmin/Qmax` are clamped at the violated
 limit, and their buses are temporarily switched from PV to PQ for the next PF
 solve. This trades fixed voltage control for fixed reactive output at the
-generator limit. It is not ACOPF and does not modify core UQGrid PF behavior.
+generator limit. The temporary bus-type changes are restored before dynamics
+are launched. It is not ACOPF and does not modify core UQGrid PF behavior.
 
 ### Available Models
 
@@ -470,6 +476,10 @@ generator limit. It is not ACOPF and does not modify core UQGrid PF behavior.
 | IEEE-39 | 39 | New England test system |
 | ACTIVSg200 | 200 | Synthetic 200-bus system |
 | ACTIVSg500 | 500 | Synthetic 500-bus system |
+
+The default-config generator knows about the ACTIVSg systems, but the tracked
+example configs in this directory are the IEEE configs above. ACTIVSg runs
+require the corresponding RAW/DYR files to be available locally.
 
 ---
 
@@ -658,15 +668,18 @@ Each scenario file contains:
 - `p_load_noise`, `q_load_noise` - Effective load perturbation factors
 - `p_gen_noise`, `q_gen_noise` - Effective generator perturbation factors
 - `load_scale`, `load_mean_shift` - Deterministic load-stress settings
+- `operating_point_id`, `accepted_operating_point_index` - Present for target
+  accepted operating-point mode
 
 ### scenario_diagnostics.jsonl
 
 When deterministic load stress or operating-point screening is active, the
-script writes one JSON object per line. Resampling attempts are recorded
-individually, so rejection summaries include failed internal attempts rather
-than only the final accepted/rejected scenario. JSONL is used because large
-Monte Carlo runs can append diagnostics incrementally without rewriting one huge
-JSON array. If a run stops early, all completed lines are still readable.
+script writes one JSON object per line to `diagnostics_file`. Resampling
+attempts are recorded individually, so rejection summaries include failed
+internal attempts rather than only the final accepted/rejected scenario. JSONL
+is used because large Monte Carlo runs can append diagnostics incrementally
+without rewriting one huge JSON array. If a run stops early, all completed
+lines are still readable.
 
 Typical fields:
 
@@ -743,9 +756,10 @@ mode candidate/fault counts when enabled.
 ### High Failure Rate
 
 1. Check for mismatched RAW/DYR files (generators without dynamic models)
-2. Reduce noise variance (`load_noise_var`, `gen_noise_var`)
+2. Reduce noise parameters (`load_noise_var`, `gen_noise_var`)
 3. Try excluding problematic fault locations
-4. Increase fault clearing time (`toff`) in the integration config
+4. Decrease fault clearing time (`toff`) to reduce fault severity, or increase
+   it only when intentionally creating harder stability cases
 
 ### Zero Accepted Operating Points
 
@@ -794,7 +808,7 @@ warning with Python's warning filter:
 
 ```bash
 PYTHONWARNINGS="ignore:Transformer Magnetizing Impedance not Implemented:UserWarning:uqgrid.io.parse,ignore:invalid value encountered in scalar divide::scipy.optimize._nonlin" \
-python generate_scenarios.py config/config_ACTIVSg500_stress.json
+python generate_scenarios.py config/config_IEEE-39_stress.json
 ```
 
 If the module-specific filter does not catch it in your environment, use the
@@ -802,7 +816,7 @@ same message-level filter without the module qualifier:
 
 ```bash
 PYTHONWARNINGS="ignore:Transformer Magnetizing Impedance not Implemented:UserWarning,ignore:invalid value encountered in scalar divide::scipy.optimize._nonlin" \
-python generate_scenarios.py config/config_ACTIVSg500_stress.json
+python generate_scenarios.py config/config_IEEE-39_stress.json
 ```
 
 For repeated production runs, export the filter for the session and unset it
@@ -810,7 +824,7 @@ afterward:
 
 ```bash
 export PYTHONWARNINGS="ignore:Transformer Magnetizing Impedance not Implemented:UserWarning:uqgrid.io.parse,ignore:invalid value encountered in scalar divide::scipy.optimize._nonlin"
-python generate_scenarios.py config/config_ACTIVSg500_stress.json
+python generate_scenarios.py config/config_IEEE-39_stress.json
 unset PYTHONWARNINGS
 ```
 

--- a/scripts/run/config/config_IEEE-39_stress.json
+++ b/scripts/run/config/config_IEEE-39_stress.json
@@ -1,0 +1,58 @@
+{
+    "model": {
+        "name": "IEEE-39",
+        "raw": "../../data/IEEE39_v33.raw",
+        "dyr": "../../data/IEEE39_gov.dyr",
+        "n_bus": 39
+    },
+    "scenarios": {
+        "samples_per_fault_location": 5,
+        "fault_impedances": [0.00001],
+        "fault_locations": "all"
+    },
+    "execution": {
+        "n_jobs": 5,
+        "batch_size": 10,
+        "checkpoint_interval": 5
+    },
+    "perturbation": {
+        "load_noise_type": "normal",
+        "load_noise_var": 0.25,
+        "gen_noise_type": "normal",
+        "gen_noise_var": 0.25,
+        "balance_generation": true,
+        "perturb_loads": true,
+        "perturb_gens": true,
+        "keep_power_factor": true,
+        "clamp_gens": true,
+        "load_scale": 1.0,
+        "load_mean_shift": 0.0,
+        "generation_dispatch_init": "perturbed"
+    },
+    "operating_point": {
+        "enabled": true,
+        "run_power_flow": true,
+        "rebalance_non_slack": true,
+        "redistribute_slack_mismatch": true,
+        "max_iterations": 5,
+        "max_attempts_per_scenario": 50,
+        "pf_residual_tol": 1e-8,
+        "slack_p_tolerance_pu": 1e-4,
+        "max_slack_p_deviation_fraction_of_load": 0.02,
+        "voltage_min": 0.85,
+        "voltage_max": 1.10,
+        "gen_limit_tolerance": 10,
+        "branch_loading_max": 2.0,
+        "diagnostics_file": "scenario_diagnostics.jsonl",
+        "diagnostics_summary_file": "scenario_diagnostics_summary.json"
+    },
+    "integration": {
+        "tend": 10.0,
+        "dt": 0.008333333333333333,
+        "power_injection": false,
+        "ton": 0.25,
+        "toff": 0.4,
+        "verbose": false,
+        "petsc": true
+    }
+}

--- a/scripts/run/config/config_IEEE-9_stress.json
+++ b/scripts/run/config/config_IEEE-9_stress.json
@@ -1,0 +1,58 @@
+{
+    "model": {
+        "name": "IEEE-9",
+        "raw": "../../data/ieee9_v33.raw",
+        "dyr": "../../data/ieee9bus_gov.dyr",
+        "n_bus": 9
+    },
+    "scenarios": {
+        "samples_per_fault_location": 5,
+        "fault_impedances": [0.00001],
+        "fault_locations": "all"
+    },
+    "execution": {
+        "n_jobs": 5,
+        "batch_size": 10,
+        "checkpoint_interval": 5
+    },
+    "perturbation": {
+        "load_noise_type": "normal",
+        "load_noise_var": 0.25,
+        "gen_noise_type": "normal",
+        "gen_noise_var": 0.25,
+        "balance_generation": true,
+        "perturb_loads": true,
+        "perturb_gens": true,
+        "keep_power_factor": true,
+        "clamp_gens": true,
+        "load_scale": 1.25,
+        "load_mean_shift": 0.0,
+        "generation_dispatch_init": "perturbed"
+    },
+    "operating_point": {
+        "enabled": true,
+        "run_power_flow": true,
+        "rebalance_non_slack": true,
+        "redistribute_slack_mismatch": true,
+        "max_iterations": 5,
+        "max_attempts_per_scenario": 50,
+        "pf_residual_tol": 1e-8,
+        "slack_p_tolerance_pu": 1e-4,
+        "max_slack_p_deviation_fraction_of_load": 0.02,
+        "voltage_min": 0.9,
+        "voltage_max": 1.1,
+        "gen_limit_tolerance": 1e-6,
+        "branch_loading_max": 1.0,
+        "diagnostics_file": "scenario_diagnostics.jsonl",
+        "diagnostics_summary_file": "scenario_diagnostics_summary.json"
+    },
+    "integration": {
+        "tend": 10.0,
+        "dt": 0.008333333333333333,
+        "power_injection": false,
+        "ton": 0.25,
+        "toff": 0.4,
+        "verbose": false,
+        "petsc": true
+    }
+}

--- a/scripts/run/generate_scenarios.py
+++ b/scripts/run/generate_scenarios.py
@@ -206,12 +206,15 @@ import gc
 import copy
 import time
 import traceback
+from collections import Counter
 from datetime import timedelta
 from joblib import Parallel, delayed
 
 from uqgrid.simulation.dynamics import integrate_system
 from uqgrid.simulation.config import IntegrationConfig
+from uqgrid.simulation.pflow import runpf
 from uqgrid.io.parse import load_psse, add_dyr
+from uqgrid.core.psydef import Bus
 
 
 # =============================================================================
@@ -324,11 +327,484 @@ def _relative_noise(scaled, base, eps=1e-8):
     return noise
 
 
+def _json_safe(value):
+    """Convert numpy/scalar values into JSON-serializable Python values."""
+    if isinstance(value, dict):
+        return {key: _json_safe(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(val) for val in value]
+    if isinstance(value, np.ndarray):
+        return [_json_safe(val) for val in value.tolist()]
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def _default_operating_point_config():
+    """Neutral defaults; operating-point screening is opt-in."""
+    return {
+        "enabled": False,
+        "run_power_flow": True,
+        "rebalance_non_slack": True,
+        "redistribute_slack_mismatch": True,
+        "rebalance_policy": "headroom",
+        "loss_compensation": False,
+        "loss_compensation_tolerance_pu": 1e-4,
+        "loss_compensation_policy": "headroom",
+        "q_limit_mitigation": False,
+        "q_limit_mitigation_tolerance_pu": 1e-6,
+        "q_limit_mitigation_max_passes": 10,
+        "q_limit_mitigation_top_n": 10,
+        "max_iterations": 5,
+        "max_attempts_per_scenario": 50,
+        "pf_residual_tol": 1e-8,
+        "slack_p_tolerance_pu": 1e-4,
+        "max_slack_p_deviation_fraction_of_load": 0.02,
+        "voltage_min": 0.90,
+        "voltage_max": 1.10,
+        "gen_limit_tolerance": 1e-6,
+        "branch_loading_max": 1.0,
+        "diagnostics_file": "scenario_diagnostics.jsonl",
+        "diagnostics_summary_file": "scenario_diagnostics_summary.json",
+    }
+
+
+def _resolve_operating_point_config(config=None):
+    """Merge user operating-point settings with neutral defaults."""
+    resolved = _default_operating_point_config()
+    if config:
+        resolved.update(config)
+    supported_policies = {
+        "headroom",
+        "capacity",
+        "current_dispatch",
+        "base_dispatch",
+        "equal",
+    }
+    for policy_key in ("rebalance_policy", "loss_compensation_policy"):
+        resolved[policy_key] = str(resolved[policy_key]).lower()
+        if resolved[policy_key] not in supported_policies:
+            supported = ", ".join(sorted(supported_policies))
+            raise ValueError(
+                f"Unsupported {policy_key}={resolved[policy_key]!r}; "
+                f"choose one of: {supported}"
+            )
+    return resolved
+
+
+def _stress_load(base_p_load, base_q_load, *, load_scale=1.0, load_mean_shift=0.0):
+    """Apply deterministic load stress before stochastic perturbations."""
+    load_factor = float(load_scale) * (1.0 + float(load_mean_shift))
+    return base_p_load * load_factor, base_q_load * load_factor, load_factor
+
+
+def _scenario_seed_sequence(global_seed, sample_idx, attempt_idx):
+    """Keep attempt 0 compatible with the previous sample-level RNG seed."""
+    if attempt_idx == 0:
+        return np.random.SeedSequence([global_seed, sample_idx])
+    return np.random.SeedSequence([global_seed, sample_idx, attempt_idx])
+
+
+def _generator_bus_type_array(psys):
+    """Return each generator's bus type."""
+    return np.array([psys.buses[gen.bus].type for gen in psys.gens], dtype=int)
+
+
+def _slack_generator_mask(psys):
+    """Return True for generators connected to slack buses."""
+    return _generator_bus_type_array(psys) == Bus.SLACK
+
+
+def _compute_generator_q_dispatch(base_p_gen, base_q_gen, p_gen, *, keep_power_factor=True):
+    """Compute generator Q schedule from the requested active-power dispatch."""
+    if not keep_power_factor:
+        return np.array(base_q_gen, copy=True, dtype=float)
+
+    q_gen = np.array(base_q_gen, copy=True, dtype=float)
+    mask_pg_nonzero = np.abs(base_p_gen) > 1e-8
+    if np.any(mask_pg_nonzero):
+        ratio = np.zeros_like(base_p_gen, dtype=float)
+        ratio[mask_pg_nonzero] = base_q_gen[mask_pg_nonzero] / base_p_gen[mask_pg_nonzero]
+        q_gen[mask_pg_nonzero] = ratio[mask_pg_nonzero] * p_gen[mask_pg_nonzero]
+
+    return q_gen
+
+
+def _limit_violation(values, lower, upper):
+    """Return the maximum absolute violation outside lower/upper bounds."""
+    if values is None or lower is None or upper is None:
+        return 0.0
+
+    values = np.asarray(values, dtype=float)
+    lower = np.asarray(lower, dtype=float)
+    upper = np.asarray(upper, dtype=float)
+    below = np.maximum(lower - values, 0.0)
+    above = np.maximum(values - upper, 0.0)
+    if values.size == 0:
+        return 0.0
+    return float(np.max(np.maximum(below, above)))
+
+
+def _bus_type_label(bus_type):
+    """Return a readable bus type label for diagnostics."""
+    if bus_type == Bus.PQ:
+        return "PQ"
+    if bus_type == Bus.PV:
+        return "PV"
+    if bus_type == Bus.SLACK:
+        return "SLACK"
+    return str(bus_type)
+
+
+def _generator_q_limit_diagnostics(psys, q_values, qg_lb, qg_ub, *, top_n=10):
+    """Return detailed per-generator reactive-power limit diagnostics."""
+    diagnostics = {
+        "gen_q_violation_count": 0,
+        "gen_q_violation_total_abs": 0.0,
+        "gen_q_violation_argmax": None,
+        "gen_q_violation_top": [],
+    }
+
+    if q_values is None or qg_lb is None or qg_ub is None:
+        return diagnostics
+
+    q_values = np.asarray(q_values, dtype=float)
+    qg_lb = np.asarray(qg_lb, dtype=float)
+    qg_ub = np.asarray(qg_ub, dtype=float)
+    if q_values.size == 0:
+        return diagnostics
+
+    lower_violation = np.maximum(qg_lb - q_values, 0.0)
+    upper_violation = np.maximum(q_values - qg_ub, 0.0)
+    violation = np.maximum(lower_violation, upper_violation)
+    violator_indices = np.where(violation > 0.0)[0]
+    if violator_indices.size == 0:
+        return diagnostics
+
+    sorted_indices = sorted(
+        violator_indices,
+        key=lambda gen_index: violation[gen_index],
+        reverse=True,
+    )
+    top = []
+    for gen_index in sorted_indices[:top_n]:
+        gen = psys.gens[int(gen_index)]
+        bus_index = int(gen.bus)
+        bus = psys.buses[bus_index]
+        bus_type = getattr(bus, "type", None)
+        side = (
+            "lower"
+            if lower_violation[gen_index] > upper_violation[gen_index]
+            else "upper"
+        )
+        top.append({
+            "gen_index": int(gen_index),
+            "gen_id": str(getattr(gen, "idx", "")),
+            "bus_index": bus_index,
+            "bus_id": getattr(bus, "id", None),
+            "bus_type": _bus_type_label(bus_type),
+            "qg": float(q_values[gen_index]),
+            "qmin": float(qg_lb[gen_index]),
+            "qmax": float(qg_ub[gen_index]),
+            "violation": float(violation[gen_index]),
+            "side": side,
+            "is_slack": bool(bus_type == Bus.SLACK),
+        })
+
+    diagnostics.update({
+        "gen_q_violation_count": int(violator_indices.size),
+        "gen_q_violation_total_abs": float(np.sum(violation[violator_indices])),
+        "gen_q_violation_argmax": int(sorted_indices[0]),
+        "gen_q_violation_top": top,
+    })
+    return diagnostics
+
+
+def _capture_bus_types(psys):
+    """Capture bus types so temporary PV/PQ changes can be restored."""
+    return [bus.type for bus in psys.buses]
+
+
+def _restore_bus_types(psys, bus_types):
+    """Restore previously captured bus types."""
+    for bus, bus_type in zip(psys.buses, bus_types):
+        bus.type = bus_type
+
+
+def _q_limit_mitigation_defaults(op_cfg):
+    """Return default diagnostics for PV-to-PQ Q-limit mitigation."""
+    return {
+        "q_limit_mitigation_enabled": bool(op_cfg["q_limit_mitigation"]),
+        "q_limit_mitigation_applied": False,
+        "q_limit_mitigation_passes": 0,
+        "q_limit_mitigation_switched_buses": [],
+        "q_limit_mitigation_switched_generators": [],
+        "q_limit_mitigation_events": [],
+        "q_limit_mitigation_limit_reached": False,
+    }
+
+
+def _apply_q_limit_mitigation(
+        psys, q_gen, q_values, qg_lb, qg_ub, op_cfg, *,
+        q_fixed_mask=None, q_fixed_values=None, pass_idx=0):
+    """Clamp violating non-slack PV generator Q and switch those buses to PQ."""
+    result = {
+        "applied": False,
+        "events": [],
+        "switched_buses": [],
+        "switched_generators": [],
+    }
+
+    if (
+        not op_cfg["q_limit_mitigation"]
+        or q_values is None
+        or qg_lb is None
+        or qg_ub is None
+    ):
+        return q_gen, result
+
+    q_gen = np.asarray(q_gen, dtype=float).copy()
+    tolerance = float(op_cfg["q_limit_mitigation_tolerance_pu"])
+    pass_bus_types = _capture_bus_types(psys)
+    q_diagnostics = _generator_q_limit_diagnostics(
+        psys,
+        q_values,
+        qg_lb,
+        qg_ub,
+        top_n=len(psys.gens),
+    )
+
+    for offender in q_diagnostics["gen_q_violation_top"]:
+        if offender["violation"] <= tolerance:
+            continue
+
+        gen_index = int(offender["gen_index"])
+        bus_index = int(offender["bus_index"])
+        if pass_bus_types[bus_index] != Bus.PV:
+            continue
+
+        side = offender["side"]
+        if side == "upper":
+            q_limit = float(qg_ub[gen_index])
+        else:
+            q_limit = float(qg_lb[gen_index])
+
+        q_gen[gen_index] = q_limit
+        psys.gens[gen_index].qsch = q_limit
+        if q_fixed_mask is not None:
+            q_fixed_mask[gen_index] = True
+        if q_fixed_values is not None:
+            q_fixed_values[gen_index] = q_limit
+
+        psys.buses[bus_index].type = Bus.PQ
+        result["applied"] = True
+        result["switched_buses"].append(bus_index)
+        result["switched_generators"].append(gen_index)
+        result["events"].append({
+            "pass": int(pass_idx),
+            "gen_index": gen_index,
+            "gen_id": offender["gen_id"],
+            "bus_index": bus_index,
+            "bus_id": offender["bus_id"],
+            "side": side,
+            "qg_solved": float(offender["qg"]),
+            "q_limit": q_limit,
+            "violation": float(offender["violation"]),
+            "from_bus_type": offender["bus_type"],
+            "to_bus_type": "PQ",
+        })
+
+    result["switched_buses"] = sorted(set(result["switched_buses"]))
+    result["switched_generators"] = sorted(set(result["switched_generators"]))
+    return q_gen, result
+
+
 # =============================================================================
 # Power Rebalancing
 # =============================================================================
 
-def _rebalance_active_power(p_gen, pg_lb, pg_ub, target_total):
+def _active_power_margin_sums(p_gen, pg_lb, pg_ub, participation_mask=None):
+    """Return total active-power headroom and footroom for selected generators."""
+    if pg_lb is None or pg_ub is None:
+        return None, None
+
+    p_gen = np.asarray(p_gen, dtype=float)
+    pg_lb = np.asarray(pg_lb, dtype=float)
+    pg_ub = np.asarray(pg_ub, dtype=float)
+    if participation_mask is None:
+        participation_mask = np.ones_like(p_gen, dtype=bool)
+    else:
+        participation_mask = np.asarray(participation_mask, dtype=bool)
+
+    headroom = np.maximum(pg_ub - p_gen, 0.0)
+    footroom = np.maximum(p_gen - pg_lb, 0.0)
+    return (
+        float(np.sum(headroom[participation_mask])),
+        float(np.sum(footroom[participation_mask])),
+    )
+
+
+def _active_power_policy_weights(
+        policy, p_gen, base_p_gen, pg_lb, pg_ub, margin, eligible_mask):
+    """Compute automatic participation weights for a bounded active-power move."""
+    if policy == "headroom":
+        weights = margin.copy()
+    elif policy == "capacity":
+        weights = np.maximum(pg_ub - pg_lb, 0.0)
+    elif policy == "current_dispatch":
+        weights = np.maximum(np.abs(p_gen), 0.0)
+    elif policy == "base_dispatch":
+        if base_p_gen is None:
+            weights = np.maximum(np.abs(p_gen), 0.0)
+        else:
+            weights = np.maximum(np.abs(np.asarray(base_p_gen, dtype=float)), 0.0)
+    elif policy == "equal":
+        weights = np.ones_like(p_gen, dtype=float)
+    else:
+        raise ValueError(f"Unsupported participation policy: {policy!r}")
+
+    weights = np.where(eligible_mask, weights, 0.0)
+    if np.sum(weights) <= 1e-12:
+        weights = np.where(eligible_mask, 1.0, 0.0)
+    return weights
+
+
+def _allocate_active_power_mismatch(
+        p_gen, pg_lb, pg_ub, mismatch, participation_mask=None, *,
+        policy="headroom", base_p_gen=None, tolerance=1e-9):
+    """Move active-power mismatch with bounded automatic participation weights."""
+    p_gen = np.asarray(p_gen, dtype=float)
+    p_new = p_gen.copy()
+    mismatch = float(mismatch)
+
+    if participation_mask is None:
+        participation_mask = np.ones_like(p_new, dtype=bool)
+    else:
+        participation_mask = np.asarray(participation_mask, dtype=bool)
+
+    headroom_start, footroom_start = _active_power_margin_sums(
+        p_new, pg_lb, pg_ub, participation_mask
+    )
+    touched = np.zeros_like(p_new, dtype=bool)
+    applied = 0.0
+
+    if (
+        p_new.size == 0
+        or not np.any(participation_mask)
+        or abs(mismatch) <= tolerance
+    ):
+        headroom_end, footroom_end = _active_power_margin_sums(
+            p_new, pg_lb, pg_ub, participation_mask
+        )
+        return {
+            "p_gen": p_new,
+            "applied_mismatch": 0.0,
+            "unresolved_mismatch": mismatch,
+            "participants": 0,
+            "direction": "none",
+            "headroom_start": headroom_start,
+            "headroom_remaining": headroom_end,
+            "footroom_start": footroom_start,
+            "footroom_remaining": footroom_end,
+        }
+
+    direction_sign = 1.0 if mismatch > 0.0 else -1.0
+    direction_name = "increase" if direction_sign > 0.0 else "decrease"
+
+    if pg_lb is None or pg_ub is None:
+        selected = np.where(participation_mask)[0]
+        selected_total = float(np.sum(p_new[selected]))
+        if not np.isclose(selected_total, 0.0):
+            p_new[selected] *= (selected_total + mismatch) / selected_total
+        else:
+            p_new[selected] += mismatch / len(selected)
+        touched[selected] = True
+        return {
+            "p_gen": p_new,
+            "applied_mismatch": mismatch,
+            "unresolved_mismatch": 0.0,
+            "participants": int(len(selected)),
+            "direction": direction_name,
+            "headroom_start": headroom_start,
+            "headroom_remaining": None,
+            "footroom_start": footroom_start,
+            "footroom_remaining": None,
+        }
+
+    pg_lb = np.asarray(pg_lb, dtype=float)
+    pg_ub = np.asarray(pg_ub, dtype=float)
+    policy = str(policy).lower()
+
+    for _iteration in range(p_new.size):
+        unresolved = mismatch - applied
+        if abs(unresolved) <= tolerance:
+            break
+
+        if direction_sign > 0.0:
+            margin = np.maximum(pg_ub - p_new, 0.0)
+        else:
+            margin = np.maximum(p_new - pg_lb, 0.0)
+
+        eligible_mask = participation_mask & (margin > tolerance)
+        if not np.any(eligible_mask):
+            break
+
+        weights = _active_power_policy_weights(
+            policy, p_new, base_p_gen, pg_lb, pg_ub, margin, eligible_mask
+        )
+        weight_total = float(np.sum(weights))
+        if weight_total <= tolerance:
+            break
+
+        requested_abs = abs(unresolved)
+        requested = requested_abs * weights / weight_total
+        applied_abs = np.minimum(requested, margin)
+        applied_step_abs = float(np.sum(applied_abs[eligible_mask]))
+        if applied_step_abs <= tolerance:
+            break
+
+        p_new[eligible_mask] += direction_sign * applied_abs[eligible_mask]
+        touched |= applied_abs > tolerance
+        applied += direction_sign * applied_step_abs
+
+    unresolved = mismatch - applied
+    headroom_end, footroom_end = _active_power_margin_sums(
+        p_new, pg_lb, pg_ub, participation_mask
+    )
+    return {
+        "p_gen": p_new,
+        "applied_mismatch": float(applied),
+        "unresolved_mismatch": float(unresolved),
+        "participants": int(np.sum(touched)),
+        "direction": direction_name,
+        "headroom_start": headroom_start,
+        "headroom_remaining": headroom_end,
+        "footroom_start": footroom_start,
+        "footroom_remaining": footroom_end,
+    }
+
+
+def _redistribute_active_power_mismatch(
+        p_gen, pg_lb, pg_ub, mismatch, participation_mask=None, *,
+        policy="headroom", base_p_gen=None, return_diagnostics=False):
+    """Move active-power mismatch onto participating generators within limits."""
+    allocation = _allocate_active_power_mismatch(
+        p_gen,
+        pg_lb,
+        pg_ub,
+        mismatch,
+        participation_mask=participation_mask,
+        policy=policy,
+        base_p_gen=base_p_gen,
+    )
+    if return_diagnostics:
+        return allocation
+    return allocation["p_gen"]
+
+
+def _rebalance_active_power(
+        p_gen, pg_lb, pg_ub, target_total, participation_mask=None, *,
+        policy="headroom", base_p_gen=None, return_diagnostics=False):
     r"""
     Rebalance generator active power to match a target total.
 
@@ -376,6 +852,16 @@ def _rebalance_active_power(p_gen, pg_lb, pg_ub, target_total):
     p_gen = np.asarray(p_gen, dtype=float)
 
     if target_total is None:
+        if return_diagnostics:
+            return _allocate_active_power_mismatch(
+                p_gen,
+                pg_lb,
+                pg_ub,
+                0.0,
+                participation_mask=participation_mask,
+                policy=policy,
+                base_p_gen=base_p_gen,
+            )
         return p_gen
 
     current_total = np.sum(p_gen)
@@ -383,48 +869,31 @@ def _rebalance_active_power(p_gen, pg_lb, pg_ub, target_total):
 
     # No rebalancing needed if already at target
     if np.isclose(mismatch, 0.0):
+        if return_diagnostics:
+            return _allocate_active_power_mismatch(
+                p_gen,
+                pg_lb,
+                pg_ub,
+                0.0,
+                participation_mask=participation_mask,
+                policy=policy,
+                base_p_gen=base_p_gen,
+            )
         return p_gen
 
-    # Fall back to uniform scaling if no bounds available
-    if pg_lb is None or pg_ub is None:
-        if current_total != 0.0:
-            return p_gen * (target_total / current_total)
-        return p_gen
-
-    pg_lb = np.asarray(pg_lb, dtype=float)
-    pg_ub = np.asarray(pg_ub, dtype=float)
-
-    if mismatch > 0.0:
-        # Need to increase generation - use upward headroom
-        headroom = pg_ub - p_gen
-        mask = headroom > 1e-9
-        total_headroom = np.sum(headroom[mask])
-
-        if total_headroom <= 0.0:
-            # Already at upper limits everywhere
-            return p_gen
-
-        # Participation factor (capped at 1.0)
-        factor = min(1.0, mismatch / total_headroom)
-        p_new = p_gen.copy()
-        p_new[mask] += headroom[mask] * factor
-
-    else:
-        # Need to decrease generation - use downward margin
-        down_margin = p_gen - pg_lb
-        mask = down_margin > 1e-9
-        total_down = np.sum(down_margin[mask])
-
-        if total_down <= 0.0:
-            # Already at lower limits everywhere
-            return p_gen
-
-        # Participation factor (capped at 1.0)
-        factor = min(1.0, -mismatch / total_down)
-        p_new = p_gen.copy()
-        p_new[mask] -= down_margin[mask] * factor
-
-    return p_new
+    allocation = _redistribute_active_power_mismatch(
+        p_gen,
+        pg_lb,
+        pg_ub,
+        mismatch,
+        participation_mask=participation_mask,
+        policy=policy,
+        base_p_gen=base_p_gen,
+        return_diagnostics=True,
+    )
+    if return_diagnostics:
+        return allocation
+    return allocation["p_gen"]
 
 
 # =============================================================================
@@ -541,6 +1010,453 @@ def generate_perturbations(base_p, base_q,
 
 
 # =============================================================================
+# Operating Point Diagnostics
+# =============================================================================
+
+def _compute_power_flow_residual(psys, pf_solution):
+    """Compute the solved PF residual norm using the same bus constraints as runpf."""
+    bus_type = np.array([bus.type for bus in psys.buses], dtype=int)
+    p_inj = np.zeros(psys.nbuses, dtype=float)
+    q_inj = np.zeros(psys.nbuses, dtype=float)
+
+    for gen in psys.gens:
+        p_inj[gen.bus] += gen.psch
+        q_inj[gen.bus] += gen.qsch
+
+    for load in psys.loads:
+        p_inj[load.bus] -= load.pload
+        q_inj[load.bus] += load.qload
+
+    residuals = []
+    solved = pf_solution.s_inj_vector
+    for bus_idx, btype in enumerate(bus_type):
+        if btype in (Bus.PQ, Bus.PV):
+            residuals.append(solved[2 * bus_idx] - p_inj[bus_idx])
+        if btype == Bus.PQ:
+            residuals.append(solved[2 * bus_idx + 1] - q_inj[bus_idx])
+
+    if not residuals:
+        return 0.0
+    return float(np.linalg.norm(np.asarray(residuals, dtype=float)))
+
+
+def _compute_branch_loading_diagnostics(psys, pf_solution):
+    """Compute branch loading against rateA when branch ratings are available."""
+    if getattr(psys, "nbranches", 0) == 0:
+        return {
+            "branch_loading_available": False,
+            "branch_loading_max": None,
+            "branch_overloaded_count": 0,
+            "branch_loading_argmax": None,
+        }
+
+    voltages = pf_solution.v_magnitudes * np.exp(1j * pf_solution.v_angles)
+    loadings = []
+    loading_indices = []
+
+    for idx, branch in enumerate(psys.branches):
+        rate = float(getattr(branch, "rateA", 0.0))
+        if rate <= 0.0:
+            continue
+
+        tap = float(branch.tap)
+        shift = float(branch.shift)
+        if tap > 0.0:
+            tpsh = tap * np.exp(1j * np.pi / 180.0 * shift)
+        else:
+            tap = 1.0
+            tpsh = 1.0
+
+        impedance = branch.r + 1j * branch.x
+        if abs(impedance) <= 1e-12:
+            continue
+        y_series = 1.0 / impedance
+        y_shunt = 1j * 0.5 * branch.sh
+        v_from = voltages[branch.fr]
+        v_to = voltages[branch.to]
+
+        i_from = ((y_series + y_shunt) / (tap * tap)) * v_from - (
+            y_series / np.conj(tpsh)
+        ) * v_to
+        i_to = -(y_series / tpsh) * v_from + (y_series + y_shunt) * v_to
+
+        s_from_mva = abs(v_from * np.conj(i_from)) * psys.basemva
+        s_to_mva = abs(v_to * np.conj(i_to)) * psys.basemva
+        loadings.append(max(s_from_mva, s_to_mva) / rate)
+        loading_indices.append(idx)
+
+    if not loadings:
+        return {
+            "branch_loading_available": False,
+            "branch_loading_max": None,
+            "branch_overloaded_count": 0,
+            "branch_loading_argmax": None,
+        }
+
+    loadings = np.asarray(loadings, dtype=float)
+    argmax_local = int(np.argmax(loadings))
+    return {
+        "branch_loading_available": True,
+        "branch_loading_max": float(loadings[argmax_local]),
+        "branch_overloaded_count": int(np.sum(loadings > 1.0)),
+        "branch_loading_argmax": int(loading_indices[argmax_local]),
+    }
+
+
+def _diagnose_power_flow(
+        psys, p_gen_target, q_gen_target, pg_lb, pg_ub, qg_lb, qg_ub,
+        op_cfg):
+    """Run PF and return solution plus screening diagnostics."""
+    diagnostics = {
+        "pf_converged": False,
+        "pf_residual": None,
+        "slack_p_target": None,
+        "slack_p_solved": None,
+        "slack_p_deviation": None,
+        "slack_q_target": None,
+        "slack_q_solved": None,
+        "slack_q_deviation": None,
+        "slack_p_limit_violation": None,
+        "voltage_min": None,
+        "voltage_max": None,
+        "gen_p_violation_max": None,
+        "gen_q_violation_max": None,
+        "gen_q_violation_count": 0,
+        "gen_q_violation_total_abs": 0.0,
+        "gen_q_violation_argmax": None,
+        "gen_q_violation_top": [],
+        "branch_loading_available": False,
+        "branch_loading_max": None,
+        "branch_overloaded_count": 0,
+        "branch_loading_argmax": None,
+    }
+
+    try:
+        pf_solution = runpf(psys, verbose=False)
+    except Exception as exc:
+        diagnostics["reject_reason"] = "pf_non_converged"
+        diagnostics["pf_error"] = str(exc)
+        return None, diagnostics
+
+    slack_mask = _slack_generator_mask(psys)
+    diagnostics.update({
+        "pf_converged": True,
+        "pf_residual": _compute_power_flow_residual(psys, pf_solution),
+        "slack_p_target": float(np.sum(p_gen_target[slack_mask])),
+        "slack_p_solved": float(np.sum(pf_solution.gen_psch[slack_mask])),
+        "slack_q_target": float(np.sum(q_gen_target[slack_mask])),
+        "slack_q_solved": float(np.sum(pf_solution.gen_qsch[slack_mask])),
+        "voltage_min": float(np.min(pf_solution.v_magnitudes)),
+        "voltage_max": float(np.max(pf_solution.v_magnitudes)),
+        "gen_p_violation_max": _limit_violation(pf_solution.gen_psch, pg_lb, pg_ub),
+        "gen_q_violation_max": _limit_violation(pf_solution.gen_qsch, qg_lb, qg_ub),
+        "slack_p_limit_violation": _limit_violation(
+            pf_solution.gen_psch[slack_mask],
+            pg_lb[slack_mask] if pg_lb is not None else None,
+            pg_ub[slack_mask] if pg_ub is not None else None,
+        ),
+    })
+    diagnostics["slack_p_deviation"] = (
+        diagnostics["slack_p_solved"] - diagnostics["slack_p_target"]
+    )
+    diagnostics["slack_q_deviation"] = (
+        diagnostics["slack_q_solved"] - diagnostics["slack_q_target"]
+    )
+    diagnostics.update(
+        _generator_q_limit_diagnostics(
+            psys,
+            pf_solution.gen_qsch,
+            qg_lb,
+            qg_ub,
+            top_n=int(op_cfg["q_limit_mitigation_top_n"]),
+        )
+    )
+    diagnostics.update(_compute_branch_loading_diagnostics(psys, pf_solution))
+
+    return pf_solution, diagnostics
+
+
+def _screen_power_flow_diagnostics(diagnostics, total_load_p, op_cfg):
+    """Return (accepted, reason) for operating-point diagnostics."""
+    if not diagnostics.get("pf_converged", False):
+        return False, diagnostics.get("reject_reason", "pf_non_converged")
+
+    if diagnostics["pf_residual"] is None or diagnostics["pf_residual"] > op_cfg["pf_residual_tol"]:
+        return False, "pf_residual"
+
+    slack_tol = max(
+        op_cfg["slack_p_tolerance_pu"],
+        abs(total_load_p) * op_cfg["max_slack_p_deviation_fraction_of_load"],
+    )
+    if abs(diagnostics["slack_p_deviation"]) > slack_tol:
+        return False, "slack_p_deviation"
+
+    if diagnostics["voltage_min"] < op_cfg["voltage_min"]:
+        return False, "voltage_low"
+    if diagnostics["voltage_max"] > op_cfg["voltage_max"]:
+        return False, "voltage_high"
+
+    limit_tol = op_cfg["gen_limit_tolerance"]
+    if diagnostics["gen_p_violation_max"] > limit_tol:
+        return False, "gen_p_limit"
+    if diagnostics["gen_q_violation_max"] > limit_tol:
+        return False, "gen_q_limit"
+
+    if (
+        diagnostics["branch_loading_available"]
+        and diagnostics["branch_loading_max"] is not None
+        and diagnostics["branch_loading_max"] > op_cfg["branch_loading_max"]
+    ):
+        return False, "branch_overload"
+
+    return True, None
+
+
+def _prepare_operating_point(
+        psys, p_load, q_load, p_gen, q_gen, base_p_gen, base_q_gen,
+        pg_lb, pg_ub, qg_lb, qg_ub, keep_power_factor, clamp_gens,
+        balance_generation, op_cfg):
+    """PF-aware active-power rebalance and scenario screening."""
+    diagnostics = {
+        "accepted": False,
+        "rebalance_iterations": 0,
+        "rebalance_policy": op_cfg["rebalance_policy"],
+        "initial_rebalance_applied_pu": 0.0,
+        "initial_rebalance_unresolved_pu": 0.0,
+        "loss_compensation_enabled": bool(op_cfg["loss_compensation"]),
+        "loss_compensation_policy": op_cfg["loss_compensation_policy"],
+        "loss_compensation_requested_pu": 0.0,
+        "loss_compensation_applied_pu": 0.0,
+        "loss_compensation_unresolved_pu": 0.0,
+        "loss_compensation_unresolved_abs_pu": 0.0,
+        "loss_compensation_participants": 0,
+        "loss_compensation_iterations": 0,
+        "loss_compensation_effective_tolerance_pu": None,
+        "non_slack_headroom_remaining": None,
+        "non_slack_footroom_remaining": None,
+        "reject_reason": None,
+    }
+    diagnostics.update(_q_limit_mitigation_defaults(op_cfg))
+
+    if not op_cfg["enabled"]:
+        return p_gen, q_gen, None, {**diagnostics, "accepted": True}
+
+    p_gen = np.asarray(p_gen, dtype=float).copy()
+    q_gen = np.asarray(q_gen, dtype=float).copy()
+    total_load_p = float(np.sum(p_load))
+    non_slack_mask = ~_slack_generator_mask(psys)
+    original_bus_types = _capture_bus_types(psys)
+    q_fixed_mask = np.zeros_like(q_gen, dtype=bool)
+    q_fixed_values = np.array(q_gen, copy=True, dtype=float)
+
+    headroom, footroom = _active_power_margin_sums(
+        p_gen, pg_lb, pg_ub, non_slack_mask
+    )
+    diagnostics["non_slack_headroom_remaining"] = headroom
+    diagnostics["non_slack_footroom_remaining"] = footroom
+
+    if balance_generation and op_cfg["rebalance_non_slack"]:
+        rebalance = _rebalance_active_power(
+            p_gen,
+            pg_lb,
+            pg_ub,
+            total_load_p,
+            participation_mask=non_slack_mask,
+            policy=op_cfg["rebalance_policy"],
+            base_p_gen=base_p_gen,
+            return_diagnostics=True,
+        )
+        p_gen = rebalance["p_gen"]
+        diagnostics["initial_rebalance_applied_pu"] = rebalance["applied_mismatch"]
+        diagnostics["initial_rebalance_unresolved_pu"] = rebalance["unresolved_mismatch"]
+        diagnostics["initial_rebalance_participants"] = rebalance["participants"]
+        diagnostics["non_slack_headroom_remaining"] = rebalance["headroom_remaining"]
+        diagnostics["non_slack_footroom_remaining"] = rebalance["footroom_remaining"]
+
+    pf_solution = None
+    max_iterations = int(op_cfg["max_iterations"])
+    for iteration in range(max_iterations):
+        q_gen = _compute_generator_q_dispatch(
+            base_p_gen, base_q_gen, p_gen, keep_power_factor=keep_power_factor
+        )
+        if np.any(q_fixed_mask):
+            q_gen[q_fixed_mask] = q_fixed_values[q_fixed_mask]
+        if clamp_gens and qg_lb is not None and qg_ub is not None and q_gen.size:
+            q_gen = np.clip(q_gen, qg_lb, qg_ub)
+            if np.any(q_fixed_mask):
+                q_fixed_values[q_fixed_mask] = q_gen[q_fixed_mask]
+
+        psys.set_load_pq(p_load, q_load)
+        psys.set_gen_pq(p_gen, q_gen)
+        psys.createYbusComplex()
+
+        diagnostics["rebalance_iterations"] = iteration + 1
+
+        if not op_cfg["run_power_flow"]:
+            diagnostics.update({
+                "accepted": True,
+                "reject_reason": None,
+                "pf_converged": None,
+                "pf_residual": None,
+            })
+            _restore_bus_types(psys, original_bus_types)
+            return p_gen, q_gen, None, diagnostics
+
+        pf_solution, pf_diag = _diagnose_power_flow(
+            psys, p_gen, q_gen, pg_lb, pg_ub, qg_lb, qg_ub, op_cfg
+        )
+        diagnostics.update(pf_diag)
+
+        if (
+            op_cfg["q_limit_mitigation"]
+            and pf_solution is not None
+            and diagnostics.get("pf_converged", False)
+        ):
+            if diagnostics["q_limit_mitigation_passes"] >= int(
+                op_cfg["q_limit_mitigation_max_passes"]
+            ):
+                diagnostics["q_limit_mitigation_limit_reached"] = (
+                    diagnostics.get("gen_q_violation_max", 0.0)
+                    > op_cfg["q_limit_mitigation_tolerance_pu"]
+                )
+            else:
+                q_next, q_mitigation = _apply_q_limit_mitigation(
+                    psys,
+                    q_gen,
+                    pf_solution.gen_qsch,
+                    qg_lb,
+                    qg_ub,
+                    op_cfg,
+                    q_fixed_mask=q_fixed_mask,
+                    q_fixed_values=q_fixed_values,
+                    pass_idx=diagnostics["q_limit_mitigation_passes"] + 1,
+                )
+                if q_mitigation["applied"]:
+                    q_gen = q_next
+                    diagnostics["q_limit_mitigation_applied"] = True
+                    diagnostics["q_limit_mitigation_passes"] += 1
+                    diagnostics["q_limit_mitigation_events"].extend(
+                        q_mitigation["events"]
+                    )
+                    diagnostics["q_limit_mitigation_switched_buses"] = sorted(
+                        set(diagnostics["q_limit_mitigation_switched_buses"])
+                        | set(q_mitigation["switched_buses"])
+                    )
+                    diagnostics["q_limit_mitigation_switched_generators"] = sorted(
+                        set(diagnostics["q_limit_mitigation_switched_generators"])
+                        | set(q_mitigation["switched_generators"])
+                    )
+                    if iteration + 1 >= max_iterations:
+                        diagnostics["reject_reason"] = (
+                            "q_limit_mitigation_max_iterations"
+                        )
+                        break
+                    continue
+
+        headroom, footroom = _active_power_margin_sums(
+            p_gen, pg_lb, pg_ub, non_slack_mask
+        )
+        diagnostics["non_slack_headroom_remaining"] = headroom
+        diagnostics["non_slack_footroom_remaining"] = footroom
+
+        pf_residual = diagnostics.get("pf_residual")
+        pf_ok_for_loss = (
+            pf_solution is not None
+            and diagnostics.get("pf_converged", False)
+            and pf_residual is not None
+            and pf_residual <= op_cfg["pf_residual_tol"]
+        )
+        slack_delta = diagnostics.get("slack_p_deviation")
+        loss_tolerance = max(
+            min(
+                op_cfg["loss_compensation_tolerance_pu"],
+                op_cfg["gen_limit_tolerance"],
+            ),
+            1e-12,
+        )
+        diagnostics["loss_compensation_effective_tolerance_pu"] = loss_tolerance
+        if (
+            op_cfg["loss_compensation"]
+            and pf_ok_for_loss
+            and slack_delta is not None
+            and abs(slack_delta) > loss_tolerance
+        ):
+            loss_rebalance = _redistribute_active_power_mismatch(
+                p_gen,
+                pg_lb,
+                pg_ub,
+                slack_delta,
+                participation_mask=non_slack_mask,
+                policy=op_cfg["loss_compensation_policy"],
+                base_p_gen=base_p_gen,
+                return_diagnostics=True,
+            )
+            diagnostics["loss_compensation_requested_pu"] += float(slack_delta)
+            diagnostics["loss_compensation_applied_pu"] += float(
+                loss_rebalance["applied_mismatch"]
+            )
+            diagnostics["loss_compensation_unresolved_pu"] = float(
+                loss_rebalance["unresolved_mismatch"]
+            )
+            diagnostics["loss_compensation_unresolved_abs_pu"] = abs(
+                diagnostics["loss_compensation_unresolved_pu"]
+            )
+            diagnostics["loss_compensation_participants"] = int(
+                loss_rebalance["participants"]
+            )
+            diagnostics["loss_compensation_iterations"] += 1
+            diagnostics["non_slack_headroom_remaining"] = loss_rebalance[
+                "headroom_remaining"
+            ]
+            diagnostics["non_slack_footroom_remaining"] = loss_rebalance[
+                "footroom_remaining"
+            ]
+
+            p_next = loss_rebalance["p_gen"]
+            if abs(loss_rebalance["applied_mismatch"]) > 1e-12:
+                if iteration + 1 >= max_iterations:
+                    p_gen = p_next
+                    diagnostics["reject_reason"] = "loss_compensation_max_iterations"
+                    break
+                p_gen = p_next
+                continue
+
+        accepted, reason = _screen_power_flow_diagnostics(diagnostics, total_load_p, op_cfg)
+        if accepted:
+            diagnostics.update({"accepted": True, "reject_reason": None})
+            _restore_bus_types(psys, original_bus_types)
+            return pf_solution.gen_psch.copy(), pf_solution.gen_qsch.copy(), pf_solution, diagnostics
+
+        diagnostics["reject_reason"] = reason
+        if (
+            reason != "slack_p_deviation"
+            or not op_cfg["redistribute_slack_mismatch"]
+            or pf_solution is None
+            or iteration + 1 >= max_iterations
+        ):
+            break
+
+        slack_rebalance = _redistribute_active_power_mismatch(
+            p_gen,
+            pg_lb,
+            pg_ub,
+            diagnostics["slack_p_deviation"],
+            participation_mask=non_slack_mask,
+            policy=op_cfg["loss_compensation_policy"],
+            base_p_gen=base_p_gen,
+            return_diagnostics=True,
+        )
+        p_next = slack_rebalance["p_gen"]
+        if abs(slack_rebalance["applied_mismatch"]) <= 1e-12:
+            break
+        p_gen = p_next
+
+    diagnostics["accepted"] = False
+    _restore_bus_types(psys, original_bus_types)
+    return p_gen, q_gen, pf_solution, diagnostics
+
+
+# =============================================================================
 # Scenario Sampling and Metadata
 # =============================================================================
 
@@ -620,6 +1536,397 @@ def generate_metadata(scenarios):
 # Simulation Worker
 # =============================================================================
 
+def _load_power_system(raw_file, dyr_file):
+    """Load a fresh power-system model with dynamic data."""
+    psys = load_psse(raw_file)
+    add_dyr(psys, dyr_file)
+    return psys
+
+
+def _get_generator_bounds(psys):
+    """Return generator active/reactive bounds when available."""
+    try:
+        pg_lb, pg_ub = psys.get_pgen_bounds()
+    except AttributeError:
+        pg_lb = pg_ub = None
+
+    try:
+        qg_lb, qg_ub = psys.get_qgen_bounds()
+    except AttributeError:
+        qg_lb = qg_ub = None
+
+    return pg_lb, pg_ub, qg_lb, qg_ub
+
+
+def _integration_config_from_dict(integration_config=None):
+    """Build an IntegrationConfig from a user dictionary."""
+    int_cfg = integration_config or {}
+    return IntegrationConfig(
+        tend=int_cfg.get("tend", 10.0),
+        dt=int_cfg.get("dt", 1 / 120.0),
+        power_injection=int_cfg.get("power_injection", False),
+        ton=int_cfg.get("ton", 0.25),
+        toff=int_cfg.get("toff", 0.4),
+        verbose=int_cfg.get("verbose", False),
+        petsc=int_cfg.get("petsc", True),
+    )
+
+
+def _simulation_file_path(scenario_id):
+    """Return the standard output path for a scenario file."""
+    return f"simulation_data/scenario_{scenario_id}.npz"
+
+
+def _prepare_operating_point_candidate(
+        raw_file, dyr_file, scenario, scenario_id,
+        *, noise_type="normal", noise_var=0.1,
+        global_seed=0,
+        balance_generation=False,
+        perturb_loads=True,
+        perturb_gens=True,
+        load_noise_type=None,
+        gen_noise_type=None,
+        load_noise_var=None,
+        gen_noise_var=None,
+        keep_power_factor=True,
+        clamp_gens=True,
+        load_scale=1.0,
+        load_mean_shift=0.0,
+        generation_dispatch_init="perturbed",
+        operating_point_config=None):
+    """Sample and PF-screen one candidate operating point."""
+    op_cfg = _resolve_operating_point_config(operating_point_config)
+    max_attempts = int(op_cfg["max_attempts_per_scenario"]) if op_cfg["enabled"] else 1
+    load_noise_type = load_noise_type or noise_type
+    gen_noise_type = gen_noise_type or noise_type
+    load_noise_var = load_noise_var if load_noise_var is not None else noise_var
+    gen_noise_var = gen_noise_var if gen_noise_var is not None else noise_var
+
+    diagnostics = None
+    psys = None
+    accepted = False
+    pL_scaled = qL_scaled = pL_noise = qL_noise = None
+    pG_scaled = qG_scaled = pG_noise = qG_noise = None
+    base_p_load = base_q_load = base_p_gen = base_q_gen = None
+    pf_v_magnitudes = pf_v_angles = None
+    attempt_diagnostics = []
+
+    try:
+        for attempt_idx in range(max_attempts):
+            if psys is not None:
+                del psys
+                gc.collect()
+
+            psys = _load_power_system(raw_file, dyr_file)
+            base_p_load, base_q_load = psys.get_load_pq()
+            base_p_gen, base_q_gen = psys.get_gen_pq()
+            pg_lb, pg_ub, qg_lb, qg_ub = _get_generator_bounds(psys)
+
+            ss = _scenario_seed_sequence(
+                global_seed,
+                scenario["sample_idx"],
+                attempt_idx,
+            )
+            rng_load, rng_gen = [np.random.default_rng(s) for s in ss.spawn(2)]
+
+            stressed_p_load, stressed_q_load, load_factor = _stress_load(
+                base_p_load,
+                base_q_load,
+                load_scale=load_scale,
+                load_mean_shift=load_mean_shift,
+            )
+
+            if perturb_loads and base_p_load.size:
+                pL_scaled, qL_scaled, _, _ = generate_perturbations(
+                    stressed_p_load,
+                    stressed_q_load,
+                    noise_type=load_noise_type,
+                    var=load_noise_var,
+                    rng=rng_load,
+                    return_noise=True,
+                    preserve_power_factor=keep_power_factor,
+                )
+            else:
+                pL_scaled = np.array(stressed_p_load, copy=True)
+                qL_scaled = np.array(stressed_q_load, copy=True)
+
+            pL_noise = _relative_noise(pL_scaled, base_p_load)
+            qL_noise = _relative_noise(qL_scaled, base_q_load)
+
+            if generation_dispatch_init not in {"base", "perturbed"}:
+                raise ValueError(
+                    "generation_dispatch_init must be either 'base' or 'perturbed'"
+                )
+
+            if generation_dispatch_init == "perturbed" and perturb_gens and base_p_gen.size:
+                pG_noise_raw = _draw_noise(
+                    base_p_gen.shape,
+                    noise_type=gen_noise_type,
+                    var=gen_noise_var,
+                    rng=rng_gen,
+                )
+                pG_scaled = base_p_gen * (1.0 + pG_noise_raw)
+            else:
+                pG_scaled = np.array(base_p_gen, copy=True)
+
+            if clamp_gens and pg_lb is not None and pg_ub is not None and pG_scaled.size:
+                pG_scaled = np.clip(pG_scaled, pg_lb, pg_ub)
+
+            if balance_generation and not op_cfg["enabled"]:
+                sum_pL = float(np.sum(pL_scaled))
+                pG_scaled = _rebalance_active_power(pG_scaled, pg_lb, pg_ub, sum_pL)
+
+            qG_scaled = _compute_generator_q_dispatch(
+                base_p_gen, base_q_gen, pG_scaled, keep_power_factor=keep_power_factor
+            )
+
+            if clamp_gens and qg_lb is not None and qg_ub is not None and qG_scaled.size:
+                qG_scaled = np.clip(qG_scaled, qg_lb, qg_ub)
+
+            pf_solution = None
+            diagnostics = {
+                "record_type": "operating_point_attempt",
+                "scenario_id": scenario_id,
+                "operating_point_id": scenario.get("operating_point_id", scenario_id),
+                "sample_idx": scenario["sample_idx"],
+                "fault_location": scenario.get("fault_location"),
+                "fault_impedance": scenario.get("fault_impedance"),
+                "accepted_operating_point_index": scenario.get(
+                    "accepted_operating_point_index"
+                ),
+                "attempt_idx": attempt_idx,
+                "attempts": attempt_idx + 1,
+                "accepted": True,
+                "reject_reason": None,
+                "load_scale": float(load_scale),
+                "load_mean_shift": float(load_mean_shift),
+                "load_factor": float(load_factor),
+                "generation_dispatch_init": generation_dispatch_init,
+                "total_p_load": float(np.sum(pL_scaled)),
+                "total_q_load": float(np.sum(qL_scaled)),
+                "total_p_gen_scheduled": float(np.sum(pG_scaled)),
+                "operating_point_enabled": bool(op_cfg["enabled"]),
+            }
+
+            if op_cfg["enabled"]:
+                pG_scaled, qG_scaled, pf_solution, op_diagnostics = _prepare_operating_point(
+                    psys,
+                    pL_scaled,
+                    qL_scaled,
+                    pG_scaled,
+                    qG_scaled,
+                    base_p_gen,
+                    base_q_gen,
+                    pg_lb,
+                    pg_ub,
+                    qg_lb,
+                    qg_ub,
+                    keep_power_factor,
+                    clamp_gens,
+                    balance_generation,
+                    op_cfg,
+                )
+                diagnostics.update(op_diagnostics)
+                diagnostics["record_type"] = "operating_point_attempt"
+                diagnostics["scenario_id"] = scenario_id
+                diagnostics["operating_point_id"] = scenario.get(
+                    "operating_point_id", scenario_id
+                )
+                diagnostics["sample_idx"] = scenario["sample_idx"]
+                diagnostics["fault_location"] = scenario.get("fault_location")
+                diagnostics["fault_impedance"] = scenario.get("fault_impedance")
+                diagnostics["accepted_operating_point_index"] = scenario.get(
+                    "accepted_operating_point_index"
+                )
+                diagnostics["attempt_idx"] = attempt_idx
+                diagnostics["attempts"] = attempt_idx + 1
+                diagnostics["total_p_gen_scheduled"] = float(np.sum(pG_scaled))
+
+                if not diagnostics["accepted"]:
+                    attempt_diagnostics.append(_json_safe(copy.deepcopy(diagnostics)))
+                    continue
+
+                if pf_solution is not None:
+                    pf_v_magnitudes = np.array(pf_solution.v_magnitudes, copy=True)
+                    pf_v_angles = np.array(pf_solution.v_angles, copy=True)
+
+            attempt_diagnostics.append(_json_safe(copy.deepcopy(diagnostics)))
+            accepted = True
+            break
+
+        if not accepted:
+            reject_reason = diagnostics.get("reject_reason", "operating_point_rejected")
+            diagnostics.update({
+                "accepted": False,
+                "attempts": max_attempts,
+                "reject_reason": reject_reason,
+            })
+            print(
+                f"Rejected scenario {scenario_id} after {max_attempts} attempts: "
+                f"{reject_reason}"
+            )
+            return {
+                "file": None,
+                "diverged": True,
+                "rejected": True,
+                "error": (
+                    f"Could not rebalance scenario after {max_attempts} attempts; "
+                    f"last reason: {reject_reason}"
+                ),
+                "diagnostics": _json_safe(diagnostics),
+                "diagnostics_attempts": _json_safe(attempt_diagnostics),
+            }
+
+        pG_noise = _relative_noise(pG_scaled, base_p_gen)
+        qG_noise = _relative_noise(qG_scaled, base_q_gen)
+
+        operating_point = {
+            "p_load_scaled": np.array(pL_scaled, copy=True),
+            "q_load_scaled": np.array(qL_scaled, copy=True),
+            "p_load_noise": np.array(pL_noise, copy=True),
+            "q_load_noise": np.array(qL_noise, copy=True),
+            "p_gen_scaled": np.array(pG_scaled, copy=True),
+            "q_gen_scaled": np.array(qG_scaled, copy=True),
+            "p_gen_noise": np.array(pG_noise, copy=True),
+            "q_gen_noise": np.array(qG_noise, copy=True),
+            "load_scale": float(load_scale),
+            "load_mean_shift": float(load_mean_shift),
+            "pf_v_magnitudes": pf_v_magnitudes,
+            "pf_v_angles": pf_v_angles,
+            "diagnostics": _json_safe(diagnostics),
+            "operating_point_id": scenario.get("operating_point_id", scenario_id),
+            "sample_idx": scenario["sample_idx"],
+            "accepted_operating_point_index": scenario.get(
+                "accepted_operating_point_index"
+            ),
+        }
+
+        return {
+            "file": None,
+            "diverged": False,
+            "rejected": False,
+            "diagnostics": _json_safe(diagnostics),
+            "diagnostics_attempts": _json_safe(attempt_diagnostics),
+            "operating_point": operating_point,
+        }
+
+    finally:
+        if psys is not None:
+            del psys
+        gc.collect()
+
+
+def _run_fault_with_operating_point_worker(
+        raw_file, dyr_file, scenario, scenario_id, operating_point,
+        integration_config=None):
+    """Run one dynamic fault simulation from a prepared operating point."""
+    psys = None
+    sim = None
+    diagnostics = copy.deepcopy(operating_point.get("diagnostics", {}))
+    diagnostics.update({
+        "record_type": "fault_scenario",
+        "scenario_id": scenario_id,
+        "operating_point_id": scenario.get(
+            "operating_point_id",
+            operating_point.get("operating_point_id"),
+        ),
+        "sample_idx": scenario["sample_idx"],
+        "fault_location": scenario["fault_location"],
+        "fault_impedance": scenario["fault_impedance"],
+        "accepted_operating_point_index": scenario.get(
+            "accepted_operating_point_index",
+            operating_point.get("accepted_operating_point_index"),
+        ),
+        "accepted": True,
+        "reject_reason": None,
+    })
+
+    try:
+        psys = _load_power_system(raw_file, dyr_file)
+        p_load = np.asarray(operating_point["p_load_scaled"], dtype=float)
+        q_load = np.asarray(operating_point["q_load_scaled"], dtype=float)
+        p_gen = np.asarray(operating_point["p_gen_scaled"], dtype=float)
+        q_gen = np.asarray(operating_point["q_gen_scaled"], dtype=float)
+
+        psys.set_load_pq(p_load, q_load)
+        psys.set_gen_pq(p_gen, q_gen)
+
+        v_magnitudes = operating_point.get("pf_v_magnitudes")
+        v_angles = operating_point.get("pf_v_angles")
+        if v_magnitudes is not None and v_angles is not None:
+            for bus_idx, bus in enumerate(psys.buses):
+                bus.set_vinit(v_magnitudes[bus_idx], v_angles[bus_idx])
+
+        psys.add_busfault(scenario["fault_location"], scenario["fault_impedance"])
+        psys.createYbusComplex()
+
+        try:
+            sim = integrate_system(psys, _integration_config_from_dict(integration_config))
+            diverged = False
+        except Exception as e:
+            print(f"Simulation failed for scenario {scenario_id}: {str(e)}")
+            sim = {"history": None, "tvec": None}
+            diverged = True
+            diagnostics["simulation_error"] = str(e)
+
+        diagnostics["simulation_diverged"] = diverged
+        diagnostics["file"] = None if diverged else _simulation_file_path(scenario_id)
+
+        os.makedirs("simulation_data", exist_ok=True)
+        fn = _simulation_file_path(scenario_id)
+        np.savez_compressed(
+            fn,
+            history=sim["history"],
+            tvec=sim["tvec"],
+            p_load_scaled=p_load,
+            q_load_scaled=q_load,
+            p_load_noise=np.asarray(operating_point["p_load_noise"], dtype=float),
+            q_load_noise=np.asarray(operating_point["q_load_noise"], dtype=float),
+            load_scale=float(operating_point["load_scale"]),
+            load_mean_shift=float(operating_point["load_mean_shift"]),
+            p_gen_scaled=p_gen,
+            q_gen_scaled=q_gen,
+            p_gen_noise=np.asarray(operating_point["p_gen_noise"], dtype=float),
+            q_gen_noise=np.asarray(operating_point["q_gen_noise"], dtype=float),
+            operating_point_id=str(diagnostics.get("operating_point_id")),
+            accepted_operating_point_index=diagnostics.get(
+                "accepted_operating_point_index"
+            ),
+        )
+
+        diagnostics["file"] = fn
+        return {
+            "file": fn,
+            "diverged": diverged,
+            "rejected": False,
+            "diagnostics": _json_safe(diagnostics),
+        }
+
+    except Exception as e:
+        print(f"Worker error for scenario {scenario_id}: {str(e)}")
+        traceback.print_exc()
+        diagnostics.update({
+            "accepted": False,
+            "reject_reason": "worker_error",
+            "simulation_error": str(e),
+            "simulation_diverged": True,
+            "file": None,
+        })
+        return {
+            "file": None,
+            "diverged": True,
+            "rejected": False,
+            "error": str(e),
+            "diagnostics": _json_safe(diagnostics),
+        }
+    finally:
+        if sim is not None:
+            del sim
+        if psys is not None:
+            del psys
+        gc.collect()
+
+
 def run_single_scenario_worker(
         raw_file, dyr_file, scenario, scenario_id,
         noise_type="normal", noise_var=0.1,
@@ -633,6 +1940,10 @@ def run_single_scenario_worker(
         gen_noise_var=None,
         keep_power_factor=True,
         clamp_gens=True,
+        load_scale=1.0,
+        load_mean_shift=0.0,
+        generation_dispatch_init="perturbed",
+        operating_point_config=None,
         integration_config=None):
     r"""
     Worker function for single-scenario simulation.
@@ -731,104 +2042,194 @@ def run_single_scenario_worker(
     generator perturbations.
     """
     try:
-        # Load fresh model in worker process to avoid MPI communicator issues
-        psys = load_psse(raw_file)
-        add_dyr(psys, dyr_file)
-
-        # Get base load and generation setpoints
-        base_p_load, base_q_load = psys.get_load_pq()
-        base_p_gen, base_q_gen = psys.get_gen_pq()
-
-        # Retrieve generator limits (may not exist in older model versions)
-        try:
-            pg_lb, pg_ub = psys.get_pgen_bounds()
-        except AttributeError:
-            pg_lb = pg_ub = None
-
-        try:
-            qg_lb, qg_ub = psys.get_qgen_bounds()
-        except AttributeError:
-            qg_lb = qg_ub = None
-
-        # Create independent RNG streams for loads and generators
-        ss = np.random.SeedSequence([global_seed, scenario["sample_idx"]])
-        rng_load, rng_gen = [np.random.default_rng(s) for s in ss.spawn(2)]
-
-        # Resolve per-type noise parameters (use defaults if not specified)
+        op_cfg = _resolve_operating_point_config(operating_point_config)
+        max_attempts = int(op_cfg["max_attempts_per_scenario"]) if op_cfg["enabled"] else 1
         load_noise_type = load_noise_type or noise_type
         gen_noise_type = gen_noise_type or noise_type
         load_noise_var = load_noise_var if load_noise_var is not None else noise_var
         gen_noise_var = gen_noise_var if gen_noise_var is not None else noise_var
 
-        # -----------------------------------------------------------------
-        # Step 1: Perturb loads
-        # -----------------------------------------------------------------
-        if perturb_loads and base_p_load.size:
-            pL_scaled, qL_scaled, pL_noise, qL_noise = generate_perturbations(
-                base_p_load, base_q_load,
-                noise_type=load_noise_type, var=load_noise_var, rng=rng_load,
-                return_noise=True, preserve_power_factor=keep_power_factor
+        diagnostics = None
+        psys = None
+        pL_scaled = qL_scaled = pL_noise = qL_noise = None
+        pG_scaled = qG_scaled = pG_noise = qG_noise = None
+        base_p_load = base_q_load = base_p_gen = base_q_gen = None
+        accepted = False
+        attempt_diagnostics = []
+
+        for attempt_idx in range(max_attempts):
+            if psys is not None:
+                del psys
+                gc.collect()
+
+            # Load fresh model in worker process to avoid MPI communicator issues
+            psys = load_psse(raw_file)
+            add_dyr(psys, dyr_file)
+
+            # Get base load and generation setpoints
+            base_p_load, base_q_load = psys.get_load_pq()
+            base_p_gen, base_q_gen = psys.get_gen_pq()
+
+            # Retrieve generator limits (may not exist in older model versions)
+            try:
+                pg_lb, pg_ub = psys.get_pgen_bounds()
+            except AttributeError:
+                pg_lb = pg_ub = None
+
+            try:
+                qg_lb, qg_ub = psys.get_qgen_bounds()
+            except AttributeError:
+                qg_lb = qg_ub = None
+
+            # Create independent RNG streams for loads and generators
+            ss = _scenario_seed_sequence(global_seed, scenario["sample_idx"], attempt_idx)
+            rng_load, rng_gen = [np.random.default_rng(s) for s in ss.spawn(2)]
+
+            # -----------------------------------------------------------------
+            # Step 1: Apply deterministic load stress and stochastic perturbation
+            # -----------------------------------------------------------------
+            stressed_p_load, stressed_q_load, load_factor = _stress_load(
+                base_p_load,
+                base_q_load,
+                load_scale=load_scale,
+                load_mean_shift=load_mean_shift,
             )
-        else:
-            # Keep base values unchanged
-            pL_scaled = np.array(base_p_load, copy=True)
-            qL_scaled = np.array(base_q_load, copy=True)
-            pL_noise = np.zeros_like(base_p_load, dtype=float)
-            qL_noise = np.zeros_like(base_q_load, dtype=float)
 
-        # -----------------------------------------------------------------
-        # Step 2: Perturb generator active power
-        # -----------------------------------------------------------------
-        if perturb_gens and base_p_gen.size:
-            pG_noise_raw = _draw_noise(
-                base_p_gen.shape,
-                noise_type=gen_noise_type,
-                var=gen_noise_var,
-                rng=rng_gen,
+            if perturb_loads and base_p_load.size:
+                pL_scaled, qL_scaled, _, _ = generate_perturbations(
+                    stressed_p_load, stressed_q_load,
+                    noise_type=load_noise_type, var=load_noise_var, rng=rng_load,
+                    return_noise=True, preserve_power_factor=keep_power_factor
+                )
+            else:
+                pL_scaled = np.array(stressed_p_load, copy=True)
+                qL_scaled = np.array(stressed_q_load, copy=True)
+
+            pL_noise = _relative_noise(pL_scaled, base_p_load)
+            qL_noise = _relative_noise(qL_scaled, base_q_load)
+
+            # -----------------------------------------------------------------
+            # Step 2: Initialize generator active power
+            # -----------------------------------------------------------------
+            if generation_dispatch_init not in {"base", "perturbed"}:
+                raise ValueError(
+                    "generation_dispatch_init must be either 'base' or 'perturbed'"
+                )
+
+            if generation_dispatch_init == "perturbed" and perturb_gens and base_p_gen.size:
+                pG_noise_raw = _draw_noise(
+                    base_p_gen.shape,
+                    noise_type=gen_noise_type,
+                    var=gen_noise_var,
+                    rng=rng_gen,
+                )
+                pG_scaled = base_p_gen * (1.0 + pG_noise_raw)
+            else:
+                pG_scaled = np.array(base_p_gen, copy=True)
+
+            # -----------------------------------------------------------------
+            # Step 3: Clamp generator active power to limits
+            # -----------------------------------------------------------------
+            if clamp_gens and pg_lb is not None and pg_ub is not None and pG_scaled.size:
+                pG_scaled = np.clip(pG_scaled, pg_lb, pg_ub)
+
+            # -----------------------------------------------------------------
+            # Step 4: Legacy or PF-aware active-power rebalancing
+            # -----------------------------------------------------------------
+            if balance_generation and not op_cfg["enabled"]:
+                sum_pL = float(np.sum(pL_scaled))
+                pG_scaled = _rebalance_active_power(pG_scaled, pg_lb, pg_ub, sum_pL)
+
+            qG_scaled = _compute_generator_q_dispatch(
+                base_p_gen, base_q_gen, pG_scaled, keep_power_factor=keep_power_factor
             )
-            pG_scaled = base_p_gen * (1.0 + pG_noise_raw)
-        else:
-            pG_scaled = np.array(base_p_gen, copy=True)
 
-        # -----------------------------------------------------------------
-        # Step 3: Clamp generator active power to limits
-        # -----------------------------------------------------------------
-        if clamp_gens and pg_lb is not None and pg_ub is not None and pG_scaled.size:
-            pG_scaled = np.clip(pG_scaled, pg_lb, pg_ub)
+            if clamp_gens and qg_lb is not None and qg_ub is not None and qG_scaled.size:
+                qG_scaled = np.clip(qG_scaled, qg_lb, qg_ub)
 
-        # -----------------------------------------------------------------
-        # Step 4: Rebalance generation to match load
-        # -----------------------------------------------------------------
-        if balance_generation:
-            sum_pL = float(np.sum(pL_scaled))
-            pG_scaled = _rebalance_active_power(pG_scaled, pg_lb, pg_ub, sum_pL)
+            pf_solution = None
+            diagnostics = {
+                "scenario_id": scenario_id,
+                "sample_idx": scenario["sample_idx"],
+                "fault_location": scenario["fault_location"],
+                "fault_impedance": scenario["fault_impedance"],
+                "attempt_idx": attempt_idx,
+                "attempts": attempt_idx + 1,
+                "accepted": True,
+                "reject_reason": None,
+                "load_scale": float(load_scale),
+                "load_mean_shift": float(load_mean_shift),
+                "load_factor": float(load_factor),
+                "generation_dispatch_init": generation_dispatch_init,
+                "total_p_load": float(np.sum(pL_scaled)),
+                "total_q_load": float(np.sum(qL_scaled)),
+                "total_p_gen_scheduled": float(np.sum(pG_scaled)),
+                "operating_point_enabled": bool(op_cfg["enabled"]),
+            }
 
-        # -----------------------------------------------------------------
-        # Step 5: Compute generator reactive power
-        # -----------------------------------------------------------------
-        if keep_power_factor:
-            # Adjust Q to maintain original power factor
-            qG_scaled = np.array(base_q_gen, copy=True, dtype=float)
+            if op_cfg["enabled"]:
+                pG_scaled, qG_scaled, pf_solution, op_diagnostics = _prepare_operating_point(
+                    psys,
+                    pL_scaled,
+                    qL_scaled,
+                    pG_scaled,
+                    qG_scaled,
+                    base_p_gen,
+                    base_q_gen,
+                    pg_lb,
+                    pg_ub,
+                    qg_lb,
+                    qg_ub,
+                    keep_power_factor,
+                    clamp_gens,
+                    balance_generation,
+                    op_cfg,
+                )
+                diagnostics.update(op_diagnostics)
+                diagnostics["attempt_idx"] = attempt_idx
+                diagnostics["attempts"] = attempt_idx + 1
+                diagnostics["total_p_gen_scheduled"] = float(np.sum(pG_scaled))
 
-            mask_pg_nonzero = np.abs(base_p_gen) > 1e-8
-            if np.any(mask_pg_nonzero):
-                ratio = np.zeros_like(base_p_gen, dtype=float)
-                ratio[mask_pg_nonzero] = base_q_gen[mask_pg_nonzero] / base_p_gen[mask_pg_nonzero]
-                qG_scaled[mask_pg_nonzero] = ratio[mask_pg_nonzero] * pG_scaled[mask_pg_nonzero]
+                if not diagnostics["accepted"]:
+                    attempt_diagnostics.append(_json_safe(copy.deepcopy(diagnostics)))
+                    continue
 
-            # For purely reactive units (P=0, Q!=0): keep original Q
-            mask_pg_zero_q_nonzero = (~mask_pg_nonzero) & (np.abs(base_q_gen) > 1e-8)
-            if np.any(mask_pg_zero_q_nonzero):
-                qG_scaled[mask_pg_zero_q_nonzero] = base_q_gen[mask_pg_zero_q_nonzero]
-        else:
-            # Keep original Q schedule unchanged
-            qG_scaled = np.array(base_q_gen, copy=True, dtype=float)
+                if pf_solution is not None:
+                    for bus_idx, bus in enumerate(psys.buses):
+                        bus.set_vinit(
+                            pf_solution.v_magnitudes[bus_idx],
+                            pf_solution.v_angles[bus_idx],
+                        )
 
-        # -----------------------------------------------------------------
-        # Step 6: Clamp generator reactive power to limits
-        # -----------------------------------------------------------------
-        if clamp_gens and qg_lb is not None and qg_ub is not None and qG_scaled.size:
-            qG_scaled = np.clip(qG_scaled, qg_lb, qg_ub)
+            attempt_diagnostics.append(_json_safe(copy.deepcopy(diagnostics)))
+            accepted = True
+            break
+
+        if not accepted:
+            reject_reason = diagnostics.get("reject_reason", "operating_point_rejected")
+            diagnostics.update({
+                "accepted": False,
+                "attempts": max_attempts,
+                "reject_reason": reject_reason,
+            })
+            print(
+                f"Rejected scenario {scenario_id} after {max_attempts} attempts: "
+                f"{reject_reason}"
+            )
+            if psys is not None:
+                del psys
+            gc.collect()
+            return {
+                "file": None,
+                "diverged": True,
+                "rejected": True,
+                "error": (
+                    f"Could not rebalance scenario after {max_attempts} attempts; "
+                    f"last reason: {reject_reason}"
+                ),
+                "diagnostics": _json_safe(diagnostics),
+                "diagnostics_attempts": _json_safe(attempt_diagnostics),
+            }
 
         # Compute effective perturbation factors for logging
         pG_noise = _relative_noise(pG_scaled, base_p_gen)
@@ -863,6 +2264,10 @@ def run_single_scenario_worker(
             print(f"Simulation failed for scenario {scenario_id}: {str(e)}")
             sim = {"history": None, "tvec": None}
             diverged = True
+            diagnostics["simulation_error"] = str(e)
+
+        diagnostics["simulation_diverged"] = diverged
+        diagnostics["file"] = None if diverged else f"simulation_data/scenario_{scenario_id}.npz"
 
         # -----------------------------------------------------------------
         # Step 8: Save results
@@ -878,22 +2283,659 @@ def run_single_scenario_worker(
             # Load values and perturbations
             p_load_scaled=pL_scaled, q_load_scaled=qL_scaled,
             p_load_noise=pL_noise, q_load_noise=qL_noise,
+            load_scale=float(load_scale),
+            load_mean_shift=float(load_mean_shift),
             # Generator values and perturbations
             p_gen_scaled=pG_scaled, q_gen_scaled=qG_scaled,
             p_gen_noise=pG_noise, q_gen_noise=qG_noise,
         )
+
+        diagnostics["file"] = fn
 
         # Clean up resources (important for PETSc/MPI)
         del sim
         del psys
         gc.collect()
 
-        return {"file": fn, "diverged": diverged}
+        return {
+            "file": fn,
+            "diverged": diverged,
+            "rejected": False,
+            "diagnostics": _json_safe(diagnostics),
+            "diagnostics_attempts": _json_safe(attempt_diagnostics),
+        }
 
     except Exception as e:
         print(f"Worker error for scenario {scenario_id}: {str(e)}")
         traceback.print_exc()
-        return {"file": None, "diverged": True, "error": str(e)}
+        return {
+            "file": None,
+            "diverged": True,
+            "error": str(e),
+            "diagnostics_attempts": _json_safe(
+                locals().get("attempt_diagnostics", [])
+            ),
+        }
+
+
+def _write_diagnostics_records(path, records):
+    """Append diagnostics records as JSONL."""
+    if not path or not records:
+        return
+    with open(path, "a") as f:
+        for record in records:
+            f.write(json.dumps(_json_safe(record), sort_keys=True) + "\n")
+
+
+def _load_diagnostics_records(path):
+    """Load existing JSONL diagnostics records when continuing a run."""
+    if not path or not os.path.exists(path):
+        return []
+    records = []
+    with open(path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return records
+
+
+def _diagnostic_records_from_output(output):
+    """Return all diagnostics records carried by a worker output."""
+    if not isinstance(output, dict):
+        return []
+    records = output.get("diagnostics_attempts")
+    if records:
+        return records
+    record = output.get("diagnostics")
+    return [record] if record else []
+
+
+def _summarize_diagnostics(records):
+    """Create a compact diagnostics summary from simulation-log records."""
+    records = [record for record in records if record]
+    accepted = [record for record in records if record.get("accepted")]
+    rejected = [record for record in records if not record.get("accepted")]
+    reasons = Counter(record.get("reject_reason") or "accepted" for record in records)
+
+    def _finite_values(key):
+        vals = []
+        for record in records:
+            val = record.get(key)
+            if val is not None and np.isfinite(val):
+                vals.append(float(val))
+        return vals
+
+    summary = {
+        "total_records": len(records),
+        "accepted": len(accepted),
+        "rejected": len(rejected),
+        "acceptance_rate": (len(accepted) / len(records)) if records else None,
+        "reject_reasons": dict(reasons),
+    }
+
+    for key in [
+        "attempts",
+        "pf_residual",
+        "voltage_min",
+        "voltage_max",
+        "slack_p_deviation",
+        "slack_q_deviation",
+        "slack_p_limit_violation",
+        "gen_p_violation_max",
+        "gen_q_violation_max",
+        "gen_q_violation_count",
+        "gen_q_violation_total_abs",
+        "branch_loading_max",
+        "initial_rebalance_unresolved_pu",
+        "loss_compensation_requested_pu",
+        "loss_compensation_applied_pu",
+        "loss_compensation_unresolved_pu",
+        "loss_compensation_unresolved_abs_pu",
+        "loss_compensation_iterations",
+        "loss_compensation_effective_tolerance_pu",
+        "q_limit_mitigation_passes",
+        "non_slack_headroom_remaining",
+        "non_slack_footroom_remaining",
+        "target_accepted_scenarios",
+        "total_candidate_attempts",
+        "max_total_attempts",
+        "faults_required",
+        "faults_attempted",
+        "faults_successful",
+        "fault_files_saved",
+    ]:
+        vals = _finite_values(key)
+        if vals:
+            summary[key] = {
+                "min": float(np.min(vals)),
+                "mean": float(np.mean(vals)),
+                "max": float(np.max(vals)),
+            }
+
+    offender_rollup = {}
+    for record in records:
+        for offender in record.get("gen_q_violation_top", []) or []:
+            key = (str(offender.get("bus_id")), str(offender.get("gen_id")))
+            entry = offender_rollup.setdefault(
+                key,
+                {
+                    "bus_id": offender.get("bus_id"),
+                    "gen_id": offender.get("gen_id"),
+                    "bus_index": offender.get("bus_index"),
+                    "gen_index": offender.get("gen_index"),
+                    "bus_type": offender.get("bus_type"),
+                    "is_slack": offender.get("is_slack"),
+                    "count": 0,
+                    "total_abs_violation": 0.0,
+                    "max_violation": 0.0,
+                },
+            )
+            violation = float(offender.get("violation") or 0.0)
+            entry["count"] += 1
+            entry["total_abs_violation"] += violation
+            entry["max_violation"] = max(entry["max_violation"], violation)
+
+    if offender_rollup:
+        top_offenders = sorted(
+            offender_rollup.values(),
+            key=lambda entry: (
+                entry["max_violation"],
+                entry["total_abs_violation"],
+                entry["count"],
+            ),
+            reverse=True,
+        )[:10]
+        for offender in top_offenders:
+            offender["mean_abs_violation"] = (
+                offender["total_abs_violation"] / offender["count"]
+            )
+        summary["gen_q_violation_top_offenders"] = top_offenders
+
+    return summary
+
+
+def _write_diagnostics_summary(path, simulation_log):
+    """Write summary JSON for diagnostics already stored in the simulation log."""
+    if not path:
+        return
+    records = [
+        entry.get("diagnostics")
+        for entry in simulation_log.values()
+        if isinstance(entry, dict) and entry.get("diagnostics")
+    ]
+    with open(path, "w") as f:
+        json.dump(_json_safe(_summarize_diagnostics(records)), f, indent=4)
+
+
+def _write_diagnostics_summary_records(path, records):
+    """Write summary JSON from an explicit diagnostics record list."""
+    if not path:
+        return
+    with open(path, "w") as f:
+        json.dump(_json_safe(_summarize_diagnostics(records)), f, indent=4)
+
+
+def _print_batch_diagnostics(batch_out):
+    """Print compact acceptance/rejection and stress diagnostics for a batch."""
+    records = [
+        out.get("diagnostics")
+        for out in batch_out
+        if isinstance(out, dict) and out.get("diagnostics")
+    ]
+    if not records:
+        return
+
+    summary = _summarize_diagnostics(records)
+    accepted = summary["accepted"]
+    total = summary["total_records"]
+    rejected = summary["rejected"]
+    acceptance_rate = summary["acceptance_rate"] or 0.0
+    reasons = Counter(
+        record.get("reject_reason") or "accepted"
+        for record in records
+        if not record.get("accepted")
+    )
+    top_reasons = ", ".join(
+        f"{reason}={count}" for reason, count in reasons.most_common(3)
+    ) or "none"
+
+    def _max_text(key, fmt="{:.3e}"):
+        stats = summary.get(key)
+        if not stats:
+            return "n/a"
+        return fmt.format(stats["max"])
+
+    message = (
+        "Batch diagnostics | "
+        f"accepted {accepted}/{total} ({acceptance_rate:.1%}) | "
+        f"rejected {rejected} | top rejects: {top_reasons} | "
+        f"avg attempts: {summary.get('attempts', {}).get('mean', 1.0):.2f} | "
+        f"max PF residual: {_max_text('pf_residual')} | "
+        f"voltage min/max: {_max_text('voltage_min', '{:.4f}')}/"
+        f"{_max_text('voltage_max', '{:.4f}')} | "
+        f"max branch loading: {_max_text('branch_loading_max', '{:.3f}')}"
+    )
+    unresolved_loss = summary.get("loss_compensation_unresolved_abs_pu")
+    if unresolved_loss and unresolved_loss["max"] > 1e-9:
+        message += (
+            " | max unresolved loss comp: "
+            f"{unresolved_loss['max']:.3e}"
+        )
+    q_violation = summary.get("gen_q_violation_max")
+    if q_violation and q_violation["max"] > 0.0:
+        message += f" | max Q viol: {q_violation['max']:.3e}"
+        top_offenders = summary.get("gen_q_violation_top_offenders") or []
+        if top_offenders:
+            worst = top_offenders[0]
+            message += (
+                f" at gen {worst.get('gen_id')} "
+                f"bus {worst.get('bus_id')}"
+            )
+    print(message)
+
+
+def _build_target_fault_metadata(
+        sample_idx, fault_locations, fault_impedances, *,
+        operating_point_id, accepted_operating_point_index):
+    """Create fault-level metadata for one accepted operating point."""
+    metadata = {}
+    for fault_location, fault_impedance in itertools.product(
+            fault_locations, fault_impedances):
+        scenario_id = str(uuid.uuid4())
+        metadata[scenario_id] = {
+            "sample_idx": sample_idx,
+            "fault_location": fault_location,
+            "fault_impedance": fault_impedance,
+            "operating_point_id": operating_point_id,
+            "accepted_operating_point_index": accepted_operating_point_index,
+        }
+    return metadata
+
+
+def _write_metadata_file(metadata, metadata_file="scenario_metadata.json"):
+    """Write scenario metadata to disk."""
+    with open(metadata_file, "w") as f:
+        json.dump(_json_safe(metadata), f, indent=4)
+
+
+def _successful_fault_output(out):
+    """Return True when a fault simulation produced a usable trajectory file."""
+    return (
+        isinstance(out, dict)
+        and not out.get("rejected", False)
+        and not out.get("diverged", False)
+        and bool(out.get("file"))
+        and os.path.exists(out["file"])
+    )
+
+
+def _successful_log_fault(entry):
+    """Return True when a simulation-log row represents a usable fault file."""
+    return (
+        isinstance(entry, dict)
+        and not entry.get("rejected", False)
+        and not entry.get("diverged", False)
+        and bool(entry.get("file"))
+        and os.path.exists(entry["file"])
+    )
+
+
+def _existing_complete_operating_point_count(
+        simulation_log, fault_locations, fault_impedances):
+    """Count complete accepted target-mode operating-point groups in a log."""
+    expected_faults = {
+        (fault_location, fault_impedance)
+        for fault_location, fault_impedance in itertools.product(
+            fault_locations,
+            fault_impedances,
+        )
+    }
+    if not expected_faults:
+        return 0, 0
+
+    grouped = {}
+    max_existing_index = -1
+    for entry in simulation_log.values():
+        if not _successful_log_fault(entry):
+            continue
+        operating_point_id = entry.get("operating_point_id")
+        if operating_point_id is None:
+            continue
+        fault_key = (entry.get("fault_location"), entry.get("fault_impedance"))
+        if fault_key not in expected_faults:
+            continue
+        grouped.setdefault(operating_point_id, set()).add(fault_key)
+        accepted_index = entry.get("accepted_operating_point_index")
+        if accepted_index is not None:
+            max_existing_index = max(max_existing_index, int(accepted_index))
+
+    complete_count = sum(
+        1 for completed_faults in grouped.values()
+        if expected_faults.issubset(completed_faults)
+    )
+    next_accepted_index = max(max_existing_index + 1, complete_count)
+    return complete_count, next_accepted_index
+
+
+def _remove_fault_outputs(batch_out):
+    """Remove partial files from an incomplete target-mode operating point."""
+    for out in batch_out:
+        if not isinstance(out, dict):
+            continue
+        path = out.get("file")
+        if path and os.path.exists(path):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+
+def _print_target_mode_progress(
+        *, accepted_operating_points, target_accepted_scenarios,
+        total_candidate_attempts, max_total_attempts,
+        fault_files_saved, last_record, start_time):
+    """Print compact progress for target accepted operating-point mode."""
+    elapsed = time.time() - start_time
+    acceptance_rate = (
+        accepted_operating_points / total_candidate_attempts
+        if total_candidate_attempts else 0.0
+    )
+    if accepted_operating_points:
+        attempts_per_accept = total_candidate_attempts / accepted_operating_points
+        remaining_accepted = target_accepted_scenarios - accepted_operating_points
+        estimated_remaining_attempts = remaining_accepted * attempts_per_accept
+        estimated_total = (
+            elapsed
+            * (total_candidate_attempts + estimated_remaining_attempts)
+            / max(total_candidate_attempts, 1)
+        )
+        eta = max(0.0, estimated_total - elapsed)
+    else:
+        eta = 0.0
+
+    reason = last_record.get("reject_reason") or "accepted"
+    print(
+        "Target mode | "
+        f"accepted OPs {accepted_operating_points}/{target_accepted_scenarios} | "
+        f"candidate attempts {total_candidate_attempts}/{max_total_attempts} | "
+        f"OP acceptance/attempt {acceptance_rate:.1%} | "
+        f"fault files saved {fault_files_saved} | "
+        f"last: {reason} | "
+        f"elapsed {timedelta(seconds=int(elapsed))} | "
+        f"ETA {timedelta(seconds=int(eta))}"
+    )
+
+
+def _run_target_accepted_driver(
+        raw, dyr, *,
+        target_accepted_scenarios,
+        max_total_attempts,
+        sample_idx_start,
+        fault_locations,
+        fault_impedances,
+        noise_type="normal",
+        noise_var=0.1,
+        balance_generation=True,
+        n_jobs=-1,
+        perturb_loads=True,
+        perturb_gens=True,
+        load_noise_type=None,
+        gen_noise_type=None,
+        load_noise_var=None,
+        gen_noise_var=None,
+        keep_power_factor=True,
+        clamp_gens=True,
+        load_scale=1.0,
+        load_mean_shift=0.0,
+        generation_dispatch_init="perturbed",
+        operating_point_config=None,
+        existing_log=None,
+        existing_metadata=None,
+        integration_config=None):
+    """Run until the requested number of complete operating-point groups exists."""
+    op_cfg = _resolve_operating_point_config(operating_point_config)
+    target_accepted_scenarios = int(target_accepted_scenarios)
+    max_total_attempts = int(max_total_attempts)
+    if target_accepted_scenarios <= 0:
+        raise ValueError("target_accepted_scenarios must be positive")
+    if max_total_attempts <= 0:
+        raise ValueError("max_total_attempts must be positive")
+
+    diagnostics_file = op_cfg.get("diagnostics_file")
+    diagnostics_summary_file = op_cfg.get("diagnostics_summary_file")
+    if diagnostics_file and not existing_log:
+        open(diagnostics_file, "w").close()
+    if diagnostics_summary_file and not existing_log:
+        _write_diagnostics_summary_records(diagnostics_summary_file, [])
+    diagnostics_records = (
+        _load_diagnostics_records(diagnostics_file)
+        if diagnostics_file and existing_log
+        else []
+    )
+
+    simulation_log = dict(existing_log) if existing_log else {}
+    scenario_metadata = dict(existing_metadata) if existing_metadata else {}
+    _write_metadata_file(scenario_metadata)
+
+    base_psys = _load_power_system(raw, dyr)
+    base_psys.export_state_metadata()
+    del base_psys
+
+    group_records = list(diagnostics_records)
+    accepted_operating_points, next_accepted_index = (
+        _existing_complete_operating_point_count(
+            simulation_log,
+            fault_locations,
+            fault_impedances,
+        )
+        if existing_log
+        else (0, 0)
+    )
+    total_candidate_attempts = 0
+    fault_files_saved = sum(
+        1 for entry in simulation_log.values()
+        if isinstance(entry, dict) and entry.get("file")
+    )
+    sample_idx = int(sample_idx_start)
+    start_time = time.time()
+    fault_count = len(fault_locations) * len(fault_impedances)
+
+    while (
+        accepted_operating_points < target_accepted_scenarios
+        and total_candidate_attempts < max_total_attempts
+    ):
+        remaining_attempts = max_total_attempts - total_candidate_attempts
+        candidate_op_cfg = dict(op_cfg)
+        candidate_op_cfg["max_attempts_per_scenario"] = min(
+            int(op_cfg["max_attempts_per_scenario"]),
+            remaining_attempts,
+        )
+
+        operating_point_id = str(uuid.uuid4())
+        candidate_scenario = {
+            "sample_idx": sample_idx,
+            "operating_point_id": operating_point_id,
+            "accepted_operating_point_index": next_accepted_index,
+        }
+        prep = _prepare_operating_point_candidate(
+            raw,
+            dyr,
+            candidate_scenario,
+            operating_point_id,
+            noise_type=noise_type,
+            noise_var=noise_var,
+            global_seed=1234,
+            balance_generation=balance_generation,
+            perturb_loads=perturb_loads,
+            perturb_gens=perturb_gens,
+            load_noise_type=load_noise_type,
+            gen_noise_type=gen_noise_type,
+            load_noise_var=load_noise_var,
+            gen_noise_var=gen_noise_var,
+            keep_power_factor=keep_power_factor,
+            clamp_gens=clamp_gens,
+            load_scale=load_scale,
+            load_mean_shift=load_mean_shift,
+            generation_dispatch_init=generation_dispatch_init,
+            operating_point_config=candidate_op_cfg,
+        )
+
+        prep_diag = prep.get("diagnostics") or {}
+        candidate_attempts = int(prep_diag.get("attempts") or 1)
+        total_candidate_attempts += candidate_attempts
+        group_record = copy.deepcopy(prep_diag)
+        group_record.update({
+            "record_type": "operating_point_group",
+            "operating_point_id": operating_point_id,
+            "sample_idx": sample_idx,
+            "accepted_operating_point_index": next_accepted_index,
+            "target_accepted_scenarios": target_accepted_scenarios,
+            "total_candidate_attempts": total_candidate_attempts,
+            "max_total_attempts": max_total_attempts,
+            "faults_required": fault_count,
+            "faults_attempted": 0,
+            "faults_successful": 0,
+            "fault_files_saved": fault_files_saved,
+        })
+
+        if prep.get("rejected") or not prep.get("operating_point"):
+            group_record.update({
+                "accepted": False,
+                "reject_reason": prep_diag.get(
+                    "reject_reason", "operating_point_rejected"
+                ),
+            })
+            prep_attempt_records = prep.get("diagnostics_attempts") or [prep_diag]
+            records_to_write = [
+                *prep_attempt_records,
+                _json_safe(group_record),
+            ]
+            group_records.extend(_json_safe(records_to_write))
+            _write_diagnostics_records(diagnostics_file, records_to_write)
+            _write_diagnostics_summary_records(diagnostics_summary_file, group_records)
+            _print_target_mode_progress(
+                accepted_operating_points=accepted_operating_points,
+                target_accepted_scenarios=target_accepted_scenarios,
+                total_candidate_attempts=total_candidate_attempts,
+                max_total_attempts=max_total_attempts,
+                fault_files_saved=fault_files_saved,
+                last_record=group_record,
+                start_time=start_time,
+            )
+            sample_idx += 1
+            continue
+
+        fault_metadata = _build_target_fault_metadata(
+            sample_idx,
+            fault_locations,
+            fault_impedances,
+            operating_point_id=operating_point_id,
+            accepted_operating_point_index=next_accepted_index,
+        )
+        fault_ids = list(fault_metadata.keys())
+        fault_args = [
+            (raw, dyr, fault_metadata[sid], sid, prep["operating_point"], integration_config)
+            for sid in fault_ids
+        ]
+
+        try:
+            batch_out = Parallel(n_jobs=n_jobs, backend="loky", timeout=600)(
+                delayed(_run_fault_with_operating_point_worker)(*args)
+                for args in fault_args
+            )
+        except Exception as e:
+            print(
+                f"Fault group failed for operating point {operating_point_id}: {e}"
+            )
+            traceback.print_exc()
+            batch_out = [
+                {
+                    "file": None,
+                    "diverged": True,
+                    "rejected": False,
+                    "error": f"Fault group failure: {str(e)}",
+                    "diagnostics": {
+                        "record_type": "fault_scenario",
+                        "accepted": False,
+                        "reject_reason": "fault_group_error",
+                        "simulation_error": str(e),
+                    },
+                }
+                for _ in fault_ids
+            ]
+
+        faults_successful = sum(_successful_fault_output(out) for out in batch_out)
+        group_accepted = faults_successful == fault_count
+        group_record.update({
+            "faults_attempted": fault_count,
+            "faults_successful": faults_successful,
+            "fault_files_saved": fault_files_saved + faults_successful,
+            "accepted": group_accepted,
+            "reject_reason": None if group_accepted else "fault_simulation_failed",
+        })
+
+        if group_accepted:
+            for sid, out in zip(fault_ids, batch_out):
+                simulation_log[sid] = _json_safe({**fault_metadata[sid], **out})
+            scenario_metadata.update(fault_metadata)
+            accepted_operating_points += 1
+            next_accepted_index += 1
+            fault_files_saved += faults_successful
+            _write_metadata_file(scenario_metadata)
+            with open("simulation_log.json", "w") as f:
+                json.dump(_json_safe(simulation_log), f, indent=4)
+        else:
+            _remove_fault_outputs(batch_out)
+            failure_reasons = Counter(
+                (out.get("diagnostics") or {}).get("reject_reason")
+                or out.get("error")
+                or "simulation_diverged"
+                for out in batch_out
+                if not _successful_fault_output(out)
+            )
+            group_record["fault_failure_reasons"] = dict(failure_reasons)
+
+        prep_attempt_records = prep.get("diagnostics_attempts") or [prep_diag]
+        records_to_write = [
+            *prep_attempt_records,
+            _json_safe(group_record),
+        ]
+        group_records.extend(_json_safe(records_to_write))
+        _write_diagnostics_records(diagnostics_file, records_to_write)
+        _write_diagnostics_summary_records(diagnostics_summary_file, group_records)
+        _print_target_mode_progress(
+            accepted_operating_points=accepted_operating_points,
+            target_accepted_scenarios=target_accepted_scenarios,
+            total_candidate_attempts=total_candidate_attempts,
+            max_total_attempts=max_total_attempts,
+            fault_files_saved=fault_files_saved,
+            last_record=group_record,
+            start_time=start_time,
+        )
+
+        sample_idx += 1
+        gc.collect()
+
+    if accepted_operating_points < target_accepted_scenarios:
+        print(
+            "Target mode stopped before reaching requested accepted operating "
+            f"points: accepted {accepted_operating_points}/"
+            f"{target_accepted_scenarios} after {total_candidate_attempts} "
+            f"candidate attempts."
+        )
+    else:
+        print(
+            "Target mode complete: accepted "
+            f"{accepted_operating_points}/{target_accepted_scenarios} "
+            f"operating points and saved {fault_files_saved} fault simulations."
+        )
+
+    return simulation_log
 
 
 # =============================================================================
@@ -914,8 +2956,18 @@ def run_simulation_driver_batched(
         gen_noise_var=None,
         keep_power_factor=True,
         clamp_gens=True,
+        load_scale=1.0,
+        load_mean_shift=0.0,
+        generation_dispatch_init="perturbed",
+        operating_point_config=None,
         existing_log=None,
-        integration_config=None):
+        integration_config=None,
+        target_accepted_scenarios=None,
+        max_total_attempts=None,
+        sample_idx_start=0,
+        fault_locations=None,
+        fault_impedances=None,
+        existing_metadata=None):
     """
     Batched simulation driver with checkpointing and error handling.
 
@@ -1000,7 +3052,58 @@ def run_simulation_driver_batched(
     --------
     run_single_scenario_worker : Worker function for individual scenarios
     """
+    if target_accepted_scenarios is not None:
+        op_cfg_for_target = _resolve_operating_point_config(operating_point_config)
+        if max_total_attempts is None:
+            max_total_attempts = (
+                int(target_accepted_scenarios)
+                * int(op_cfg_for_target["max_attempts_per_scenario"])
+            )
+        if fault_locations is None or fault_impedances is None:
+            raise ValueError(
+                "fault_locations and fault_impedances are required in target mode"
+            )
+        return _run_target_accepted_driver(
+            raw,
+            dyr,
+            target_accepted_scenarios=target_accepted_scenarios,
+            max_total_attempts=max_total_attempts,
+            sample_idx_start=sample_idx_start,
+            fault_locations=fault_locations,
+            fault_impedances=fault_impedances,
+            noise_type=noise_type,
+            noise_var=noise_var,
+            balance_generation=balance_generation,
+            n_jobs=n_jobs,
+            perturb_loads=perturb_loads,
+            perturb_gens=perturb_gens,
+            load_noise_type=load_noise_type,
+            gen_noise_type=gen_noise_type,
+            load_noise_var=load_noise_var,
+            gen_noise_var=gen_noise_var,
+            keep_power_factor=keep_power_factor,
+            clamp_gens=clamp_gens,
+            load_scale=load_scale,
+            load_mean_shift=load_mean_shift,
+            generation_dispatch_init=generation_dispatch_init,
+            operating_point_config=operating_point_config,
+            existing_log=existing_log,
+            existing_metadata=existing_metadata,
+            integration_config=integration_config,
+        )
+
     scenario_ids = list(scenarios_metadata.keys())
+    op_cfg = _resolve_operating_point_config(operating_point_config)
+    diagnostics_enabled = (
+        op_cfg["enabled"]
+        or not np.isclose(load_scale, 1.0)
+        or not np.isclose(load_mean_shift, 0.0)
+    )
+    diagnostics_file = op_cfg.get("diagnostics_file") if diagnostics_enabled else None
+    diagnostics_summary_file = (
+        op_cfg.get("diagnostics_summary_file") if diagnostics_enabled else None
+    )
+    diagnostics_records = []
     
     # Initialize log, optionally starting from existing data (for --continue mode)
     simulation_log = dict(existing_log) if existing_log else {}
@@ -1018,6 +3121,14 @@ def run_simulation_driver_batched(
                 print(f"Resuming from batch {start_batch}")
         except Exception as e:
             print(f"Failed to load checkpoint: {e}")
+
+    if diagnostics_file and start_batch == 0 and not existing_log:
+        open(diagnostics_file, "w").close()
+    if diagnostics_summary_file and start_batch == 0 and not existing_log:
+        with open(diagnostics_summary_file, "w") as f:
+            json.dump(_summarize_diagnostics([]), f, indent=4)
+    if diagnostics_file and (existing_log or start_batch > 0):
+        diagnostics_records = _load_diagnostics_records(diagnostics_file)
 
     t0 = time.time()
     total_batches = int(np.ceil(len(scenario_ids) / batch_size))
@@ -1037,8 +3148,14 @@ def run_simulation_driver_batched(
         else:
             est_total = remaining = 0
 
+        progress = (batch_idx + 1) / total_batches if total_batches else 1.0
+        bar_width = 24
+        filled = int(round(bar_width * progress))
+        progress_bar = "#" * filled + "-" * (bar_width - filled)
+
         print(
             f"Processing batch {batch_idx + 1} / {total_batches} | "
+            f"[{progress_bar}] {progress:.1%} | "
             f"elapsed {timedelta(seconds=int(elapsed))} | "
             f"est total {timedelta(seconds=int(est_total))} | "
             f"ETA {timedelta(seconds=int(remaining))}"
@@ -1058,6 +3175,8 @@ def run_simulation_driver_batched(
              load_noise_type, gen_noise_type,
              load_noise_var, gen_noise_var,
              keep_power_factor, clamp_gens,
+             load_scale, load_mean_shift,
+             generation_dispatch_init, op_cfg,
              integration_config)
             for sid in batch_ids
         ]
@@ -1071,7 +3190,18 @@ def run_simulation_driver_batched(
 
             # Update simulation log with results
             for sid, out in zip(batch_ids, batch_out):
-                simulation_log[sid] = {**scenarios_metadata[sid], **out}
+                simulation_log[sid] = _json_safe({**scenarios_metadata[sid], **out})
+
+            batch_diagnostics = []
+            for out in batch_out:
+                batch_diagnostics.extend(_diagnostic_records_from_output(out))
+            _write_diagnostics_records(diagnostics_file, batch_diagnostics)
+            diagnostics_records.extend(_json_safe(batch_diagnostics))
+            _write_diagnostics_summary_records(
+                diagnostics_summary_file,
+                diagnostics_records,
+            )
+            _print_batch_diagnostics(batch_out)
 
         except Exception as e:
             print(f"Batch {batch_idx + 1} failed with error: {e}")
@@ -1232,7 +3362,9 @@ def get_default_config(model_name: str) -> dict:
         "scenarios": {
             "samples_per_fault_location": 5,
             "fault_impedances": [0.00001],
-            "fault_locations": "all"  # "all" means list(range(n_bus)), or specify list
+            "fault_locations": "all",  # "all" means list(range(n_bus)), or specify list
+            "target_accepted_scenarios": None,
+            "max_total_attempts": None
         },
 
         # Execution parameters
@@ -1257,7 +3389,37 @@ def get_default_config(model_name: str) -> dict:
             "perturb_loads": True,
             "perturb_gens": True,
             "keep_power_factor": True,
-            "clamp_gens": True
+            "clamp_gens": True,
+            "load_scale": 1.0,
+            "load_mean_shift": 0.0,
+            "generation_dispatch_init": "perturbed"
+        },
+
+        # PF-aware operating-point screening (opt-in; disabled preserves legacy behavior)
+        "operating_point": {
+            "enabled": False,
+            "run_power_flow": True,
+            "rebalance_non_slack": True,
+            "redistribute_slack_mismatch": True,
+            "rebalance_policy": "headroom",
+            "loss_compensation": False,
+            "loss_compensation_tolerance_pu": 1e-4,
+            "loss_compensation_policy": "headroom",
+            "q_limit_mitigation": False,
+            "q_limit_mitigation_tolerance_pu": 1e-6,
+            "q_limit_mitigation_max_passes": 10,
+            "q_limit_mitigation_top_n": 10,
+            "max_iterations": 5,
+            "max_attempts_per_scenario": 50,
+            "pf_residual_tol": 1e-8,
+            "slack_p_tolerance_pu": 1e-4,
+            "max_slack_p_deviation_fraction_of_load": 0.02,
+            "voltage_min": 0.90,
+            "voltage_max": 1.10,
+            "gen_limit_tolerance": 1e-6,
+            "branch_loading_max": 1.0,
+            "diagnostics_file": "scenario_diagnostics.jsonl",
+            "diagnostics_summary_file": "scenario_diagnostics_summary.json"
         },
 
         # Integration/simulation configuration
@@ -1459,7 +3621,9 @@ def main(config_path: str = None):
             "scenarios": {
                 "samples_per_fault_location": 5,
                 "fault_impedances": [0.00001],
-                "fault_locations": "all"  // or [0, 1, 2, ...]
+                "fault_locations": "all",  // or [0, 1, 2, ...]
+                "target_accepted_scenarios": null,
+                "max_total_attempts": null
             },
             "execution": {
                 "n_jobs": 5,
@@ -1475,7 +3639,35 @@ def main(config_path: str = None):
                 "perturb_loads": true,
                 "perturb_gens": true,
                 "keep_power_factor": true,
-                "clamp_gens": true
+                "clamp_gens": true,
+                "load_scale": 1.0,
+                "load_mean_shift": 0.0,
+                "generation_dispatch_init": "perturbed"
+            },
+            "operating_point": {
+                "enabled": false,
+                "run_power_flow": true,
+                "rebalance_non_slack": true,
+                "redistribute_slack_mismatch": true,
+                "rebalance_policy": "headroom",
+                "loss_compensation": false,
+                "loss_compensation_tolerance_pu": 1e-4,
+                "loss_compensation_policy": "headroom",
+                "q_limit_mitigation": false,
+                "q_limit_mitigation_tolerance_pu": 1e-6,
+                "q_limit_mitigation_max_passes": 10,
+                "q_limit_mitigation_top_n": 10,
+                "max_iterations": 5,
+                "max_attempts_per_scenario": 50,
+                "pf_residual_tol": 1e-8,
+                "slack_p_tolerance_pu": 1e-4,
+                "max_slack_p_deviation_fraction_of_load": 0.02,
+                "voltage_min": 0.9,
+                "voltage_max": 1.1,
+                "gen_limit_tolerance": 1e-6,
+                "branch_loading_max": 1.0,
+                "diagnostics_file": "scenario_diagnostics.jsonl",
+                "diagnostics_summary_file": "scenario_diagnostics_summary.json"
             },
             "integration": {
                 "tend": 10.0,
@@ -1579,6 +3771,8 @@ Examples:
     scenario_cfg = config["scenarios"]
     samples_per_fault = scenario_cfg["samples_per_fault_location"]
     fault_impedances = scenario_cfg["fault_impedances"]
+    target_accepted_scenarios = scenario_cfg.get("target_accepted_scenarios")
+    max_total_attempts = scenario_cfg.get("max_total_attempts")
 
     # Handle fault_locations: "all" means all buses, otherwise use the list
     fault_locations_cfg = scenario_cfg["fault_locations"]
@@ -1595,15 +3789,31 @@ Examples:
 
     # Perturbation configuration
     pert_cfg = config["perturbation"]
-    load_noise_type = pert_cfg["load_noise_type"]
-    load_noise_var = pert_cfg["load_noise_var"]
-    gen_noise_type = pert_cfg["gen_noise_type"]
-    gen_noise_var = pert_cfg["gen_noise_var"]
-    balance_generation = pert_cfg["balance_generation"]
-    perturb_loads = pert_cfg["perturb_loads"]
-    perturb_gens = pert_cfg["perturb_gens"]
-    keep_power_factor = pert_cfg["keep_power_factor"]
-    clamp_gens = pert_cfg["clamp_gens"]
+    load_noise_type = pert_cfg.get("load_noise_type", config.get("noise_type", "normal"))
+    load_noise_var = pert_cfg.get("load_noise_var", config.get("noise_var", 0.1))
+    gen_noise_type = pert_cfg.get("gen_noise_type", load_noise_type)
+    gen_noise_var = pert_cfg.get("gen_noise_var", load_noise_var)
+    balance_generation = pert_cfg.get("balance_generation", True)
+    perturb_loads = pert_cfg.get("perturb_loads", True)
+    perturb_gens = pert_cfg.get("perturb_gens", True)
+    keep_power_factor = pert_cfg.get("keep_power_factor", True)
+    clamp_gens = pert_cfg.get("clamp_gens", True)
+    load_scale = pert_cfg.get("load_scale", 1.0)
+    load_mean_shift = pert_cfg.get("load_mean_shift", 0.0)
+    generation_dispatch_init = pert_cfg.get("generation_dispatch_init", "perturbed")
+
+    # Operating-point screening is opt-in for backward compatibility.
+    operating_point_config = _resolve_operating_point_config(config.get("operating_point", {}))
+    target_mode = target_accepted_scenarios is not None
+    if target_mode:
+        target_accepted_scenarios = int(target_accepted_scenarios)
+        if max_total_attempts is None:
+            max_total_attempts = (
+                target_accepted_scenarios
+                * int(operating_point_config["max_attempts_per_scenario"])
+            )
+        else:
+            max_total_attempts = int(max_total_attempts)
 
     # Integration configuration (with defaults for backward compatibility)
     integration_cfg = config.get("integration", {})
@@ -1620,7 +3830,12 @@ Examples:
     # -------------------------------------------------------------------------
     # Print configuration summary
     # -------------------------------------------------------------------------
-    total_scenarios = samples_per_fault * len(fault_locations) * len(fault_impedances)
+    if target_mode:
+        total_scenarios = (
+            target_accepted_scenarios * len(fault_locations) * len(fault_impedances)
+        )
+    else:
+        total_scenarios = samples_per_fault * len(fault_locations) * len(fault_impedances)
 
     print("\n" + "=" * 60)
     print("SIMULATION CONFIGURATION")
@@ -1643,7 +3858,14 @@ Examples:
         existing_metadata, existing_log, max_sample_idx = load_existing_state()
         sample_idx_offset = max_sample_idx + 1
         samples_per_fault = args.additional_samples
-        total_scenarios = samples_per_fault * len(fault_locations) * len(fault_impedances)
+        if target_mode:
+            total_scenarios = (
+                target_accepted_scenarios
+                * len(fault_locations)
+                * len(fault_impedances)
+            )
+        else:
+            total_scenarios = samples_per_fault * len(fault_locations) * len(fault_impedances)
         print(f"  - Starting sample_idx from: {sample_idx_offset}")
         print(f"  - Additional samples per fault: {samples_per_fault}")
         print(f"  - New scenarios to generate: {total_scenarios:,}")
@@ -1654,6 +3876,10 @@ Examples:
     print(f"  - Samples per fault location: {samples_per_fault}")
     print(f"  - Fault locations: {len(fault_locations)}")
     print(f"  - Fault impedances: {fault_impedances}")
+    if target_mode:
+        print("  - Target mode: enabled")
+        print(f"  - Target accepted operating points: {target_accepted_scenarios}")
+        print(f"  - Max total candidate attempts: {max_total_attempts}")
     print()
     print(f"Execution:")
     print(f"  - Parallel jobs: {n_jobs}")
@@ -1668,6 +3894,21 @@ Examples:
     print(f"  - Perturb generators: {perturb_gens}")
     print(f"  - Keep power factor: {keep_power_factor}")
     print(f"  - Clamp generators: {clamp_gens}")
+    print(f"  - Load scale: {load_scale}")
+    print(f"  - Load mean shift: {load_mean_shift}")
+    print(f"  - Generation dispatch init: {generation_dispatch_init}")
+    print()
+    print(f"Operating point:")
+    print(f"  - Enabled: {operating_point_config['enabled']}")
+    print(f"  - Run power flow: {operating_point_config['run_power_flow']}")
+    print(f"  - Rebalance non-slack: {operating_point_config['rebalance_non_slack']}")
+    print(f"  - Redistribute slack mismatch: {operating_point_config['redistribute_slack_mismatch']}")
+    print(f"  - Rebalance policy: {operating_point_config['rebalance_policy']}")
+    print(f"  - Loss compensation: {operating_point_config['loss_compensation']}")
+    print(f"  - Loss compensation policy: {operating_point_config['loss_compensation_policy']}")
+    print(f"  - Q-limit mitigation: {operating_point_config['q_limit_mitigation']}")
+    print(f"  - Max iterations: {operating_point_config['max_iterations']}")
+    print(f"  - Max attempts/scenario: {operating_point_config['max_attempts_per_scenario']}")
     print()
     print(f"Integration:")
     print(f"  - End time (tend): {integration_config['tend']} s")
@@ -1682,19 +3923,23 @@ Examples:
     # -------------------------------------------------------------------------
     # Generate scenario definitions
     # -------------------------------------------------------------------------
-    # Generate sample indices with offset for continuation mode
-    sample_indices = range(sample_idx_offset, sample_idx_offset + samples_per_fault)
-    scenarios = list(itertools.product(sample_indices, fault_locations, fault_impedances))
-    
-    # Generate metadata (merged with existing if continuing)
-    if args.continue_run:
-        metadata = generate_metadata_continued(scenarios, existing_metadata)
-        # Extract only the NEW scenario metadata for simulation
-        new_scenario_ids = set(metadata.keys()) - set(existing_metadata.keys())
-        new_metadata = {sid: metadata[sid] for sid in new_scenario_ids}
+    if target_mode:
+        metadata = dict(existing_metadata)
+        new_metadata = {}
     else:
-        metadata = generate_metadata(scenarios)
-        new_metadata = metadata
+        # Generate sample indices with offset for continuation mode
+        sample_indices = range(sample_idx_offset, sample_idx_offset + samples_per_fault)
+        scenarios = list(itertools.product(sample_indices, fault_locations, fault_impedances))
+
+        # Generate metadata (merged with existing if continuing)
+        if args.continue_run:
+            metadata = generate_metadata_continued(scenarios, existing_metadata)
+            # Extract only the NEW scenario metadata for simulation
+            new_scenario_ids = set(metadata.keys()) - set(existing_metadata.keys())
+            new_metadata = {sid: metadata[sid] for sid in new_scenario_ids}
+        else:
+            metadata = generate_metadata(scenarios)
+            new_metadata = metadata
 
     # -------------------------------------------------------------------------
     # Execute Simulation Campaign
@@ -1716,8 +3961,18 @@ Examples:
         gen_noise_var=gen_noise_var,
         keep_power_factor=keep_power_factor,
         clamp_gens=clamp_gens,
+        load_scale=load_scale,
+        load_mean_shift=load_mean_shift,
+        generation_dispatch_init=generation_dispatch_init,
+        operating_point_config=operating_point_config,
         existing_log=existing_log if args.continue_run else None,
-        integration_config=integration_config
+        integration_config=integration_config,
+        target_accepted_scenarios=target_accepted_scenarios if target_mode else None,
+        max_total_attempts=max_total_attempts if target_mode else None,
+        sample_idx_start=sample_idx_offset,
+        fault_locations=fault_locations,
+        fault_impedances=fault_impedances,
+        existing_metadata=metadata if target_mode else None
     )
 
 

--- a/tests/test_generate_scenarios_operating_point.py
+++ b/tests/test_generate_scenarios_operating_point.py
@@ -1,0 +1,971 @@
+import importlib.util
+import json
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from uqgrid.io.parse import load_psse
+
+
+def _load_generate_scenarios_module():
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    script_path = os.path.join(repo_root, "scripts", "run", "generate_scenarios.py")
+    spec = importlib.util.spec_from_file_location("generate_scenarios", script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def gs():
+    return _load_generate_scenarios_module()
+
+
+@pytest.fixture
+def data_dir():
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data"
+    )
+
+
+def _dummy_q_limit_psys(gs):
+    return SimpleNamespace(
+        buses=[
+            SimpleNamespace(id=10, type=gs.Bus.SLACK),
+            SimpleNamespace(id=20, type=gs.Bus.PV),
+            SimpleNamespace(id=30, type=gs.Bus.PQ),
+        ],
+        gens=[
+            SimpleNamespace(bus=0, idx="1"),
+            SimpleNamespace(bus=1, idx="A"),
+            SimpleNamespace(bus=2, idx="B"),
+        ],
+    )
+
+
+def _dummy_export_psys():
+    return SimpleNamespace(export_state_metadata=lambda: None)
+
+
+def test_stress_load_preserves_load_power_factor_with_no_noise(gs):
+    base_p = np.array([1.0, 2.0, 0.0])
+    base_q = np.array([0.4, 0.8, 0.5])
+
+    stressed_p, stressed_q, load_factor = gs._stress_load(
+        base_p, base_q, load_scale=1.2, load_mean_shift=0.1
+    )
+    p_scaled, q_scaled = gs.generate_perturbations(
+        stressed_p,
+        stressed_q,
+        noise_type="none",
+        preserve_power_factor=True,
+    )
+
+    assert load_factor == pytest.approx(1.32)
+    np.testing.assert_allclose(p_scaled[:2] / base_p[:2], [1.32, 1.32])
+    np.testing.assert_allclose(q_scaled[:2] / base_q[:2], [1.32, 1.32])
+    assert q_scaled[2] == pytest.approx(base_q[2] * 1.32)
+
+
+def test_rebalance_active_power_can_exclude_slack_generator(gs):
+    p_gen = np.array([1.0, 2.0, 3.0])
+    pg_lb = np.array([0.0, 0.0, 0.0])
+    pg_ub = np.array([10.0, 10.0, 10.0])
+    non_slack_mask = np.array([False, True, True])
+
+    rebalanced = gs._rebalance_active_power(
+        p_gen,
+        pg_lb,
+        pg_ub,
+        target_total=np.sum(p_gen) + 3.0,
+        participation_mask=non_slack_mask,
+    )
+
+    assert rebalanced[0] == pytest.approx(p_gen[0])
+    assert np.sum(rebalanced) == pytest.approx(np.sum(p_gen) + 3.0)
+    assert rebalanced[1] > p_gen[1]
+    assert rebalanced[2] > p_gen[2]
+
+
+def test_redistribute_slack_mismatch_respects_participation_and_limits(gs):
+    p_gen = np.array([5.0, 2.0, 2.0])
+    pg_lb = np.array([0.0, 1.5, 1.0])
+    pg_ub = np.array([10.0, 10.0, 10.0])
+    non_slack_mask = np.array([False, True, True])
+
+    redistributed = gs._redistribute_active_power_mismatch(
+        p_gen,
+        pg_lb,
+        pg_ub,
+        mismatch=-2.0,
+        participation_mask=non_slack_mask,
+    )
+
+    assert redistributed[0] == pytest.approx(p_gen[0])
+    assert redistributed[1] >= pg_lb[1]
+    assert redistributed[2] >= pg_lb[2]
+    assert np.sum(p_gen) - np.sum(redistributed) == pytest.approx(1.5)
+
+
+@pytest.mark.parametrize(
+    "policy",
+    ["headroom", "capacity", "current_dispatch", "base_dispatch", "equal"],
+)
+def test_active_power_allocator_policies_respect_limits(gs, policy):
+    p_gen = np.array([5.0, 2.0, 4.0, 1.0])
+    base_p_gen = np.array([5.0, 3.0, 1.0, 1.0])
+    pg_lb = np.array([0.0, 1.0, 3.0, 0.0])
+    pg_ub = np.array([8.0, 6.0, 9.0, 2.0])
+    non_slack_mask = np.array([False, True, True, True])
+
+    allocation = gs._redistribute_active_power_mismatch(
+        p_gen,
+        pg_lb,
+        pg_ub,
+        mismatch=3.0,
+        participation_mask=non_slack_mask,
+        policy=policy,
+        base_p_gen=base_p_gen,
+        return_diagnostics=True,
+    )
+
+    redistributed = allocation["p_gen"]
+    assert redistributed[0] == pytest.approx(p_gen[0])
+    assert np.all(redistributed >= pg_lb)
+    assert np.all(redistributed <= pg_ub)
+    assert allocation["applied_mismatch"] == pytest.approx(3.0)
+    assert allocation["unresolved_mismatch"] == pytest.approx(0.0)
+    assert allocation["participants"] > 0
+
+
+def test_equal_policy_clips_and_redistributes_remaining_mismatch(gs):
+    p_gen = np.array([0.0, 0.0])
+    pg_lb = np.array([0.0, 0.0])
+    pg_ub = np.array([1.0, 10.0])
+
+    allocation = gs._redistribute_active_power_mismatch(
+        p_gen,
+        pg_lb,
+        pg_ub,
+        mismatch=4.0,
+        policy="equal",
+        return_diagnostics=True,
+    )
+
+    np.testing.assert_allclose(allocation["p_gen"], [1.0, 3.0])
+    assert allocation["applied_mismatch"] == pytest.approx(4.0)
+    assert allocation["unresolved_mismatch"] == pytest.approx(0.0)
+
+
+def test_bounded_allocation_reports_unresolved_mismatch(gs):
+    p_gen = np.array([0.0, 0.0])
+    pg_lb = np.array([0.0, 0.0])
+    pg_ub = np.array([1.0, 1.0])
+
+    allocation = gs._redistribute_active_power_mismatch(
+        p_gen,
+        pg_lb,
+        pg_ub,
+        mismatch=3.0,
+        policy="headroom",
+        return_diagnostics=True,
+    )
+
+    np.testing.assert_allclose(allocation["p_gen"], [1.0, 1.0])
+    assert allocation["applied_mismatch"] == pytest.approx(2.0)
+    assert allocation["unresolved_mismatch"] == pytest.approx(1.0)
+    assert allocation["participants"] == 2
+
+
+def test_loss_compensation_can_remove_slack_p_limit_burden(gs):
+    op_cfg = gs._resolve_operating_point_config(
+        {
+            "enabled": True,
+            "loss_compensation": True,
+            "max_slack_p_deviation_fraction_of_load": 0.02,
+            "gen_limit_tolerance": 1e-6,
+        }
+    )
+    diagnostics = {
+        "pf_converged": True,
+        "pf_residual": 1e-10,
+        "slack_p_deviation": 0.735,
+        "voltage_min": 1.0,
+        "voltage_max": 1.04,
+        "gen_p_violation_max": 0.735,
+        "gen_q_violation_max": 0.0,
+        "branch_loading_available": False,
+        "branch_loading_max": None,
+    }
+    accepted, reason = gs._screen_power_flow_diagnostics(
+        diagnostics, total_load_p=70.0, op_cfg=op_cfg
+    )
+    assert not accepted
+    assert reason == "gen_p_limit"
+
+    p_gen = np.array([8.889, 2.0, 3.0])
+    pg_lb = np.array([0.0, 0.0, 0.0])
+    pg_ub = np.array([8.889, 10.0, 10.0])
+    non_slack_mask = np.array([False, True, True])
+
+    allocation = gs._redistribute_active_power_mismatch(
+        p_gen,
+        pg_lb,
+        pg_ub,
+        mismatch=diagnostics["slack_p_deviation"],
+        participation_mask=non_slack_mask,
+        policy=op_cfg["loss_compensation_policy"],
+        return_diagnostics=True,
+    )
+
+    assert allocation["p_gen"][0] == pytest.approx(p_gen[0])
+    assert allocation["applied_mismatch"] == pytest.approx(0.735)
+    assert allocation["unresolved_mismatch"] == pytest.approx(0.0)
+    slack_p_solved_after = p_gen[0] + 0.735 - allocation["applied_mismatch"]
+    assert slack_p_solved_after <= pg_ub[0] + 1e-9
+
+
+def test_generator_q_limit_diagnostics_reports_upper_and_lower_violations(gs):
+    psys = _dummy_q_limit_psys(gs)
+    q_values = np.array([1.25, -0.85, 0.0])
+    qg_lb = np.array([-1.0, -0.5, -0.1])
+    qg_ub = np.array([1.0, 0.5, 0.1])
+
+    diagnostics = gs._generator_q_limit_diagnostics(psys, q_values, qg_lb, qg_ub)
+
+    assert diagnostics["gen_q_violation_count"] == 2
+    assert diagnostics["gen_q_violation_total_abs"] == pytest.approx(0.60)
+    assert diagnostics["gen_q_violation_argmax"] == 1
+    assert len(diagnostics["gen_q_violation_top"]) == 2
+
+    worst = diagnostics["gen_q_violation_top"][0]
+    assert worst["gen_index"] == 1
+    assert worst["gen_id"] == "A"
+    assert worst["bus_index"] == 1
+    assert worst["bus_id"] == 20
+    assert worst["bus_type"] == "PV"
+    assert worst["qg"] == pytest.approx(-0.85)
+    assert worst["qmin"] == pytest.approx(-0.5)
+    assert worst["qmax"] == pytest.approx(0.5)
+    assert worst["violation"] == pytest.approx(0.35)
+    assert worst["side"] == "lower"
+    assert not worst["is_slack"]
+
+    second = diagnostics["gen_q_violation_top"][1]
+    assert second["gen_index"] == 0
+    assert second["side"] == "upper"
+    assert second["is_slack"]
+
+
+def test_generator_q_limit_diagnostics_reports_no_violations(gs):
+    psys = _dummy_q_limit_psys(gs)
+    q_values = np.array([0.0, -0.25, 0.05])
+    qg_lb = np.array([-1.0, -0.5, -0.1])
+    qg_ub = np.array([1.0, 0.5, 0.1])
+
+    diagnostics = gs._generator_q_limit_diagnostics(psys, q_values, qg_lb, qg_ub)
+
+    assert diagnostics["gen_q_violation_count"] == 0
+    assert diagnostics["gen_q_violation_total_abs"] == pytest.approx(0.0)
+    assert diagnostics["gen_q_violation_argmax"] is None
+    assert diagnostics["gen_q_violation_top"] == []
+
+
+def test_q_limit_summary_rolls_up_top_offenders(gs):
+    psys = _dummy_q_limit_psys(gs)
+    diagnostics = gs._generator_q_limit_diagnostics(
+        psys,
+        np.array([1.25, -0.85, 0.0]),
+        np.array([-1.0, -0.5, -0.1]),
+        np.array([1.0, 0.5, 0.1]),
+    )
+
+    summary = gs._summarize_diagnostics([
+        {
+            "accepted": False,
+            "reject_reason": "gen_q_limit",
+            "gen_q_violation_max": 0.35,
+            "gen_q_violation_count": diagnostics["gen_q_violation_count"],
+            "gen_q_violation_total_abs": diagnostics["gen_q_violation_total_abs"],
+            "gen_q_violation_top": diagnostics["gen_q_violation_top"],
+        },
+        {
+            "accepted": False,
+            "reject_reason": "gen_q_limit",
+            "gen_q_violation_max": 0.35,
+            "gen_q_violation_count": diagnostics["gen_q_violation_count"],
+            "gen_q_violation_total_abs": diagnostics["gen_q_violation_total_abs"],
+            "gen_q_violation_top": diagnostics["gen_q_violation_top"],
+        },
+    ])
+
+    top_offenders = summary["gen_q_violation_top_offenders"]
+    assert top_offenders[0]["bus_id"] == 20
+    assert top_offenders[0]["gen_id"] == "A"
+    assert top_offenders[0]["count"] == 2
+    assert top_offenders[0]["max_violation"] == pytest.approx(0.35)
+    assert top_offenders[0]["mean_abs_violation"] == pytest.approx(0.35)
+
+
+def test_q_limit_mitigation_upper_switches_pv_bus_and_clamps_qmax(gs):
+    psys = _dummy_q_limit_psys(gs)
+    op_cfg = gs._resolve_operating_point_config(
+        {"enabled": True, "q_limit_mitigation": True}
+    )
+    q_gen = np.array([0.0, 0.0, 0.0])
+    q_values = np.array([0.0, 0.85, 0.0])
+    qg_lb = np.array([-1.0, -0.5, -0.1])
+    qg_ub = np.array([1.0, 0.5, 0.1])
+    q_fixed_mask = np.zeros_like(q_gen, dtype=bool)
+    q_fixed_values = q_gen.copy()
+
+    q_new, result = gs._apply_q_limit_mitigation(
+        psys,
+        q_gen,
+        q_values,
+        qg_lb,
+        qg_ub,
+        op_cfg,
+        q_fixed_mask=q_fixed_mask,
+        q_fixed_values=q_fixed_values,
+        pass_idx=1,
+    )
+
+    assert result["applied"]
+    assert psys.buses[1].type == gs.Bus.PQ
+    assert q_new[1] == pytest.approx(qg_ub[1])
+    assert q_fixed_mask[1]
+    assert q_fixed_values[1] == pytest.approx(qg_ub[1])
+    assert result["events"][0]["side"] == "upper"
+
+
+def test_q_limit_mitigation_lower_switches_pv_bus_and_clamps_qmin(gs):
+    psys = _dummy_q_limit_psys(gs)
+    op_cfg = gs._resolve_operating_point_config(
+        {"enabled": True, "q_limit_mitigation": True}
+    )
+    q_gen = np.array([0.0, 0.0, 0.0])
+    q_values = np.array([0.0, -0.85, 0.0])
+    qg_lb = np.array([-1.0, -0.5, -0.1])
+    qg_ub = np.array([1.0, 0.5, 0.1])
+
+    q_new, result = gs._apply_q_limit_mitigation(
+        psys, q_gen, q_values, qg_lb, qg_ub, op_cfg
+    )
+
+    assert result["applied"]
+    assert psys.buses[1].type == gs.Bus.PQ
+    assert q_new[1] == pytest.approx(qg_lb[1])
+    assert result["events"][0]["side"] == "lower"
+
+
+def test_q_limit_mitigation_does_not_switch_slack_generator(gs):
+    psys = _dummy_q_limit_psys(gs)
+    op_cfg = gs._resolve_operating_point_config(
+        {"enabled": True, "q_limit_mitigation": True}
+    )
+    q_gen = np.array([0.0, 0.0, 0.0])
+    q_values = np.array([1.25, 0.0, 0.0])
+    qg_lb = np.array([-1.0, -0.5, -0.1])
+    qg_ub = np.array([1.0, 0.5, 0.1])
+
+    q_new, result = gs._apply_q_limit_mitigation(
+        psys, q_gen, q_values, qg_lb, qg_ub, op_cfg
+    )
+
+    assert not result["applied"]
+    assert psys.buses[0].type == gs.Bus.SLACK
+    np.testing.assert_allclose(q_new, q_gen)
+
+
+def test_q_limit_mitigation_can_restore_and_repeat_bus_type_changes(gs):
+    psys = _dummy_q_limit_psys(gs)
+    op_cfg = gs._resolve_operating_point_config(
+        {"enabled": True, "q_limit_mitigation": True}
+    )
+    original_bus_types = gs._capture_bus_types(psys)
+    q_gen = np.array([0.0, 0.0, 0.0])
+    q_values = np.array([0.0, 0.85, 0.0])
+    qg_lb = np.array([-1.0, -0.5, -0.1])
+    qg_ub = np.array([1.0, 0.5, 0.1])
+
+    _, first = gs._apply_q_limit_mitigation(
+        psys, q_gen, q_values, qg_lb, qg_ub, op_cfg
+    )
+    gs._restore_bus_types(psys, original_bus_types)
+    _, second = gs._apply_q_limit_mitigation(
+        psys, q_gen, q_values, qg_lb, qg_ub, op_cfg
+    )
+
+    assert first["applied"]
+    assert second["applied"]
+    assert psys.buses[1].type == gs.Bus.PQ
+    gs._restore_bus_types(psys, original_bus_types)
+    assert [bus.type for bus in psys.buses] == original_bus_types
+
+
+def test_q_limit_mitigation_disabled_does_not_apply(gs):
+    psys = _dummy_q_limit_psys(gs)
+    op_cfg = gs._resolve_operating_point_config(
+        {"enabled": True, "q_limit_mitigation": False}
+    )
+    q_gen = np.array([0.0, 0.0, 0.0])
+    q_values = np.array([0.0, 0.85, 0.0])
+    qg_lb = np.array([-1.0, -0.5, -0.1])
+    qg_ub = np.array([1.0, 0.5, 0.1])
+
+    q_new, result = gs._apply_q_limit_mitigation(
+        psys, q_gen, q_values, qg_lb, qg_ub, op_cfg
+    )
+
+    assert not result["applied"]
+    assert psys.buses[1].type == gs.Bus.PV
+    np.testing.assert_allclose(q_new, q_gen)
+
+
+def test_target_fault_metadata_covers_complete_fault_grid(gs):
+    metadata = gs._build_target_fault_metadata(
+        7,
+        [0, 2],
+        [1e-4, 2e-4],
+        operating_point_id="op-1",
+        accepted_operating_point_index=3,
+    )
+
+    assert len(metadata) == 4
+    faults = {
+        (entry["fault_location"], entry["fault_impedance"])
+        for entry in metadata.values()
+    }
+    assert faults == {(0, 1e-4), (0, 2e-4), (2, 1e-4), (2, 2e-4)}
+    assert {entry["sample_idx"] for entry in metadata.values()} == {7}
+    assert {entry["operating_point_id"] for entry in metadata.values()} == {"op-1"}
+    assert {
+        entry["accepted_operating_point_index"] for entry in metadata.values()
+    } == {3}
+
+
+def test_target_mode_replaces_pf_rejected_candidates(gs, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(gs, "_load_power_system", lambda *_: _dummy_export_psys())
+
+    seen_samples = []
+
+    def fake_prepare(*args, **kwargs):
+        scenario = args[2]
+        seen_samples.append(scenario["sample_idx"])
+        if scenario["sample_idx"] == 0:
+            diagnostics = {
+                "record_type": "operating_point_attempt",
+                "accepted": False,
+                "attempts": 1,
+                "reject_reason": "pf_non_converged",
+            }
+            return {
+                "rejected": True,
+                "diverged": True,
+                "diagnostics": diagnostics,
+                "diagnostics_attempts": [diagnostics],
+            }
+        diagnostics = {
+            "record_type": "operating_point_attempt",
+            "accepted": True,
+            "attempts": 1,
+            "pf_residual": 1e-12,
+        }
+        return {
+            "rejected": False,
+            "diverged": False,
+            "diagnostics": diagnostics,
+            "diagnostics_attempts": [diagnostics],
+            "operating_point": {
+                "diagnostics": {"accepted": True, "attempts": 1},
+                "operating_point_id": scenario["operating_point_id"],
+                "sample_idx": scenario["sample_idx"],
+                "accepted_operating_point_index": scenario[
+                    "accepted_operating_point_index"
+                ],
+            },
+        }
+
+    def fake_fault_worker(raw, dyr, scenario, scenario_id, operating_point, integration):
+        os.makedirs("simulation_data", exist_ok=True)
+        path = gs._simulation_file_path(scenario_id)
+        with open(path, "w") as f:
+            f.write("ok")
+        return {
+            "file": path,
+            "diverged": False,
+            "rejected": False,
+            "diagnostics": {
+                "accepted": True,
+                "sample_idx": scenario["sample_idx"],
+                "operating_point_id": scenario["operating_point_id"],
+            },
+        }
+
+    monkeypatch.setattr(gs, "_prepare_operating_point_candidate", fake_prepare)
+    monkeypatch.setattr(gs, "_run_fault_with_operating_point_worker", fake_fault_worker)
+
+    log = gs._run_target_accepted_driver(
+        "case.raw",
+        "case.dyr",
+        target_accepted_scenarios=1,
+        max_total_attempts=5,
+        sample_idx_start=0,
+        fault_locations=[10, 20],
+        fault_impedances=[1e-4],
+        n_jobs=1,
+        operating_point_config={"enabled": True},
+    )
+
+    assert seen_samples == [0, 1]
+    assert len(log) == 2
+    metadata = json.load(open("scenario_metadata.json"))
+    assert len(metadata) == 2
+    assert {entry["sample_idx"] for entry in metadata.values()} == {1}
+    assert {entry["accepted_operating_point_index"] for entry in metadata.values()} == {0}
+    diagnostics = [
+        json.loads(line)
+        for line in open("scenario_diagnostics.jsonl")
+        if line.strip()
+    ]
+    groups = [
+        record for record in diagnostics
+        if record.get("record_type") == "operating_point_group"
+    ]
+    attempts = [
+        record for record in diagnostics
+        if record.get("record_type") == "operating_point_attempt"
+    ]
+    assert [record["accepted"] for record in groups] == [False, True]
+    assert [record["accepted"] for record in attempts] == [False, True]
+
+
+def test_target_mode_incomplete_fault_group_does_not_count(gs, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(gs, "_load_power_system", lambda *_: _dummy_export_psys())
+
+    seen_samples = []
+    failed_group_files = []
+
+    def fake_prepare(*args, **kwargs):
+        scenario = args[2]
+        seen_samples.append(scenario["sample_idx"])
+        return {
+            "rejected": False,
+            "diverged": False,
+            "diagnostics": {"accepted": True, "attempts": 1},
+            "operating_point": {
+                "diagnostics": {"accepted": True, "attempts": 1},
+                "operating_point_id": scenario["operating_point_id"],
+                "sample_idx": scenario["sample_idx"],
+                "accepted_operating_point_index": scenario[
+                    "accepted_operating_point_index"
+                ],
+            },
+        }
+
+    def fake_fault_worker(raw, dyr, scenario, scenario_id, operating_point, integration):
+        if scenario["sample_idx"] == 0 and scenario["fault_location"] == 10:
+            os.makedirs("simulation_data", exist_ok=True)
+            path = gs._simulation_file_path(scenario_id)
+            with open(path, "w") as f:
+                f.write("partial")
+            failed_group_files.append(path)
+            return {
+                "file": path,
+                "diverged": False,
+                "rejected": False,
+                "diagnostics": {"accepted": True},
+            }
+        if scenario["sample_idx"] == 0:
+            return {
+                "file": None,
+                "diverged": True,
+                "rejected": False,
+                "diagnostics": {
+                    "accepted": False,
+                    "reject_reason": "simulation_diverged",
+                },
+            }
+        os.makedirs("simulation_data", exist_ok=True)
+        path = gs._simulation_file_path(scenario_id)
+        with open(path, "w") as f:
+            f.write("ok")
+        return {
+            "file": path,
+            "diverged": False,
+            "rejected": False,
+            "diagnostics": {"accepted": True},
+        }
+
+    monkeypatch.setattr(gs, "_prepare_operating_point_candidate", fake_prepare)
+    monkeypatch.setattr(gs, "_run_fault_with_operating_point_worker", fake_fault_worker)
+
+    log = gs._run_target_accepted_driver(
+        "case.raw",
+        "case.dyr",
+        target_accepted_scenarios=1,
+        max_total_attempts=5,
+        sample_idx_start=0,
+        fault_locations=[10, 20],
+        fault_impedances=[1e-4],
+        n_jobs=1,
+        operating_point_config={"enabled": True},
+    )
+
+    assert seen_samples == [0, 1]
+    assert len(log) == 2
+    metadata = json.load(open("scenario_metadata.json"))
+    assert {entry["sample_idx"] for entry in metadata.values()} == {1}
+    assert failed_group_files
+    assert not any(os.path.exists(path) for path in failed_group_files)
+
+
+def test_target_mode_continue_counts_existing_complete_groups(
+        gs, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(gs, "_load_power_system", lambda *_: _dummy_export_psys())
+
+    os.makedirs("simulation_data", exist_ok=True)
+    existing_log = {}
+    existing_metadata = {}
+    for idx, fault_location in enumerate([10, 20]):
+        scenario_id = f"existing-{idx}"
+        path = f"simulation_data/scenario_{scenario_id}.npz"
+        with open(path, "w") as f:
+            f.write("ok")
+        row = {
+            "sample_idx": 0,
+            "fault_location": fault_location,
+            "fault_impedance": 1e-4,
+            "operating_point_id": "existing-op",
+            "accepted_operating_point_index": 0,
+            "file": path,
+            "diverged": False,
+            "rejected": False,
+        }
+        existing_log[scenario_id] = dict(row)
+        existing_metadata[scenario_id] = {
+            key: row[key]
+            for key in [
+                "sample_idx",
+                "fault_location",
+                "fault_impedance",
+                "operating_point_id",
+                "accepted_operating_point_index",
+            ]
+        }
+
+    seen_candidates = []
+
+    def fake_prepare(*args, **kwargs):
+        scenario = args[2]
+        seen_candidates.append(
+            (
+                scenario["sample_idx"],
+                scenario["accepted_operating_point_index"],
+            )
+        )
+        diagnostics = {
+            "record_type": "operating_point_attempt",
+            "accepted": True,
+            "attempts": 1,
+        }
+        return {
+            "rejected": False,
+            "diverged": False,
+            "diagnostics": diagnostics,
+            "diagnostics_attempts": [diagnostics],
+            "operating_point": {
+                "diagnostics": {"accepted": True, "attempts": 1},
+                "operating_point_id": scenario["operating_point_id"],
+                "sample_idx": scenario["sample_idx"],
+                "accepted_operating_point_index": scenario[
+                    "accepted_operating_point_index"
+                ],
+            },
+        }
+
+    def fake_fault_worker(raw, dyr, scenario, scenario_id, operating_point, integration):
+        path = gs._simulation_file_path(scenario_id)
+        with open(path, "w") as f:
+            f.write("ok")
+        return {
+            "file": path,
+            "diverged": False,
+            "rejected": False,
+            "diagnostics": {"accepted": True},
+        }
+
+    monkeypatch.setattr(gs, "_prepare_operating_point_candidate", fake_prepare)
+    monkeypatch.setattr(gs, "_run_fault_with_operating_point_worker", fake_fault_worker)
+
+    log = gs._run_target_accepted_driver(
+        "case.raw",
+        "case.dyr",
+        target_accepted_scenarios=2,
+        max_total_attempts=5,
+        sample_idx_start=5,
+        fault_locations=[10, 20],
+        fault_impedances=[1e-4],
+        n_jobs=1,
+        operating_point_config={"enabled": True},
+        existing_log=existing_log,
+        existing_metadata=existing_metadata,
+    )
+
+    assert seen_candidates == [(5, 1)]
+    assert len(log) == 4
+    metadata = json.load(open("scenario_metadata.json"))
+    assert len(metadata) == 4
+    assert {
+        entry["accepted_operating_point_index"]
+        for entry in metadata.values()
+    } == {0, 1}
+
+
+def test_legacy_driver_uses_predefined_grid_when_target_unset(gs, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(gs, "load_psse", lambda *_: _dummy_export_psys())
+    monkeypatch.setattr(gs, "add_dyr", lambda *_: None)
+
+    called_ids = []
+
+    def fake_worker(*args):
+        scenario = args[2]
+        scenario_id = args[3]
+        called_ids.append(scenario_id)
+        return {
+            "file": f"simulation_data/scenario_{scenario_id}.npz",
+            "diverged": False,
+            "rejected": False,
+            "diagnostics": {
+                "accepted": True,
+                "sample_idx": scenario["sample_idx"],
+            },
+        }
+
+    monkeypatch.setattr(gs, "run_single_scenario_worker", fake_worker)
+    scenarios_metadata = {
+        "a": {"sample_idx": 0, "fault_location": 1, "fault_impedance": 1e-4},
+        "b": {"sample_idx": 0, "fault_location": 2, "fault_impedance": 1e-4},
+    }
+
+    log = gs.run_simulation_driver_batched(
+        "case.raw",
+        "case.dyr",
+        scenarios_metadata,
+        n_jobs=1,
+        batch_size=2,
+        checkpoint_interval=10,
+        operating_point_config={"enabled": True},
+    )
+
+    assert called_ids == ["a", "b"]
+    assert set(log) == {"a", "b"}
+
+
+def test_legacy_driver_writes_all_attempt_diagnostics(gs, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(gs, "load_psse", lambda *_: _dummy_export_psys())
+    monkeypatch.setattr(gs, "add_dyr", lambda *_: None)
+
+    def fake_worker(*args):
+        scenario = args[2]
+        scenario_id = args[3]
+        attempts = [
+            {
+                "record_type": "operating_point_attempt",
+                "scenario_id": scenario_id,
+                "sample_idx": scenario["sample_idx"],
+                "accepted": False,
+                "reject_reason": "voltage_low",
+                "attempts": 1,
+            },
+            {
+                "record_type": "operating_point_attempt",
+                "scenario_id": scenario_id,
+                "sample_idx": scenario["sample_idx"],
+                "accepted": True,
+                "reject_reason": None,
+                "attempts": 2,
+            },
+        ]
+        return {
+            "file": f"simulation_data/scenario_{scenario_id}.npz",
+            "diverged": False,
+            "rejected": False,
+            "diagnostics": attempts[-1],
+            "diagnostics_attempts": attempts,
+        }
+
+    monkeypatch.setattr(gs, "run_single_scenario_worker", fake_worker)
+    gs.run_simulation_driver_batched(
+        "case.raw",
+        "case.dyr",
+        {"a": {"sample_idx": 0, "fault_location": 1, "fault_impedance": 1e-4}},
+        n_jobs=1,
+        batch_size=1,
+        checkpoint_interval=10,
+        operating_point_config={"enabled": True},
+    )
+
+    records = [
+        json.loads(line)
+        for line in open("scenario_diagnostics.jsonl")
+        if line.strip()
+    ]
+    assert [record["accepted"] for record in records] == [False, True]
+    summary = json.load(open("scenario_diagnostics_summary.json"))
+    assert summary["reject_reasons"]["voltage_low"] == 1
+
+
+def test_legacy_checkpoint_resume_preserves_diagnostics_summary(
+    gs, tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(gs, "load_psse", lambda *_: _dummy_export_psys())
+    monkeypatch.setattr(gs, "add_dyr", lambda *_: None)
+
+    previous_record = {
+        "record_type": "operating_point_attempt",
+        "scenario_id": "a",
+        "sample_idx": 0,
+        "accepted": False,
+        "reject_reason": "voltage_low",
+        "attempts": 1,
+    }
+    with open("scenario_diagnostics.jsonl", "w") as f:
+        f.write(json.dumps(previous_record) + "\n")
+    with open("simulation_checkpoint.json", "w") as f:
+        json.dump(
+            {
+                "last_batch": 0,
+                "simulation_log": {
+                    "a": {
+                        "sample_idx": 0,
+                        "fault_location": 1,
+                        "fault_impedance": 1e-4,
+                        "file": None,
+                        "diverged": True,
+                    }
+                },
+            },
+            f,
+        )
+
+    called_ids = []
+
+    def fake_worker(*args):
+        scenario = args[2]
+        scenario_id = args[3]
+        called_ids.append(scenario_id)
+        diagnostics = {
+            "record_type": "operating_point_attempt",
+            "scenario_id": scenario_id,
+            "sample_idx": scenario["sample_idx"],
+            "accepted": True,
+            "reject_reason": None,
+            "attempts": 1,
+        }
+        return {
+            "file": f"simulation_data/scenario_{scenario_id}.npz",
+            "diverged": False,
+            "rejected": False,
+            "diagnostics": diagnostics,
+            "diagnostics_attempts": [diagnostics],
+        }
+
+    monkeypatch.setattr(gs, "run_single_scenario_worker", fake_worker)
+    log = gs.run_simulation_driver_batched(
+        "case.raw",
+        "case.dyr",
+        {
+            "a": {"sample_idx": 0, "fault_location": 1, "fault_impedance": 1e-4},
+            "b": {"sample_idx": 0, "fault_location": 2, "fault_impedance": 1e-4},
+        },
+        n_jobs=1,
+        batch_size=1,
+        checkpoint_interval=10,
+        operating_point_config={"enabled": True},
+    )
+
+    assert called_ids == ["b"]
+    assert set(log) == {"a", "b"}
+    records = [
+        json.loads(line)
+        for line in open("scenario_diagnostics.jsonl")
+        if line.strip()
+    ]
+    assert [record["scenario_id"] for record in records] == ["a", "b"]
+    summary = json.load(open("scenario_diagnostics_summary.json"))
+    assert summary["total_records"] == 2
+    assert summary["reject_reasons"]["voltage_low"] == 1
+    assert summary["accepted"] == 1
+
+
+def test_screen_power_flow_diagnostics_accepts_and_rejects_synthetic_cases(gs):
+    op_cfg = gs._resolve_operating_point_config({"enabled": True})
+    diagnostics = {
+        "pf_converged": True,
+        "pf_residual": 1e-10,
+        "slack_p_deviation": 0.0,
+        "voltage_min": 0.95,
+        "voltage_max": 1.04,
+        "gen_p_violation_max": 0.0,
+        "gen_q_violation_max": 0.0,
+        "branch_loading_available": False,
+        "branch_loading_max": None,
+    }
+
+    accepted, reason = gs._screen_power_flow_diagnostics(
+        diagnostics, total_load_p=10.0, op_cfg=op_cfg
+    )
+    assert accepted
+    assert reason is None
+
+    diagnostics["voltage_min"] = 0.85
+    accepted, reason = gs._screen_power_flow_diagnostics(
+        diagnostics, total_load_p=10.0, op_cfg=op_cfg
+    )
+    assert not accepted
+    assert reason == "voltage_low"
+
+
+def test_power_flow_diagnostics_on_ieee9_are_finite(gs, data_dir):
+    psys = load_psse(os.path.join(data_dir, "ieee9_v33.raw"))
+    psys.createYbusComplex()
+    p_gen, q_gen = psys.get_gen_pq()
+    pg_lb, pg_ub = psys.get_pgen_bounds()
+    qg_lb, qg_ub = psys.get_qgen_bounds()
+
+    _, diagnostics = gs._diagnose_power_flow(
+        psys,
+        p_gen,
+        q_gen,
+        pg_lb,
+        pg_ub,
+        qg_lb,
+        qg_ub,
+        gs._resolve_operating_point_config({"enabled": True}),
+    )
+
+    assert diagnostics["pf_converged"]
+    assert diagnostics["pf_residual"] < 1e-7
+    assert np.isfinite(diagnostics["voltage_min"])
+    assert np.isfinite(diagnostics["voltage_max"])
+    assert diagnostics["voltage_min"] > 0.0
+    assert diagnostics["voltage_max"] > diagnostics["voltage_min"]
+    assert "gen_q_violation_count" in diagnostics
+    assert "gen_q_violation_total_abs" in diagnostics
+    assert "gen_q_violation_argmax" in diagnostics
+    assert "gen_q_violation_top" in diagnostics
+    mitigation_diagnostics = gs._q_limit_mitigation_defaults(
+        gs._resolve_operating_point_config({"enabled": True})
+    )
+    json.dumps(gs._json_safe(mitigation_diagnostics))
+    json.dumps(gs._json_safe(diagnostics))


### PR DESCRIPTION
# Add PF-aware scenario generation workflow

Adds load-stress scenario generation, PF-aware rebalance, loss compensation, Q-limit diagnostics/mitigation, accepted operating-point target mode, diagnostics export, stress configs, and tests.

- Validation run:
```python -m pytest -p no:cacheprovider tests/test_generate_scenarios_operating_point.py tests/test_pflow.py```
- Broader validation:
```python -m pytest -p no:cacheprovider -m "not adjoint" --ignore tests/test_state_metadata_export.py```