### PR TITLE
Add half-explicit RK integrator

### DIFF
--- a/tests/test_herk.py
+++ b/tests/test_herk.py
@@ -1,0 +1,466 @@
+import os
+
+os.environ.setdefault("MPLCONFIGDIR", "/tmp")
+
+import matplotlib
+import numpy as np
+import pytest
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from uqgrid.io.parse import add_dyr, load_psse
+from uqgrid.simulation.config import IntegrationConfig
+from uqgrid.simulation.dynamics import (
+    initialize_system,
+    integrate_system,
+    preallocate_jacobian,
+)
+from uqgrid.simulation.herk import solve_stage_algebraic
+from uqgrid.simulation.pflow import runpf
+from uqgrid.simulation.residual import residual_function
+
+
+@pytest.fixture
+def data_dir():
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data"
+    )
+
+
+def _build_two_bus_psys(data_dir):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "2bus_33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "GENROU.dyr"))
+    psys.createYbusComplex()
+    psys.add_busfault(1, 1.0)
+    return psys
+
+
+def test_config_defaults_preserve_beuler():
+    cfg = IntegrationConfig()
+
+    assert cfg.method == "beuler"
+    assert cfg.herk_alg_tol == pytest.approx(1e-10)
+    assert cfg.herk_alg_max_iter == 50
+
+
+def test_unknown_method_raises(data_dir):
+    psys = _build_two_bus_psys(data_dir)
+    cfg = IntegrationConfig(method="bogus", tend=0.0, steps=1, petsc=False)
+
+    with pytest.raises(ValueError, match="Unknown integration method: bogus"):
+        integrate_system(psys, cfg)
+
+
+def test_beuler_regression_unchanged(data_dir):
+    base_config = dict(
+        tend=0.1,
+        dt=1.0 / 120.0,
+        steps=3,
+        power_injection=True,
+        verbose=False,
+        comp_sens=False,
+        fsolve=False,
+        petsc=False,
+        ton=10.0,
+        toff=11.0,
+    )
+
+    psys_default = _build_two_bus_psys(data_dir)
+    res_default = integrate_system(psys_default, IntegrationConfig(**base_config))
+
+    psys_explicit = _build_two_bus_psys(data_dir)
+    res_explicit = integrate_system(
+        psys_explicit, IntegrationConfig(method="beuler", **base_config)
+    )
+
+    assert np.array_equal(res_default["tvec"], res_explicit["tvec"])
+    assert np.allclose(res_default["history"], res_explicit["history"])
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — stage algebraic Newton
+# ---------------------------------------------------------------------------
+
+
+def _init_psys_at_steady_state(psys):
+    """Return (sysvec, theta, F, J) initialized from a power-flow solution."""
+    pf_solution = runpf(psys, verbose=False)
+    sysvec, theta = initialize_system(psys, pf_solution)
+    F = np.zeros_like(sysvec)
+    J = preallocate_jacobian(psys)
+    return sysvec, theta, F, J
+
+
+def _build_two_bus_no_fault(data_dir):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "2bus_33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "GENROU.dyr"))
+    psys.createYbusComplex()
+    return psys
+
+
+def _build_ieee9_no_fault(data_dir):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "ieee9_v33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "ieee9bus.dyr"))
+    psys.createYbusComplex()
+    return psys
+
+
+def _build_ieee9_gov_no_fault(data_dir):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "ieee9_v33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "ieee9bus_gov.dyr"))
+    psys.createYbusComplex()
+    return psys
+
+
+def _build_ieee9_fault(data_dir):
+    psys = _build_ieee9_no_fault(data_dir)
+    psys.add_busfault(1, 1.0)
+    return psys
+
+
+def _build_ieee39_no_fault(data_dir):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "IEEE39_v33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "IEEE39.dyr"))
+    psys.createYbusComplex()
+    return psys
+
+
+def _split_z(sysvec, psys):
+    NDIFFEQ = psys.num_dof_dif
+    alg_size = psys.num_dof_alg
+    x = sysvec[:NDIFFEQ].copy()
+    y = sysvec[NDIFFEQ:NDIFFEQ + alg_size].copy()
+    v = sysvec[NDIFFEQ + alg_size:].copy()
+    return x, y, v
+
+
+def test_stage_solve_at_init_2bus(data_dir):
+    psys = _build_two_bus_no_fault(data_dir)
+    sysvec, theta, F, J = _init_psys_at_steady_state(psys)
+    x0, y0, v0 = _split_z(sysvec, psys)
+
+    y, v, iters = solve_stage_algebraic(x0, y0, v0, theta, psys, F, J,
+                                        tol=1e-10, max_iter=10)
+
+    # At a well-initialized state, expect at most 1 Newton iteration.
+    assert iters <= 1
+    z_check = np.concatenate([x0, y, v])
+    residual_function(F, z_check, theta, psys)
+    assert np.linalg.norm(F[psys.num_dof_dif:]) < 1e-10
+
+
+def test_stage_solve_at_init_ieee9(data_dir):
+    psys = _build_ieee9_no_fault(data_dir)
+    sysvec, theta, F, J = _init_psys_at_steady_state(psys)
+    x0, y0, v0 = _split_z(sysvec, psys)
+
+    y, v, iters = solve_stage_algebraic(x0, y0, v0, theta, psys, F, J,
+                                        tol=1e-10, max_iter=10)
+
+    z_check = np.concatenate([x0, y, v])
+    residual_function(F, z_check, theta, psys)
+    assert np.linalg.norm(F[psys.num_dof_dif:]) < 1e-10
+
+
+def test_stage_solve_recovers_from_perturbation(data_dir):
+    psys = _build_ieee9_no_fault(data_dir)
+    sysvec, theta, F, J = _init_psys_at_steady_state(psys)
+    x0, y0, v0 = _split_z(sysvec, psys)
+
+    rng = np.random.default_rng(0)
+    y_pert = y0 + 1e-3 * rng.standard_normal(y0.shape)
+    v_pert = v0 + 1e-3 * rng.standard_normal(v0.shape)
+
+    y, v, iters = solve_stage_algebraic(x0, y_pert, v_pert, theta, psys, F, J,
+                                        tol=1e-10, max_iter=50)
+
+    assert iters >= 1
+    z_check = np.concatenate([x0, y, v])
+    residual_function(F, z_check, theta, psys)
+    assert np.linalg.norm(F[psys.num_dof_dif:]) < 1e-10
+    # Should recover close to the original consistent (y, v).
+    assert np.linalg.norm(y - y0) < 1e-6
+    assert np.linalg.norm(v - v0) < 1e-6
+
+
+def test_stage_solve_freezes_x(data_dir):
+    psys = _build_ieee9_no_fault(data_dir)
+    sysvec, theta, F, J = _init_psys_at_steady_state(psys)
+    x0, y0, v0 = _split_z(sysvec, psys)
+
+    rng = np.random.default_rng(1)
+    X_i = x0 + 1e-3 * rng.standard_normal(x0.shape)
+    X_i_before = X_i.copy()
+
+    y, v, _ = solve_stage_algebraic(X_i, y0, v0, theta, psys, F, J,
+                                    tol=1e-10, max_iter=50)
+
+    # X_i must not have been modified by the stage solve.
+    assert np.array_equal(X_i, X_i_before)
+    # Residual is g(X_i, y, v); verify by rebuilding z with the perturbed X_i.
+    z_check = np.concatenate([X_i, y, v])
+    residual_function(F, z_check, theta, psys)
+    assert np.linalg.norm(F[psys.num_dof_dif:]) < 1e-10
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — HERK2 (Heun) per-step driver and flat-line check
+# ---------------------------------------------------------------------------
+
+
+def test_first_step_residual_herk2(data_dir):
+    from uqgrid.simulation.herk import A_HEUN, B_HEUN, C_HEUN, herk_step
+
+    psys = _build_ieee9_no_fault(data_dir)
+    sysvec, theta, F, J = _init_psys_at_steady_state(psys)
+    x0, y0, v0 = _split_z(sysvec, psys)
+
+    h = 1e-5
+    z1 = herk_step(sysvec, theta, h, psys, A_HEUN, B_HEUN, C_HEUN,
+                   F, J, tol=1e-10, max_iter=50)
+
+    residual_function(F, z1, theta, psys)
+    assert np.linalg.norm(F[psys.num_dof_dif:]) < 1e-8
+
+    x1 = z1[:psys.num_dof_dif]
+    assert np.linalg.norm(x1 - x0, np.inf) < 1e-4
+
+
+def _run_flatline_herk2(psys, tend=5.0, h=1e-3):
+    cfg = IntegrationConfig(
+        method="herk2",
+        tend=tend,
+        dt=h,
+        steps=-1,
+        power_injection=True,
+        verbose=False,
+        comp_sens=False,
+        fsolve=False,
+        petsc=False,
+        ton=tend + 10.0,  # never trigger
+        toff=tend + 11.0,
+    )
+    res = integrate_system(psys, cfg)
+    return res
+
+
+def test_flatline_herk2_2bus(data_dir):
+    psys = _build_two_bus_no_fault(data_dir)
+    res = _run_flatline_herk2(psys, tend=5.0, h=1e-3)
+    NDIFFEQ = psys.num_dof_dif
+    x_traj = res["history"][:NDIFFEQ, :]
+    x0 = x_traj[:, 0]
+    drift = np.max(np.abs(x_traj - x0[:, None]))
+    assert drift < 1e-6, f"flat-line drift on 2-bus = {drift:.3e}"
+
+
+def test_flatline_herk2_ieee9(data_dir):
+    psys = _build_ieee9_no_fault(data_dir)
+    res = _run_flatline_herk2(psys, tend=5.0, h=1e-3)
+    NDIFFEQ = psys.num_dof_dif
+    x_traj = res["history"][:NDIFFEQ, :]
+    x0 = x_traj[:, 0]
+    drift = np.max(np.abs(x_traj - x0[:, None]))
+    assert drift < 1e-6, f"flat-line drift on IEEE9 = {drift:.3e}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — HERK4 (classical RK4) driver
+# ---------------------------------------------------------------------------
+
+
+def test_first_step_residual_herk4(data_dir):
+    from uqgrid.simulation.herk import A_RK4, B_RK4, C_RK4, herk_step
+
+    psys = _build_ieee9_no_fault(data_dir)
+    sysvec, theta, F, J = _init_psys_at_steady_state(psys)
+    x0, y0, v0 = _split_z(sysvec, psys)
+
+    h = 1e-5
+    z1 = herk_step(sysvec, theta, h, psys, A_RK4, B_RK4, C_RK4,
+                   F, J, tol=1e-10, max_iter=50)
+
+    residual_function(F, z1, theta, psys)
+    assert np.linalg.norm(F[psys.num_dof_dif:]) < 1e-8
+
+    x1 = z1[:psys.num_dof_dif]
+    assert np.linalg.norm(x1 - x0, np.inf) < 1e-4
+
+
+def _run_flatline_herk4(psys, tend=5.0, h=1e-3):
+    cfg = IntegrationConfig(
+        method="herk4",
+        tend=tend,
+        dt=h,
+        steps=-1,
+        power_injection=True,
+        verbose=False,
+        comp_sens=False,
+        fsolve=False,
+        petsc=False,
+        ton=tend + 10.0,
+        toff=tend + 11.0,
+    )
+    res = integrate_system(psys, cfg)
+    return res
+
+
+def test_flatline_herk4_ieee9(data_dir):
+    psys = _build_ieee9_no_fault(data_dir)
+    res = _run_flatline_herk4(psys, tend=5.0, h=1e-3)
+    NDIFFEQ = psys.num_dof_dif
+    x_traj = res["history"][:NDIFFEQ, :]
+    x0 = x_traj[:, 0]
+    drift = np.max(np.abs(x_traj - x0[:, None]))
+    assert drift < 1e-6, f"flat-line drift on IEEE9 = {drift:.3e}"
+
+
+def test_flatline_herk4_ieee39(data_dir):
+    psys = _build_ieee39_no_fault(data_dir)
+    res = _run_flatline_herk4(psys, tend=5.0, h=1e-3)
+    NDIFFEQ = psys.num_dof_dif
+    x_traj = res["history"][:NDIFFEQ, :]
+    x0 = x_traj[:, 0]
+    drift = np.max(np.abs(x_traj - x0[:, None]))
+    assert drift < 1e-6, f"flat-line drift on IEEE39 = {drift:.3e}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — fault response cross-validated against backward Euler
+# ---------------------------------------------------------------------------
+
+
+def _run_ieee9_fault(data_dir, method):
+    psys = _build_ieee9_fault(data_dir)
+    cfg = IntegrationConfig(
+        method=method,
+        tend=5.0,
+        dt=1e-4,
+        steps=-1,
+        power_injection=True,
+        verbose=False,
+        comp_sens=False,
+        fsolve=False,
+        petsc=False,
+        ton=1.0,
+        toff=1.1,
+    )
+    return psys, integrate_system(psys, cfg)
+
+
+def _gen_angle_speed_indices(psys):
+    angle_idx = [gen.dif_ptr + 5 for gen in psys.gendyn]
+    speed_idx = psys.genspeed_idx_set()
+    return angle_idx + speed_idx
+
+
+def _save_ieee9_fault_plot(out_path, tvec, beuler, herk4, indices):
+    fig, axes = plt.subplots(2, 1, figsize=(8, 5), sharex=True)
+    ngen = len(indices) // 2
+    angle_idx = indices[:ngen]
+    speed_idx = indices[ngen:]
+
+    for k, idx in enumerate(angle_idx):
+        axes[0].plot(tvec, beuler[idx, :], color=f"C{k}", linewidth=1.0)
+        axes[0].plot(tvec, herk4[idx, :], color=f"C{k}", linewidth=0.8, linestyle="--")
+    axes[0].set_ylabel("delta")
+
+    for k, idx in enumerate(speed_idx):
+        axes[1].plot(tvec, beuler[idx, :], color=f"C{k}", linewidth=1.0)
+        axes[1].plot(tvec, herk4[idx, :], color=f"C{k}", linewidth=0.8, linestyle="--")
+    axes[1].set_ylabel("w")
+    axes[1].set_xlabel("time [s]")
+
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+
+
+def test_fault_response_herk4_vs_beuler_ieee9(data_dir):
+    psys_be, res_be = _run_ieee9_fault(data_dir, "beuler")
+    psys_rk, res_rk = _run_ieee9_fault(data_dir, "herk4")
+
+    assert np.array_equal(res_be["tvec"], res_rk["tvec"])
+    indices = _gen_angle_speed_indices(psys_be)
+    rk_indices = _gen_angle_speed_indices(psys_rk)
+    assert indices == rk_indices
+
+    out_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "benchmarks",
+        "herk_vs_beuler_ieee9.png",
+    )
+    _save_ieee9_fault_plot(
+        out_path, res_be["tvec"], res_be["history"], res_rk["history"], indices
+    )
+    assert os.path.exists(out_path)
+
+    ngen = len(indices) // 2
+    diff = np.abs(res_be["history"][indices, :] - res_rk["history"][indices, :])
+    angle_err = np.max(diff[:ngen, :])
+    speed_err = np.max(diff[ngen:, :])
+    assert angle_err < 5e-4, f"IEEE9 fault HERK4 vs BE rotor angle error = {angle_err:.3e}"
+    assert speed_err < 1e-5, f"IEEE9 fault HERK4 vs BE speed error = {speed_err:.3e}"
+
+
+def test_controller_blend_propagates_under_herk(data_dir):
+    from uqgrid.simulation.herk import A_RK4, B_RK4, C_RK4, herk_step
+
+    psys = _build_ieee9_gov_no_fault(data_dir)
+    sysvec, theta, F, J = _init_psys_at_steady_state(psys)
+    gov_indices = np.flatnonzero(psys.gov_mask)
+    assert gov_indices.size > 0
+
+    gen_idx = int(gov_indices[0])
+    gen = psys.gendyn[gen_idx]
+    gov = gen.governor
+
+    h = 1e-4
+    eps = 1e-3
+    z_pert = sysvec.copy()
+    z_pert[gov.dif_ptr + 4] += eps  # IEESGO TP3 directly shifts p_m output.
+
+    base = herk_step(sysvec, theta, h, psys, A_RK4, B_RK4, C_RK4,
+                     F, J, tol=1e-10, max_iter=50)
+    pert = herk_step(z_pert, theta, h, psys, A_RK4, B_RK4, C_RK4,
+                     F, J, tol=1e-10, max_iter=50)
+
+    speed_idx = gen.dif_ptr + 4
+    speed_delta = pert[speed_idx] - base[speed_idx]
+    expected = h * eps / (2.0 * gen.H)
+
+    assert speed_delta > 0.0
+    assert speed_delta == pytest.approx(expected, rel=5e-2, abs=1e-11)
+
+
+# ---------------------------------------------------------------------------
+# Phase 6 — convergence-order study and Jacobian sanity
+# ---------------------------------------------------------------------------
+
+
+def test_stage_jacobian_matches_finite_difference(data_dir):
+    from uqgrid.simulation.jacobian import residual_jacobian
+
+    psys = _build_ieee9_no_fault(data_dir)
+    sysvec, theta, F, J = _init_psys_at_steady_state(psys)
+    residual_jacobian(J, sysvec, theta, psys)
+
+    ndiff = psys.num_dof_dif
+    Jgg = J[ndiff:, ndiff:].toarray()
+    Jfd = np.zeros_like(Jgg)
+    eps = 1e-6
+
+    F_plus = np.zeros_like(sysvec)
+    F_minus = np.zeros_like(sysvec)
+    for col in range(Jgg.shape[1]):
+        z_plus = sysvec.copy()
+        z_minus = sysvec.copy()
+        z_plus[ndiff + col] += eps
+        z_minus[ndiff + col] -= eps
+        residual_function(F_plus, z_plus, theta, psys)
+        residual_function(F_minus, z_minus, theta, psys)
+        Jfd[:, col] = (F_plus[ndiff:] - F_minus[ndiff:]) / (2.0 * eps)
+
+    max_abs = np.max(np.abs(Jgg - Jfd))
+    assert max_abs < 1e-6, f"stage algebraic Jacobian FD mismatch = {max_abs:.3e}"

--- a/tests/test_herk.py
+++ b/tests/test_herk.py
@@ -1,13 +1,7 @@
 import os
 
-os.environ.setdefault("MPLCONFIGDIR", "/tmp")
-
-import matplotlib
 import numpy as np
 import pytest
-
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt
 
 from uqgrid.io.parse import add_dyr, load_psse
 from uqgrid.simulation.config import IntegrationConfig
@@ -355,28 +349,6 @@ def _gen_angle_speed_indices(psys):
     return angle_idx + speed_idx
 
 
-def _save_ieee9_fault_plot(out_path, tvec, beuler, herk4, indices):
-    fig, axes = plt.subplots(2, 1, figsize=(8, 5), sharex=True)
-    ngen = len(indices) // 2
-    angle_idx = indices[:ngen]
-    speed_idx = indices[ngen:]
-
-    for k, idx in enumerate(angle_idx):
-        axes[0].plot(tvec, beuler[idx, :], color=f"C{k}", linewidth=1.0)
-        axes[0].plot(tvec, herk4[idx, :], color=f"C{k}", linewidth=0.8, linestyle="--")
-    axes[0].set_ylabel("delta")
-
-    for k, idx in enumerate(speed_idx):
-        axes[1].plot(tvec, beuler[idx, :], color=f"C{k}", linewidth=1.0)
-        axes[1].plot(tvec, herk4[idx, :], color=f"C{k}", linewidth=0.8, linestyle="--")
-    axes[1].set_ylabel("w")
-    axes[1].set_xlabel("time [s]")
-
-    fig.tight_layout()
-    fig.savefig(out_path, dpi=150)
-    plt.close(fig)
-
-
 def test_fault_response_herk4_vs_beuler_ieee9(data_dir):
     psys_be, res_be = _run_ieee9_fault(data_dir, "beuler")
     psys_rk, res_rk = _run_ieee9_fault(data_dir, "herk4")
@@ -385,16 +357,6 @@ def test_fault_response_herk4_vs_beuler_ieee9(data_dir):
     indices = _gen_angle_speed_indices(psys_be)
     rk_indices = _gen_angle_speed_indices(psys_rk)
     assert indices == rk_indices
-
-    out_path = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-        "benchmarks",
-        "herk_vs_beuler_ieee9.png",
-    )
-    _save_ieee9_fault_plot(
-        out_path, res_be["tvec"], res_be["history"], res_rk["history"], indices
-    )
-    assert os.path.exists(out_path)
 
     ngen = len(indices) // 2
     diff = np.abs(res_be["history"][indices, :] - res_rk["history"][indices, :])

--- a/uqgrid/simulation/config.py
+++ b/uqgrid/simulation/config.py
@@ -36,6 +36,9 @@ class IntegrationConfig(BaseModel):
             " must be treated as fast in the ARKIMEX fast/slow split."
         ),
     )
+    method: str = Field("beuler", description="Integrator method: beuler | herk2 | herk4.")
+    herk_alg_tol: float = Field(1e-10, gt=0.0, description="HERK stage algebraic tolerance.")
+    herk_alg_max_iter: int = Field(50, gt=0, description="HERK stage Newton max iterations.")
 
     @field_validator('tend', 'dt', 'ton', 'toff', mode='after')
     def positive_values(cls, v, info: Any):

--- a/uqgrid/simulation/dynamics.py
+++ b/uqgrid/simulation/dynamics.py
@@ -32,6 +32,7 @@ from uqgrid.core import Psystem
 from uqgrid.simulation.pflow import runpf, compute_pinj_alt, PowerFlowSolution
 from uqgrid.simulation.gradients import gradient_p, gradient_xp, gradient_pp
 from uqgrid.simulation.residual import residual_function
+from uqgrid.simulation.herk import integrate_system_herk
 from uqgrid.simulation.jacobian import residual_jacobian
 from uqgrid.utils.tools import (
     matprint,
@@ -1579,6 +1580,14 @@ def integrate_system(
     power_injection = config.power_injection
     solve_power_flow = config.solve_powerflow_dynamics
     arkimex = config.arkimex
+    method = config.method
+
+    if method == "beuler":
+        pass
+    elif method in {"herk2", "herk4"}:
+        return integrate_system_herk(psys, config, ctx)
+    else:
+        raise ValueError(f"Unknown integration method: {method}")
 
     # check for arkimex enabled
     if arkimex and petsc:

--- a/uqgrid/simulation/herk.py
+++ b/uqgrid/simulation/herk.py
@@ -126,8 +126,9 @@ def herk_step(z_old, theta, h, psys, A, b, c, F, J, tol, max_iter):
 def integrate_system_herk(psys, config, ctx=None):
     """HERK driver mirroring the non-PETSc branch of ``integrate_system``.
 
-    Only the no-PETSc, no-sensitivity, no-Jacobian-check path is supported.
-    Fault on/off events are handled between steps via an algebraic resolve.
+    Only the no-PETSc, no-sensitivity, no-fsolve, no-ARKIMEX,
+    no-Jacobian-check path is supported. Fault on/off events are handled
+    between steps via an algebraic resolve.
     """
     import math
 
@@ -141,6 +142,15 @@ def integrate_system_herk(psys, config, ctx=None):
         raise ValueError("HERK driver does not support PETSc.")
     if config.comp_sens:
         raise ValueError("HERK driver does not support sensitivities.")
+    if config.fsolve:
+        raise ValueError(
+            "HERK driver does not support config.fsolve; it uses sparse "
+            "Newton solves for algebraic stages."
+        )
+    if config.arkimex:
+        raise ValueError("HERK driver does not support ARKIMEX.")
+    if config.check_jacobian:
+        raise ValueError("HERK driver does not support Jacobian checking.")
 
     method = config.method
     if method not in TABLEAUS:

--- a/uqgrid/simulation/herk.py
+++ b/uqgrid/simulation/herk.py
@@ -1,0 +1,214 @@
+"""Half-explicit Runge-Kutta integrator for UQGrid.
+
+Heun (HERK2) and classical RK4 (HERK4) are wired through
+``integrate_system``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.sparse.linalg import spsolve
+
+from uqgrid.simulation.residual import residual_function
+from uqgrid.simulation.jacobian import residual_jacobian
+
+
+# ---------------------------------------------------------------------------
+# Tableaus
+# ---------------------------------------------------------------------------
+
+# Heun (explicit RK2)
+A_HEUN = np.array([[0.0, 0.0],
+                   [1.0, 0.0]])
+B_HEUN = np.array([0.5, 0.5])
+C_HEUN = np.array([0.0, 1.0])
+
+# Classical RK4
+A_RK4 = np.array([[0.0, 0.0, 0.0, 0.0],
+                  [0.5, 0.0, 0.0, 0.0],
+                  [0.0, 0.5, 0.0, 0.0],
+                  [0.0, 0.0, 1.0, 0.0]])
+B_RK4 = np.array([1.0 / 6.0, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 6.0])
+C_RK4 = np.array([0.0, 0.5, 0.5, 1.0])
+
+
+TABLEAUS = {
+    "herk2": (A_HEUN, B_HEUN, C_HEUN),
+    "herk4": (A_RK4, B_RK4, C_RK4),
+}
+
+
+# ---------------------------------------------------------------------------
+# Stage algebraic Newton
+# ---------------------------------------------------------------------------
+
+
+def solve_stage_algebraic(X_i, y0, v0, theta, psys, F_full, J_full,
+                          tol=1e-10, max_iter=50):
+    """Solve g(X_i, y, v) = 0 for (y, v) with X_i frozen.
+
+    Returns (y, v, iterations). Raises RuntimeError on non-convergence.
+    """
+    NDIFFEQ = psys.num_dof_dif
+    alg_size = psys.num_dof_alg
+
+    z = np.concatenate([X_i, y0, v0])
+
+    for it in range(max_iter):
+        residual_function(F_full, z, theta, psys)
+        g = F_full[NDIFFEQ:]
+        g_norm = np.linalg.norm(g)
+        if g_norm < tol:
+            y = z[NDIFFEQ:NDIFFEQ + alg_size].copy()
+            v = z[NDIFFEQ + alg_size:].copy()
+            return y, v, it
+
+        residual_jacobian(J_full, z, theta, psys)
+        Jgg = J_full[NDIFFEQ:, NDIFFEQ:].tocsc()
+        dy = spsolve(Jgg, g)
+        z[NDIFFEQ:] -= dy
+
+    raise RuntimeError(
+        f"HERK stage algebraic Newton did not converge in {max_iter} iters "
+        f"(||g||={g_norm:.3e}, tol={tol:.3e})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-step driver
+# ---------------------------------------------------------------------------
+
+
+def herk_step(z_old, theta, h, psys, A, b, c, F, J, tol, max_iter):
+    """Advance one HERK step from ``z_old`` by ``h``.
+
+    Returns the new combined state vector ``z_new = [x_new; y_new; v_new]``.
+    """
+    NDIFFEQ = psys.num_dof_dif
+    alg_size = psys.num_dof_alg
+    s = len(b)
+
+    x_n = z_old[:NDIFFEQ].copy()
+    y_prev = z_old[NDIFFEQ:NDIFFEQ + alg_size].copy()
+    v_prev = z_old[NDIFFEQ + alg_size:].copy()
+
+    K = np.zeros((s, NDIFFEQ))
+    Y_last, V_last = y_prev, v_prev
+
+    for i in range(s):
+        X_i = x_n.copy()
+        for j in range(i):
+            a_ij = A[i, j]
+            if a_ij != 0.0:
+                X_i += h * a_ij * K[j]
+
+        Y_i, V_i, _ = solve_stage_algebraic(
+            X_i, Y_last, V_last, theta, psys, F, J, tol, max_iter)
+        Y_last, V_last = Y_i, V_i
+
+        z_stage = np.concatenate([X_i, Y_i, V_i])
+        residual_function(F, z_stage, theta, psys)
+        K[i] = F[:NDIFFEQ].copy()
+
+    x_new = x_n + h * (b @ K)
+
+    Y_new, V_new, _ = solve_stage_algebraic(
+        x_new, Y_last, V_last, theta, psys, F, J, tol, max_iter)
+
+    return np.concatenate([x_new, Y_new, V_new])
+
+
+# ---------------------------------------------------------------------------
+# Integration driver
+# ---------------------------------------------------------------------------
+
+
+def integrate_system_herk(psys, config, ctx=None):
+    """HERK driver mirroring the non-PETSc branch of ``integrate_system``.
+
+    Only the no-PETSc, no-sensitivity, no-Jacobian-check path is supported.
+    Fault on/off events are handled between steps via an algebraic resolve.
+    """
+    import math
+
+    from uqgrid.simulation.dynamics import (
+        initialize_system,
+        preallocate_jacobian,
+    )
+    from uqgrid.simulation.pflow import runpf
+
+    if config.petsc:
+        raise ValueError("HERK driver does not support PETSc.")
+    if config.comp_sens:
+        raise ValueError("HERK driver does not support sensitivities.")
+
+    method = config.method
+    if method not in TABLEAUS:
+        raise ValueError(f"HERK tableau not registered for method: {method}")
+    A, b, c = TABLEAUS[method]
+
+    psys.power_injection = config.power_injection
+
+    pf_solution = runpf(psys, verbose=False)
+    z0, theta = initialize_system(psys, pf_solution)
+
+    z0_user = ctx.z0_user if ctx is not None else getattr(config, "z0_user", None)
+    theta_user = ctx.theta_user if ctx is not None else getattr(config, "theta_user", None)
+    if z0_user is not None:
+        if z0_user.shape[0] != z0.shape[0]:
+            raise ValueError("Provided initial state does not match system size.")
+        z0 = z0_user
+    if theta_user is not None:
+        if theta_user.shape[0] != theta.shape[0]:
+            raise ValueError("Provided theta does not match system parameters.")
+        theta = theta_user
+
+    system_size = z0.shape[0]
+    J = preallocate_jacobian(psys)
+    F = np.zeros(system_size)
+
+    h = config.dt
+    if config.steps > 0:
+        nsteps = config.steps
+    else:
+        nsteps = int(math.floor(config.tend / config.dt)) + 1
+
+    step_on = int(config.ton / h)
+    step_off = int(config.toff / h)
+
+    tol = config.herk_alg_tol
+    max_iter = config.herk_alg_max_iter
+
+    tvec = np.linspace(0, nsteps * h, nsteps)
+    history = np.zeros((system_size, nsteps))
+    z = z0
+
+    NDIFFEQ = psys.num_dof_dif
+    alg_size = psys.num_dof_alg
+
+    for i in range(nsteps):
+        z = herk_step(z, theta, h, psys, A, b, c, F, J, tol, max_iter)
+        history[:, i] = z
+
+        if i == step_on and len(psys.fault_events) > 0:
+            psys.fault_events[0].apply()
+            x = z[:NDIFFEQ]
+            y = z[NDIFFEQ:NDIFFEQ + alg_size]
+            v = z[NDIFFEQ + alg_size:]
+            y_new, v_new, _ = solve_stage_algebraic(
+                x, y, v, theta, psys, F, J, tol, max_iter)
+            z = np.concatenate([x, y_new, v_new])
+
+        if i == step_off and len(psys.fault_events) > 0:
+            psys.fault_events[0].remove()
+            x = z[:NDIFFEQ]
+            y = z[NDIFFEQ:NDIFFEQ + alg_size]
+            v = z[NDIFFEQ + alg_size:]
+            y_new, v_new, _ = solve_stage_algebraic(
+                x, y, v, theta, psys, F, J, tol, max_iter)
+            z = np.concatenate([x, y_new, v_new])
+
+    if nsteps - 1 < step_off and len(psys.fault_events) > 0:
+        psys.fault_events[0].remove()
+
+    return {"tvec": tvec, "history": history}


### PR DESCRIPTION
This PR adds a half-explicit Runge-Kutta integrator path for UQGrid's semi-explicit index-1 DAE, where the dynamic simulation state is split as `z = [x; y; v]` with differential machine/controller states `x`, device algebraic states `y`, and network voltage states `v`. The existing backward-Euler method solves the full coupled DAE implicitly each step; the new HERK path advances only `x` explicitly while enforcing algebraic consistency in `(y, v)` at every RK stage.

For each stage, HERK forms `X_i = x_n + h * sum(a_ij K_j)`, freezes that differential stage state, and solves `g(X_i, Y_i, V_i) = 0` with Newton over the algebraic block. The stage derivative is then `K_i = f(X_i, Y_i, V_i)`, and the final differential update is `x_{n+1} = x_n + h * sum(b_i K_i)`, followed by one final algebraic consistency solve. The implementation includes Heun RK2 and classical RK4 tableaus.

The algebraic Newton solve reuses the existing residual and Jacobian assembly: it evaluates the full residual, slices `F[NDIFFEQ:]` as the algebraic residual, and solves against the `J[NDIFFEQ:, NDIFFEQ:]` block..