### PR TITLE
Forced oscillation module

### DIFF
--- a/bin/activsg200_osl.py
+++ b/bin/activsg200_osl.py
@@ -1,0 +1,185 @@
+"""Example: generate one OSL-style case on ACTIVSg200 and plot it.
+
+Injects two signal sources into the ACTIVSg200 dynamics simulation:
+  * a ~0.8 Hz sinusoidal forced oscillation on the TGOV1 governor pref
+    of generator at PSSE bus 49,
+  * colored load noise on every load (low- + high-frequency components).
+
+Then runs the case through the PMU emulator and produces three plots:
+  1. raw bus-voltage magnitude trajectories (sim-rate),
+  2. PMU bus-voltage magnitude at a handful of observed buses,
+  3. PMU branch current magnitude at observed branches.
+
+Reference
+---------
+Maslennikov, S. and Wang, B. (2022). NREL/CP-6A40-81394.
+https://www.nrel.gov/docs/fy22osti/81394.pdf
+
+Usage
+-----
+    python bin/activsg200_osl.py [--outdir plots/osl] [--tend 20.0]
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+from uqgrid.osl import (
+    ColoredNoise,
+    ForcedOscillation,
+    PMUEmulator,
+    build_osl_case,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_RAW = REPO_ROOT / "data" / "ACTIVSg200.raw"
+DEFAULT_DYR = REPO_ROOT / "data" / "ACTIVSg200.dyr"
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--raw", default=str(DEFAULT_RAW))
+    p.add_argument("--dyr", default=str(DEFAULT_DYR))
+    p.add_argument("--outdir", default="plots/osl",
+                   help="Where to write PNGs + case artifacts.")
+    p.add_argument("--tend", type=float, default=20.0)
+    p.add_argument("--dt", type=float, default=1.0 / 240.0)
+    p.add_argument("--fo-bus", type=int, default=49,
+                   help="PSSE generator bus to host the governor FO.")
+    p.add_argument("--fo-freq", type=float, default=0.8)
+    p.add_argument("--fo-amp", type=float, default=0.20,
+                   help="FO amplitude in per-unit of system MVA (TGOV1 pref).")
+    p.add_argument("--fo-start", type=float, default=2.0)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--no-noise", action="store_true",
+                   help="Disable the colored-noise injector.")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    injectors = [
+        ForcedOscillation(
+            target=("gov", args.fo_bus),
+            freq_hz=args.fo_freq,
+            amplitude=args.fo_amp,
+            t_start=args.fo_start,
+            t_end=args.tend,
+            waveform="sine",
+        ),
+    ]
+    noise = None if args.no_noise else ColoredNoise(
+        sigma_lf=0.002, sigma_hf=0.001, seed=args.seed,
+    )
+
+    case = build_osl_case(
+        raw=args.raw,
+        dyr=args.dyr,
+        forced_oscillations=injectors,
+        colored_noise=noise if noise is not None else False,
+        tend=args.tend,
+        dt=args.dt,
+        pmu=PMUEmulator(
+            rate_hz=30.0,
+            p_class_fraction=0.7,
+            observed_buses="50%",
+            missing_rate=0.0,
+            seed=args.seed,
+        ),
+        label=f"ACTIVSg200_gov{args.fo_bus}_{args.fo_freq:g}Hz",
+        keep_raw=True,
+    )
+
+    safe_label = case.metadata["label"].replace(".", "p")
+    stem = outdir / safe_label
+    npz, js = case.export(stem)
+    print(f"wrote {npz}\nwrote {js}")
+
+    _plot_raw_voltages(case, args, stem)
+    _plot_pmu_voltages(case, args, stem)
+    _plot_pmu_currents(case, stem)
+
+
+def _plot_raw_voltages(case, args, stem: Path):
+    history = case.raw_history
+    tvec = case.raw_tvec
+    psys_nbuses = (history.shape[0] - 0) // 1  # not needed; recover from metadata
+    nbus = case.metadata["system"]["nbuses"]
+    v_block = history[-2 * nbus:, :]
+    vr = v_block[0::2, :]
+    vi = v_block[1::2, :]
+    vm = np.sqrt(vr ** 2 + vi ** 2)
+
+    obs_psse = case.pmu["observed_buses_psse"].tolist()
+    obs_int = case.pmu["observed_buses_internal"].tolist()
+    sel = obs_int[:5]
+    sel_labels = obs_psse[:5]
+
+    fig, ax = plt.subplots(figsize=(9, 4))
+    for k, b_int in enumerate(sel):
+        ax.plot(tvec, vm[b_int, :], lw=0.8, label=f"PSSE bus {sel_labels[k]}")
+    ax.axvline(args.fo_start, color="k", lw=0.5, ls="--",
+               label=f"FO on at t={args.fo_start:g}s")
+    ax.set_xlabel("time (s)")
+    ax.set_ylabel("|V| (pu)")
+    ax.set_title("Raw bus voltage magnitudes (simulation rate)")
+    ax.legend(loc="best", fontsize=8)
+    fig.tight_layout()
+    fig.savefig(stem.with_suffix(".raw_voltages.png"), dpi=130)
+    plt.close(fig)
+
+
+def _plot_pmu_voltages(case, args, stem: Path):
+    pmu = case.pmu
+    t = pmu["t"]
+    V = pmu["V_mag"]
+    obs = pmu["observed_buses_psse"].tolist()
+
+    fig, ax = plt.subplots(figsize=(9, 4))
+    for k in range(min(5, V.shape[0])):
+        ax.plot(t, V[k, :], lw=0.8, label=f"PSSE bus {obs[k]} ({pmu['pmu_class'][k]})")
+    ax.axvline(args.fo_start, color="k", lw=0.5, ls="--")
+    ax.set_xlabel("time (s)")
+    ax.set_ylabel("|V| (pu)")
+    ax.set_title(f"PMU voltages — {pmu['rate_hz']:.0f} Hz, "
+                 f"FO {args.fo_freq:g} Hz at gen bus {args.fo_bus}")
+    ax.legend(loc="best", fontsize=8)
+    fig.tight_layout()
+    fig.savefig(stem.with_suffix(".pmu_voltages.png"), dpi=130)
+    plt.close(fig)
+
+
+def _plot_pmu_currents(case, stem: Path):
+    pmu = case.pmu
+    if pmu["I_mag"].size == 0:
+        return
+    t = pmu["t"]
+    I = pmu["I_mag"]
+    branches = pmu["branches"]
+
+    fig, ax = plt.subplots(figsize=(9, 4))
+    for k in range(min(5, I.shape[0])):
+        fr, to = branches[k]
+        ax.plot(t, I[k, :], lw=0.8, label=f"branch {fr}->{to}")
+    ax.set_xlabel("time (s)")
+    ax.set_ylabel("|I| (pu)")
+    ax.set_title("PMU branch currents (sample)")
+    ax.legend(loc="best", fontsize=8)
+    fig.tight_layout()
+    fig.savefig(stem.with_suffix(".pmu_currents.png"), dpi=130)
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/osl/README.md
+++ b/scripts/osl/README.md
@@ -1,0 +1,93 @@
+# OSL Dataset Scripts
+
+Lightweight scripts for generating Oscillation Source Location style PMU data.
+
+This script is for batch data generation: many cases, no plots, plus a manifest
+for training loaders.
+
+## Generate A Small Dataset
+
+Run from the repository root:
+
+```bash
+python scripts/osl/generate_dataset.py scripts/osl/configs/activsg200_small.json
+```
+
+The sample config uses `data/ACTIVSg200.raw` and `data/ACTIVSg200.dyr`, injects
+governor forced oscillations at PSSE bus 49, and sweeps:
+
+- frequencies: `0.6`, `0.8`, `1.0` Hz
+- amplitudes: `0.10`, `0.20`
+- colored load noise: enabled
+- PMU buses: all buses, for stable channel order across cases
+
+The same defaults can still be run without a config:
+
+```bash
+python scripts/osl/generate_dataset.py --outdir outputs/osl_dataset --tend 8.0
+```
+
+For a quick smoke run:
+
+```bash
+python scripts/osl/generate_dataset.py scripts/osl/configs/activsg200_small.json \
+  --outdir /tmp/osl_smoke --tend 0.5 --fo-start 0.1 --limit 1 --overwrite
+```
+
+## Output Layout
+
+```text
+outputs/osl_dataset/
+  manifest.jsonl
+  cases/
+    case_0000.npz
+    case_0000.json
+    case_0001.npz
+    case_0001.json
+```
+
+Each `.npz` stores PMU arrays such as `V_mag`, `V_ang`, `I_mag`, `I_ang`,
+`observed_buses_psse`, `branches`, masks, PMU classes, and the PMU time vector.
+Each `.json` stores metadata: source label, target, frequency, amplitude,
+simulation settings, noise settings, and PMU settings.
+
+`manifest.jsonl` has one row per case with the relative `.npz`/`.json` paths and
+the main labels needed by a training script.
+
+## Useful Options
+
+Config files and command-line flags can be combined. Values are applied in this
+order:
+
+```text
+built-in defaults < JSON config < command-line flags
+```
+
+```bash
+# Generate only three cases
+python scripts/osl/generate_dataset.py scripts/osl/configs/activsg200_small.json --limit 3 --overwrite
+
+# Use 50% randomly observed buses instead of all buses
+python scripts/osl/generate_dataset.py scripts/osl/configs/activsg200_small.json --observed-buses "50%" --overwrite
+
+# Sweep two known governor buses
+python scripts/osl/generate_dataset.py scripts/osl/configs/activsg200_small.json --fo-buses 49 50 --freqs 0.8 1.0 --overwrite
+
+# Disable colored load noise
+python scripts/osl/generate_dataset.py scripts/osl/configs/activsg200_small.json --no-noise --overwrite
+```
+
+For plain tensor models, prefer `--observed-buses all` or an explicit
+comma-separated bus list so channel order is stable across cases.
+
+## Config File
+
+The sample config is:
+
+```text
+scripts/osl/configs/activsg200_small.json
+```
+
+It uses the same key names as the command-line options, with underscores instead
+of dashes. For example, `fo_start` matches `--fo-start`, and `pmu_rate_hz`
+matches `--pmu-rate-hz`.

--- a/scripts/osl/configs/activsg200_small.json
+++ b/scripts/osl/configs/activsg200_small.json
@@ -1,0 +1,22 @@
+{
+  "raw": "data/ACTIVSg200.raw",
+  "dyr": "data/ACTIVSg200.dyr",
+  "outdir": "outputs/osl_dataset/activsg200_small",
+  "tend": 8.0,
+  "dt": 0.004166666666666667,
+  "fo_start": 2.0,
+  "fo_buses": [49],
+  "freqs": [0.6, 0.8, 1.0],
+  "amplitudes": [0.1, 0.2],
+  "seed_start": 1000,
+  "limit": null,
+  "observed_buses": "all",
+  "pmu_rate_hz": 30.0,
+  "p_class_fraction": 0.7,
+  "missing_rate": 0.0,
+  "colored_noise": true,
+  "noise_sigma_lf": 0.002,
+  "noise_sigma_hf": 0.001,
+  "noise_tau_lf_range": [0.5, 5.0],
+  "overwrite": false
+}

--- a/scripts/osl/generate_dataset.py
+++ b/scripts/osl/generate_dataset.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python
+"""Generate a small OSL-style PMU dataset.
+
+Light batch driver: it defines a compact scenario grid,
+runs ``uqgrid.osl.build_osl_case`` for each scenario, and writes paired
+``.npz``/``.json`` case files plus a ``manifest.jsonl`` index.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+# Keep numerical libraries from oversubscribing if the script is launched in a
+# larger batch job. This script itself runs serially.
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("MKL_NUM_THREADS", "1")
+os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+os.environ.setdefault("NUMEXPR_NUM_THREADS", "1")
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_RAW = REPO_ROOT / "data" / "ACTIVSg200.raw"
+DEFAULT_DYR = REPO_ROOT / "data" / "ACTIVSg200.dyr"
+
+DEFAULT_CONFIG = {
+    "raw": str(DEFAULT_RAW),
+    "dyr": str(DEFAULT_DYR),
+    "outdir": "outputs/osl_dataset",
+    "tend": 8.0,
+    "dt": 1.0 / 240.0,
+    "fo_start": 2.0,
+    "fo_buses": [49],
+    "freqs": [0.6, 0.8, 1.0],
+    "amplitudes": [0.10, 0.20],
+    "seed_start": 1000,
+    "limit": None,
+    "observed_buses": "all",
+    "pmu_rate_hz": 30.0,
+    "p_class_fraction": 0.70,
+    "missing_rate": 0.0,
+    "colored_noise": True,
+    "noise_sigma_lf": 0.002,
+    "noise_sigma_hf": 0.001,
+    "noise_tau_lf_range": [0.5, 5.0],
+    "overwrite": False,
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("config", nargs="?", help="Optional JSON config path.")
+    parser.add_argument("--config", dest="config_option", help="Optional JSON config path.")
+    parser.add_argument("--raw", default=argparse.SUPPRESS)
+    parser.add_argument("--dyr", default=argparse.SUPPRESS)
+    parser.add_argument("--outdir", default=argparse.SUPPRESS)
+    parser.add_argument("--tend", type=float, default=argparse.SUPPRESS)
+    parser.add_argument("--dt", type=float, default=argparse.SUPPRESS)
+    parser.add_argument("--fo-start", type=float, default=argparse.SUPPRESS)
+    parser.add_argument("--fo-buses", type=int, nargs="+", default=argparse.SUPPRESS)
+    parser.add_argument("--freqs", type=float, nargs="+", default=argparse.SUPPRESS)
+    parser.add_argument("--amplitudes", type=float, nargs="+", default=argparse.SUPPRESS)
+    parser.add_argument("--seed-start", type=int, default=argparse.SUPPRESS)
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=argparse.SUPPRESS,
+        help="Run only the first N scenarios.",
+    )
+    parser.add_argument(
+        "--observed-buses",
+        default=argparse.SUPPRESS,
+        help='PMU bus set: "all", a percent like "50%%", or comma-separated PSSE buses.',
+    )
+    parser.add_argument("--pmu-rate-hz", type=float, default=argparse.SUPPRESS)
+    parser.add_argument("--p-class-fraction", type=float, default=argparse.SUPPRESS)
+    parser.add_argument("--missing-rate", type=float, default=argparse.SUPPRESS)
+    parser.add_argument(
+        "--colored-noise",
+        dest="colored_noise",
+        action="store_true",
+        default=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--no-noise",
+        dest="colored_noise",
+        action="store_false",
+        default=argparse.SUPPRESS,
+    )
+    parser.add_argument("--noise-sigma-lf", type=float, default=argparse.SUPPRESS)
+    parser.add_argument("--noise-sigma-hf", type=float, default=argparse.SUPPRESS)
+    parser.add_argument("--noise-tau-lf-range", type=float, nargs=2, default=argparse.SUPPRESS)
+    parser.add_argument("--overwrite", action="store_true", default=argparse.SUPPRESS)
+
+    parsed = parser.parse_args()
+    cli_values = vars(parsed).copy()
+    config_path = cli_values.pop("config", None)
+    config_option = cli_values.pop("config_option", None)
+    if config_path and config_option:
+        parser.error("pass only one config path, either positional or --config")
+    config_path = config_path or config_option
+
+    config = DEFAULT_CONFIG.copy()
+    if config_path:
+        config.update(load_config(config_path))
+    config.update(cli_values)
+    config["config"] = config_path
+    return argparse.Namespace(**config)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    config_path = Path(path)
+    with config_path.open() as f:
+        config = json.load(f)
+    unknown = sorted(set(config) - set(DEFAULT_CONFIG))
+    if unknown:
+        raise SystemExit(f"{config_path} contains unknown keys: {', '.join(unknown)}")
+    return config
+
+
+def parse_observed_buses(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return [int(bus) for bus in value]
+    if value.lower() == "all":
+        return None
+    if value.endswith("%"):
+        return value
+    return [int(part) for part in value.split(",") if part.strip()]
+
+
+def scenario_label(kind: str, bus: int, freq_hz: float, amplitude: float, seed: int) -> str:
+    freq = f"{freq_hz:g}".replace(".", "p")
+    amp = f"{amplitude:g}".replace(".", "p")
+    return f"{kind}{bus}_f{freq}_a{amp}_s{seed}"
+
+
+def iter_scenarios(args: argparse.Namespace) -> list[dict[str, Any]]:
+    scenarios = []
+    for idx, (bus, freq_hz, amplitude) in enumerate(
+        itertools.product(args.fo_buses, args.freqs, args.amplitudes)
+    ):
+        seed = args.seed_start + idx
+        scenarios.append({
+            "case_id": f"case_{idx:04d}",
+            "label": scenario_label("gov", bus, freq_hz, amplitude, seed),
+            "target": ("gov", bus),
+            "freq_hz": freq_hz,
+            "amplitude": amplitude,
+            "seed": seed,
+        })
+    if args.limit is not None:
+        scenarios = scenarios[:args.limit]
+    return scenarios
+
+
+def main() -> None:
+    args = parse_args()
+    from uqgrid.osl import ColoredNoise, ForcedOscillation, PMUEmulator, build_osl_case
+
+    outdir = Path(args.outdir)
+    cases_dir = outdir / "cases"
+    manifest_path = outdir / "manifest.jsonl"
+
+    if manifest_path.exists() and not args.overwrite:
+        raise SystemExit(f"{manifest_path} exists; pass --overwrite to replace it.")
+
+    cases_dir.mkdir(parents=True, exist_ok=True)
+    scenarios = iter_scenarios(args)
+    observed_buses = parse_observed_buses(args.observed_buses)
+
+    with manifest_path.open("w") as manifest:
+        for i, scenario in enumerate(scenarios, start=1):
+            print(f"[{i}/{len(scenarios)}] {scenario['label']}")
+            noise = False
+            if args.colored_noise:
+                noise = ColoredNoise(
+                    sigma_lf=args.noise_sigma_lf,
+                    sigma_hf=args.noise_sigma_hf,
+                    tau_lf_range=tuple(args.noise_tau_lf_range),
+                    seed=scenario["seed"],
+                )
+            case = build_osl_case(
+                raw=args.raw,
+                dyr=args.dyr,
+                forced_oscillations=[
+                    ForcedOscillation(
+                        target=scenario["target"],
+                        freq_hz=scenario["freq_hz"],
+                        amplitude=scenario["amplitude"],
+                        t_start=args.fo_start,
+                        t_end=args.tend,
+                    )
+                ],
+                colored_noise=noise,
+                tend=args.tend,
+                dt=args.dt,
+                pmu=PMUEmulator(
+                    rate_hz=args.pmu_rate_hz,
+                    p_class_fraction=args.p_class_fraction,
+                    observed_buses=observed_buses,
+                    missing_rate=args.missing_rate,
+                    seed=scenario["seed"],
+                ),
+                label=scenario["label"],
+            )
+            stem = cases_dir / scenario["case_id"]
+            npz_path, json_path = case.export(stem)
+            row = {
+                **scenario,
+                "target": list(scenario["target"]),
+                "npz": str(npz_path.relative_to(outdir)),
+                "json": str(json_path.relative_to(outdir)),
+                "n_observed_buses": int(case.pmu["observed_buses_internal"].shape[0]),
+                "n_pmu_samples": int(case.pmu["t"].shape[0]),
+                "config": args.config,
+            }
+            manifest.write(json.dumps(row) + "\n")
+
+    print(f"wrote {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_osl_scenario.py
+++ b/tests/test_osl_scenario.py
@@ -1,0 +1,135 @@
+"""Correctness tests for uqgrid.osl on the 2-bus PSSE fixture.
+
+Asserts:
+1. Empty signal_injectors produces bit-identical results to the baseline
+   integration path (zero-overhead regression guard).
+2. ForcedOscillation resolves the right theta index for a load target and
+   mutates theta in place at every integration step (within its active
+   interval).
+3. build_osl_case wires the integrator + PMU emulator together, produces
+   PMU output with the right shape, and round-trips through .export().
+"""
+
+from pathlib import Path
+
+import json
+
+import numpy as np
+
+from uqgrid.io.parse import load_psse, add_dyr
+from uqgrid.simulation.config import IntegrationConfig
+from uqgrid.simulation.dynamics import integrate_system
+
+from uqgrid.osl import (
+    build_osl_case,
+    ForcedOscillation,
+    PMUEmulator,
+)
+from uqgrid.osl.injectors import LOAD_PL_OFFSET
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RAW = REPO_ROOT / "data" / "2bus_33.raw"
+DYR = REPO_ROOT / "data" / "2bus_TGOV1.dyr"
+
+SIM_TEND = 2.0
+SIM_DT = 1.0 / 240.0
+
+
+def _build_psys():
+    psys = load_psse(str(RAW))
+    add_dyr(psys, str(DYR))
+    psys.createYbusComplex()
+    return psys
+
+
+def test_zero_overhead_when_no_injectors():
+    """Empty signal_injectors must produce bit-identical results."""
+    psys_a = _build_psys()
+    cfg = IntegrationConfig(tend=SIM_TEND, dt=SIM_DT, method="beuler")
+    res_a = integrate_system(psys_a, cfg)
+
+    psys_b = _build_psys()
+    assert psys_b.signal_injectors == []
+    res_b = integrate_system(psys_b, cfg)
+
+    np.testing.assert_array_equal(res_a["history"], res_b["history"])
+    np.testing.assert_array_equal(res_a["tvec"], res_b["tvec"])
+
+
+def test_forced_oscillation_resolves_and_mutates_theta():
+    """Injector must resolve the right theta index and mutate it on update."""
+    psys = _build_psys()
+    load = psys.loads[0]
+    expected_idx = load.par_ptr + LOAD_PL_OFFSET
+    psse_bus = next(k for k, v in psys.ext2int.items() if v == load.bus)
+
+    fo = ForcedOscillation(
+        target=("load_p", psse_bus),
+        freq_hz=1.0,
+        amplitude=0.1,
+        t_start=0.5,
+        t_end=1.5,
+        waveform="sine",
+    )
+
+    theta = np.zeros(psys.num_pars)
+    theta[expected_idx] = load.pload  # mimic initialize_theta
+    theta[load.par_ptr + 4] = 1.0     # v0
+    theta0 = theta.copy()
+
+    fo.update(0.0, theta, psys)
+    assert fo._par_idx == expected_idx
+    # before t_start: theta restored to baseline
+    np.testing.assert_allclose(theta[expected_idx], theta0[expected_idx])
+
+    fo.update(0.75, theta, psys)
+    # inside active window with phase 0, sin(2π·1·0.75) = -1 → -amplitude
+    assert theta[expected_idx] != theta0[expected_idx]
+    np.testing.assert_allclose(
+        theta[expected_idx] - theta0[expected_idx],
+        0.1 * np.sin(2.0 * np.pi * 0.75),
+        atol=1e-12,
+    )
+
+    fo.update(2.0, theta, psys)
+    # after t_end: restored to baseline
+    np.testing.assert_allclose(theta[expected_idx], theta0[expected_idx])
+
+
+def test_build_osl_case_shape_and_export(tmp_path):
+    case = build_osl_case(
+        raw=RAW,
+        dyr=DYR,
+        forced_oscillations=[
+            ForcedOscillation(
+                target=("load_p", 2),
+                freq_hz=1.0,
+                amplitude=0.05,
+                t_start=0.5,
+                t_end=SIM_TEND,
+            ),
+        ],
+        tend=SIM_TEND,
+        dt=SIM_DT,
+        pmu=PMUEmulator(rate_hz=30.0, seed=1),
+        label="2bus_test_fo",
+    )
+
+    pmu = case.pmu
+    assert pmu["V_mag"].shape[0] == 2
+    assert pmu["V_mag"].shape == pmu["V_ang"].shape
+    assert pmu["V_mag"].shape[1] == pmu["t"].shape[0]
+    assert pmu["t"][-1] <= SIM_TEND + SIM_DT * 2
+    assert pmu["pmu_class"].shape == (2,)
+    assert set(pmu["pmu_class"].tolist()).issubset({"P", "M"})
+
+    npz_path, json_path = case.export(tmp_path / "case")
+    assert npz_path.exists() and json_path.exists()
+    loaded = np.load(npz_path)
+    assert "V_mag" in loaded.files
+
+    meta = json.loads(json_path.read_text())
+    assert meta["sources"][0]["kind"] == "load_p"
+    assert meta["sources"][0]["freq_hz"] == 1.0
+    assert meta["pmu"]["rate_hz"] == 30.0

--- a/tests/test_osl_scenario.py
+++ b/tests/test_osl_scenario.py
@@ -6,7 +6,8 @@ Asserts:
 2. ForcedOscillation resolves the right theta index for a load target and
    mutates theta in place at every integration step (within its active
    interval).
-3. build_osl_case wires the integrator + PMU emulator together, produces
+3. ColoredNoise mutates load P/Q in a way that reaches the load residual.
+4. build_osl_case wires the integrator + PMU emulator together, produces
    PMU output with the right shape, and round-trips through .export().
 """
 
@@ -22,10 +23,11 @@ from uqgrid.simulation.dynamics import integrate_system
 
 from uqgrid.osl import (
     build_osl_case,
+    ColoredNoise,
     ForcedOscillation,
     PMUEmulator,
 )
-from uqgrid.osl.injectors import LOAD_PL_OFFSET
+from uqgrid.osl.injectors import LOAD_PL_OFFSET, LOAD_QL_OFFSET
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -95,6 +97,58 @@ def test_forced_oscillation_resolves_and_mutates_theta():
     fo.update(2.0, theta, psys)
     # after t_end: restored to baseline
     np.testing.assert_allclose(theta[expected_idx], theta0[expected_idx])
+
+
+def test_colored_noise_refreshes_load_admittance_for_impedance_loads():
+    """ColoredNoise must update the impedance entries used when alpha == 1."""
+    psys = _build_psys()
+    load = psys.loads[0]
+    pp = load.par_ptr
+
+    theta = np.zeros(psys.num_pars)
+    theta[pp + LOAD_PL_OFFSET] = load.pload
+    theta[pp + LOAD_QL_OFFSET] = load.qload
+    theta[pp + 2] = 1.0  # default ZIP alpha: pure impedance
+    theta[pp + 3] = load.weight
+    theta[pp + 4] = 1.0  # v0
+    theta[pp + 5] = load.pload
+    theta[pp + 6] = load.qload
+    before = theta.copy()
+
+    noise = ColoredNoise(
+        sigma_lf=0.2,
+        sigma_hf=0.1,
+        tau_lf_range=(1.0, 1.0),
+        seed=7,
+    )
+
+    noise.update(0.0, theta, psys)
+
+    assert not np.allclose(theta[pp:pp + 2], before[pp:pp + 2])
+    assert not np.allclose(theta[pp + 5:pp + 7], before[pp + 5:pp + 7])
+    np.testing.assert_allclose(theta[pp + 5], theta[pp] / theta[pp + 4] ** 2)
+    np.testing.assert_allclose(theta[pp + 6], theta[pp + 1] / theta[pp + 4] ** 2)
+
+
+def test_colored_noise_changes_default_impedance_load_trajectory():
+    """Default alpha == 1 loads should still feel ColoredNoise in dynamics."""
+    cfg = IntegrationConfig(tend=0.5, dt=SIM_DT, method="beuler")
+
+    psys_a = _build_psys()
+    baseline = integrate_system(psys_a, cfg)
+
+    psys_b = _build_psys()
+    psys_b.add_signal_injector(
+        ColoredNoise(
+            sigma_lf=0.2,
+            sigma_hf=0.1,
+            tau_lf_range=(1.0, 1.0),
+            seed=7,
+        )
+    )
+    noisy = integrate_system(psys_b, cfg)
+
+    assert not np.allclose(noisy["history"], baseline["history"], rtol=0.0, atol=1e-12)
 
 
 def test_build_osl_case_shape_and_export(tmp_path):

--- a/uqgrid/core/psydef.py
+++ b/uqgrid/core/psydef.py
@@ -399,6 +399,10 @@ class Psystem:
 
         self.fault_events = []
 
+        # OSL signal injectors (forced oscillations, colored noise).
+        # See uqgrid/osl/. Empty by default → zero-overhead in integrators.
+        self.signal_injectors = []
+
         # Dynamic devices
         self.gendyn = []
         self.static_gens = []
@@ -492,6 +496,9 @@ class Psystem:
 
     def add_busfault(self, bus, rfault):
         self.fault_events.append(BusFault(bus, rfault))
+
+    def add_signal_injector(self, injector):
+        self.signal_injectors.append(injector)
 
     def add_gen_dynamics(self, gen, gendynamics):
         assert isinstance(gen, Generator)

--- a/uqgrid/osl/__init__.py
+++ b/uqgrid/osl/__init__.py
@@ -1,0 +1,48 @@
+"""uqgrid.osl — Oscillation Source Location case generation.
+
+Generates synthetic PMU datasets with labeled forced-oscillation sources
+and colored-noise loads, in the style of the 2021 IEEE-NASPI Oscillation
+Source Location Contest cases.
+
+Reference
+---------
+Maslennikov, S. and Wang, B. (2022). *Creation of Simulated Test Cases
+for the Oscillation Source Location Contest.* NREL/CP-6A40-81394.
+2022 IEEE PES General Meeting.
+https://www.nrel.gov/docs/fy22osti/81394.pdf
+
+Quick start
+-----------
+    from uqgrid.osl import build_osl_case, ForcedOscillation
+
+    case = build_osl_case(
+        raw="data/ACTIVSg200.raw",
+        dyr="data/ACTIVSg200.dyr",
+        forced_oscillations=[
+            ForcedOscillation(target=("gov", 7), freq_hz=0.82,
+                              amplitude=0.02, t_start=5.0, t_end=30.0),
+        ],
+        colored_noise=True,
+        tend=30.0, dt=1/240,
+        pmu=dict(rate_hz=30, observed_buses="50%", missing_rate=0.001, seed=42),
+        label="ACTIVSg200_case01",
+    )
+    case.export("cases/ACTIVSg200_case01")
+"""
+
+from .injectors import (
+    SignalInjector,
+    ForcedOscillation,
+    ColoredNoise,
+)
+from .pmu import PMUEmulator
+from .scenario import OSLCase, build_osl_case
+
+__all__ = [
+    "SignalInjector",
+    "ForcedOscillation",
+    "ColoredNoise",
+    "PMUEmulator",
+    "OSLCase",
+    "build_osl_case",
+]

--- a/uqgrid/osl/injectors.py
+++ b/uqgrid/osl/injectors.py
@@ -207,6 +207,9 @@ class ColoredNoise(SignalInjector):
     _rng: np.random.Generator = field(default=None, init=False, repr=False)
     _load_p_idx: np.ndarray = field(default=None, init=False, repr=False)
     _load_q_idx: np.ndarray = field(default=None, init=False, repr=False)
+    _load_v0_idx: np.ndarray = field(default=None, init=False, repr=False)
+    _load_yr_idx: np.ndarray = field(default=None, init=False, repr=False)
+    _load_yi_idx: np.ndarray = field(default=None, init=False, repr=False)
     _theta0_p: np.ndarray = field(default=None, init=False, repr=False)
     _theta0_q: np.ndarray = field(default=None, init=False, repr=False)
     _lf_value_p: np.ndarray = field(default=None, init=False, repr=False)
@@ -219,6 +222,9 @@ class ColoredNoise(SignalInjector):
         nloads = len(psys.loads)
         self._load_p_idx = np.array([l.par_ptr + LOAD_PL_OFFSET for l in psys.loads], dtype=np.int64)
         self._load_q_idx = np.array([l.par_ptr + LOAD_QL_OFFSET for l in psys.loads], dtype=np.int64)
+        self._load_v0_idx = np.array([l.par_ptr + 4 for l in psys.loads], dtype=np.int64)
+        self._load_yr_idx = np.array([l.par_ptr + 5 for l in psys.loads], dtype=np.int64)
+        self._load_yi_idx = np.array([l.par_ptr + 6 for l in psys.loads], dtype=np.int64)
         self._lf_value_p = np.zeros(nloads)
         self._lf_value_q = np.zeros(nloads)
         self._lf_next_change = np.full(nloads, t)
@@ -251,3 +257,10 @@ class ColoredNoise(SignalInjector):
         if self.apply_to_q:
             hf_q = self._rng.uniform(-self.sigma_hf, self.sigma_hf, size=self._theta0_q.size) * scale_q
             theta[self._load_q_idx] = self._theta0_q + self._lf_value_q + hf_q
+
+        v0 = theta[self._load_v0_idx]
+        valid = v0 > 0.0
+        if np.any(valid):
+            inv_v02 = 1.0 / (v0[valid] * v0[valid])
+            theta[self._load_yr_idx[valid]] = theta[self._load_p_idx[valid]] * inv_v02
+            theta[self._load_yi_idx[valid]] = theta[self._load_q_idx[valid]] * inv_v02

--- a/uqgrid/osl/injectors.py
+++ b/uqgrid/osl/injectors.py
@@ -1,0 +1,253 @@
+"""Signal injectors for forced oscillations and colored-noise loads.
+
+Each injector exposes ``update(t, theta, psys)`` and is appended to
+``psys.signal_injectors``. The dynamics integrator calls ``update`` once
+per step before solving, mutating ``theta`` in place. Empty injector
+list means zero overhead.
+
+Targeted theta offsets are model-specific and documented inline:
+
+* TGOV1 ``pref``  at ``gov.par_ptr + 8`` (uqgrid/models/tgov1_imp.py:141)
+* SEXS  ``vref``  at ``exc.par_ptr + 7`` (uqgrid/models/sexs_imp.py:120)
+* Load  ``pl,ql`` at ``load.par_ptr + 0/+1`` (uqgrid/models/load_imp.py:15-16)
+
+Reference
+---------
+Maslennikov, S. and Wang, B. (2022). *Creation of Simulated Test Cases
+for the Oscillation Source Location Contest.* NREL/CP-6A40-81394.
+2022 IEEE PES General Meeting.
+https://www.nrel.gov/docs/fy22osti/81394.pdf
+
+The forced-oscillation injectors implement §III-C (sinusoidal and
+rectangular forcing in TGOV1 governors, SEXS exciters, and loads). The
+colored-noise injector implements §III-D (sum of low- and high-frequency
+random components on every load).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+
+
+TGOV1_PREF_OFFSET = 8
+SEXS_VREF_OFFSET = 7
+LOAD_PL_OFFSET = 0
+LOAD_QL_OFFSET = 1
+
+
+def _resolve_bus(psys, bus) -> int:
+    """Accept an internal bus index or a PSSE bus number; return internal index."""
+    if hasattr(psys, "ext2int") and bus in psys.ext2int:
+        return psys.ext2int[bus]
+    if 0 <= int(bus) < psys.nbuses:
+        return int(bus)
+    raise KeyError(f"Bus {bus!r} not found (neither internal index nor PSSE id).")
+
+
+def _find_governor_param(psys, bus_internal: int, tag=None) -> int:
+    matches = [g for g in psys.gov if g.bus == bus_internal and (tag is None or str(g.id_tag) == str(tag))]
+    if not matches:
+        raise ValueError(f"No governor found at internal bus {bus_internal} (tag={tag}).")
+    if len(matches) > 1:
+        raise ValueError(f"Multiple governors at bus {bus_internal}; specify tag.")
+    return matches[0].par_ptr + TGOV1_PREF_OFFSET
+
+
+def _find_exciter_param(psys, bus_internal: int, tag=None) -> int:
+    matches = [e for e in psys.exc if e.bus == bus_internal and (tag is None or str(e.id_tag) == str(tag))]
+    if not matches:
+        raise ValueError(f"No exciter found at internal bus {bus_internal} (tag={tag}).")
+    if len(matches) > 1:
+        raise ValueError(f"Multiple exciters at bus {bus_internal}; specify tag.")
+    return matches[0].par_ptr + SEXS_VREF_OFFSET
+
+
+def _find_load_params(psys, bus_internal: int, tag=None) -> Tuple[int, int]:
+    matches = [l for l in psys.loads if l.bus == bus_internal and (tag is None or str(l.id_tag) == str(tag))]
+    if not matches:
+        raise ValueError(f"No load found at internal bus {bus_internal} (tag={tag}).")
+    if len(matches) > 1:
+        raise ValueError(f"Multiple loads at bus {bus_internal}; specify tag.")
+    load = matches[0]
+    return load.par_ptr + LOAD_PL_OFFSET, load.par_ptr + LOAD_QL_OFFSET
+
+
+class SignalInjector(ABC):
+    """Base class. Subclasses mutate theta in place every integration step."""
+
+    @abstractmethod
+    def update(self, t: float, theta: np.ndarray, psys) -> None:
+        ...
+
+
+@dataclass
+class ForcedOscillation(SignalInjector):
+    """Periodic forced oscillation on a single device parameter.
+
+    Parameters
+    ----------
+    target : tuple
+        One of:
+          ``("gov", bus)``       -> TGOV1 pref
+          ``("exc", bus)``       -> SEXS vref
+          ``("load_p", bus)``    -> load active power
+          ``("load_q", bus)``    -> load reactive power
+        ``bus`` may be a PSSE bus number (preferred) or internal index.
+        Optionally append a tag: ``("gov", bus, tag)``.
+    freq_hz : float
+        Fundamental forcing frequency.
+    amplitude : float
+        Peak deviation, in the *same per-unit system* as the targeted
+        parameter (e.g. p.u. on system MVA for TGOV1 pref/load).
+    t_start, t_end : float
+        Active interval in seconds (relative to t=0 of integration).
+    waveform : {"sine", "rectangular"}
+        See paper §III-C, Fig. 2.
+    harmonics : list[(rel_freq, rel_amp)], optional
+        Additional harmonic components added on top of the fundamental,
+        each ``(multiplier_of_freq, fraction_of_amplitude)``.
+    phase : float
+        Phase offset in radians (sine only).
+    """
+
+    target: Tuple
+    freq_hz: float
+    amplitude: float
+    t_start: float = 0.0
+    t_end: float = np.inf
+    waveform: str = "sine"
+    harmonics: Optional[Sequence[Tuple[float, float]]] = None
+    phase: float = 0.0
+
+    _par_idx: int = field(default=-1, init=False)
+    _theta0: float = field(default=0.0, init=False)
+    _resolved: bool = field(default=False, init=False)
+    # for load targets: paired (pl_idx, ql_idx, y_real_idx, y_imag_idx, v0)
+    _load_pair: Optional[tuple] = field(default=None, init=False, repr=False)
+
+    def _resolve(self, psys) -> None:
+        kind = self.target[0]
+        bus_user = self.target[1]
+        tag = self.target[2] if len(self.target) > 2 else None
+        bus_int = _resolve_bus(psys, bus_user)
+
+        if kind == "gov":
+            self._par_idx = _find_governor_param(psys, bus_int, tag)
+        elif kind == "exc":
+            self._par_idx = _find_exciter_param(psys, bus_int, tag)
+        elif kind in ("load_p", "load_q"):
+            p_idx, q_idx = _find_load_params(psys, bus_int, tag)
+            self._par_idx = p_idx if kind == "load_p" else q_idx
+            # cache the load's full theta block so we can keep ZIP Y entries
+            # consistent with the time-varying P/Q (load_imp.py reads
+            # theta[pp+5,+6] as the constant-admittance part).
+            self._load_pair = (p_idx, q_idx, p_idx + 5, p_idx + 6)
+        else:
+            raise ValueError(f"Unknown ForcedOscillation target kind {kind!r}.")
+        self._resolved = True
+
+    def _wave(self, t: float) -> float:
+        omega = 2.0 * np.pi * self.freq_hz
+        if self.waveform == "sine":
+            val = np.sin(omega * t + self.phase)
+        elif self.waveform == "rectangular":
+            val = 1.0 if np.sin(omega * t + self.phase) >= 0.0 else -1.0
+        else:
+            raise ValueError(f"Unknown waveform {self.waveform!r}.")
+        if self.harmonics:
+            for k, rel_amp in self.harmonics:
+                val += rel_amp * np.sin(k * omega * t + self.phase)
+        return val
+
+    def update(self, t: float, theta: np.ndarray, psys) -> None:
+        if not self._resolved:
+            self._resolve(psys)
+            self._theta0 = float(theta[self._par_idx])
+        if self.t_start <= t <= self.t_end:
+            theta[self._par_idx] = self._theta0 + self.amplitude * self._wave(t)
+        else:
+            theta[self._par_idx] = self._theta0
+        # Keep ZIP-load constant-admittance entries consistent with the new P/Q.
+        if self._load_pair is not None:
+            p_idx, q_idx, yr_idx, yi_idx = self._load_pair
+            pl = theta[p_idx]
+            ql = theta[q_idx]
+            # v0 was captured at init in load_imp; re-derive from existing y0:
+            # y0 = (pl0 + j*ql0) / v0**2  =>  v0**2 = (pl0+jql0)/y0
+            # but simplest: just refresh y = (pl + j ql) / v0**2 using the
+            # load's stored v0 (par_ptr+4).
+            v0 = theta[p_idx + 4]
+            if v0 > 0.0:
+                inv_v02 = 1.0 / (v0 * v0)
+                theta[yr_idx] = pl * inv_v02
+                theta[yi_idx] = ql * inv_v02
+
+
+@dataclass
+class ColoredNoise(SignalInjector):
+    """Additive load-power noise modelled as low-frequency + high-frequency
+    components, applied to every load's pl and ql (paper §III-D, Fig. 3).
+
+    The low-frequency component changes value at random intervals in
+    ``tau_lf_range`` seconds. The high-frequency component changes every
+    integration step. Both are zero-mean uniform variates scaled by
+    ``sigma_*`` (interpreted as a fraction of the load's nominal pl/ql).
+    """
+
+    sigma_lf: float = 0.002
+    sigma_hf: float = 0.001
+    tau_lf_range: Tuple[float, float] = (0.5, 5.0)
+    seed: Optional[int] = None
+    apply_to_q: bool = True
+
+    _rng: np.random.Generator = field(default=None, init=False, repr=False)
+    _load_p_idx: np.ndarray = field(default=None, init=False, repr=False)
+    _load_q_idx: np.ndarray = field(default=None, init=False, repr=False)
+    _theta0_p: np.ndarray = field(default=None, init=False, repr=False)
+    _theta0_q: np.ndarray = field(default=None, init=False, repr=False)
+    _lf_value_p: np.ndarray = field(default=None, init=False, repr=False)
+    _lf_value_q: np.ndarray = field(default=None, init=False, repr=False)
+    _lf_next_change: np.ndarray = field(default=None, init=False, repr=False)
+    _resolved: bool = field(default=False, init=False)
+
+    def _resolve(self, psys, t: float) -> None:
+        self._rng = np.random.default_rng(self.seed)
+        nloads = len(psys.loads)
+        self._load_p_idx = np.array([l.par_ptr + LOAD_PL_OFFSET for l in psys.loads], dtype=np.int64)
+        self._load_q_idx = np.array([l.par_ptr + LOAD_QL_OFFSET for l in psys.loads], dtype=np.int64)
+        self._lf_value_p = np.zeros(nloads)
+        self._lf_value_q = np.zeros(nloads)
+        self._lf_next_change = np.full(nloads, t)
+        self._resolved = True
+
+    def _maybe_refresh_lf(self, t: float, scale_p: np.ndarray, scale_q: np.ndarray) -> None:
+        due = t >= self._lf_next_change
+        if not np.any(due):
+            return
+        n_due = int(np.sum(due))
+        self._lf_value_p[due] = self._rng.uniform(-self.sigma_lf, self.sigma_lf, size=n_due) * scale_p[due]
+        if self.apply_to_q:
+            self._lf_value_q[due] = self._rng.uniform(-self.sigma_lf, self.sigma_lf, size=n_due) * scale_q[due]
+        dt_low, dt_high = self.tau_lf_range
+        self._lf_next_change[due] = t + self._rng.uniform(dt_low, dt_high, size=n_due)
+
+    def update(self, t: float, theta: np.ndarray, psys) -> None:
+        if not self._resolved:
+            self._resolve(psys, t)
+            self._theta0_p = theta[self._load_p_idx].copy()
+            self._theta0_q = theta[self._load_q_idx].copy()
+
+        scale_p = np.abs(self._theta0_p) + 1e-12
+        scale_q = np.abs(self._theta0_q) + 1e-12
+
+        self._maybe_refresh_lf(t, scale_p, scale_q)
+
+        hf_p = self._rng.uniform(-self.sigma_hf, self.sigma_hf, size=self._theta0_p.size) * scale_p
+        theta[self._load_p_idx] = self._theta0_p + self._lf_value_p + hf_p
+        if self.apply_to_q:
+            hf_q = self._rng.uniform(-self.sigma_hf, self.sigma_hf, size=self._theta0_q.size) * scale_q
+            theta[self._load_q_idx] = self._theta0_q + self._lf_value_q + hf_q

--- a/uqgrid/osl/pmu.py
+++ b/uqgrid/osl/pmu.py
@@ -1,0 +1,243 @@
+"""PMU-style post-processing of a uqgrid integration result.
+
+Takes the dense ``history`` returned by ``integrate_system`` and turns it
+into a PMU-shaped measurement bundle: down-sampled at the configured rate
+(default 30 Hz), masked to a configurable observed-bus set, and with
+randomly-injected missing-sample packets.
+
+The P/M-class filter is approximated by a single first-order Butterworth
+lowpass. The actual EPRI PMU Emulator referenced in the paper is more
+sophisticated; this is an admitted stand-in and the cutoff is recorded in
+the case metadata.
+
+Reference
+---------
+Maslennikov, S. and Wang, B. (2022). NREL/CP-6A40-81394, §III-A, III-E,
+III-F. https://www.nrel.gov/docs/fy22osti/81394.pdf
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Sequence, Union
+
+import numpy as np
+
+try:
+    from scipy.signal import butter, filtfilt
+    _HAS_SCIPY = True
+except ImportError:
+    _HAS_SCIPY = False
+
+
+@dataclass
+class PMUEmulator:
+    """Configurable PMU post-processor.
+
+    Parameters
+    ----------
+    rate_hz : float
+        Output sampling rate (paper uses 30 Hz).
+    p_class_fraction : float
+        Fraction of PMUs assigned P-class (rest are M-class). The paper
+        used 30% M, 70% P; we expose the P-fraction directly. Currently
+        only used as metadata + per-bus filter cutoff selection.
+    p_class_cutoff_hz, m_class_cutoff_hz : float
+        Lowpass cutoffs used as a stand-in for the actual EPRI filter.
+    observed_buses : Sequence[int] | float | str | None
+        Which buses are observed. ``None`` → all. A float in (0,1] or a
+        string like ``"50%"`` → that fraction picked at random with the
+        provided seed.
+    missing_rate : float
+        Average fraction of samples replaced by NaN (per channel),
+        applied as small packets to mimic real PMU data drops.
+    packet_size_range : (int, int)
+        Min/max packet length of consecutive missing samples.
+    seed : int | None
+        RNG seed for observability + missing-sample draws.
+    """
+
+    rate_hz: float = 30.0
+    p_class_fraction: float = 0.70
+    p_class_cutoff_hz: float = 7.0
+    m_class_cutoff_hz: float = 4.0
+    observed_buses: Union[Sequence[int], float, str, None] = None
+    missing_rate: float = 0.0
+    packet_size_range: tuple = (1, 8)
+    seed: Optional[int] = None
+
+    def _resolve_observed(self, psys, rng) -> np.ndarray:
+        if self.observed_buses is None:
+            return np.arange(psys.nbuses, dtype=np.int64)
+        if isinstance(self.observed_buses, str) and self.observed_buses.endswith("%"):
+            frac = float(self.observed_buses[:-1]) / 100.0
+        elif isinstance(self.observed_buses, float):
+            frac = float(self.observed_buses)
+        else:
+            return np.asarray([_to_internal(psys, b) for b in self.observed_buses], dtype=np.int64)
+        k = max(1, int(round(frac * psys.nbuses)))
+        return np.sort(rng.choice(psys.nbuses, size=k, replace=False)).astype(np.int64)
+
+    def _lowpass(self, x: np.ndarray, fs: float, cutoff: float) -> np.ndarray:
+        if not _HAS_SCIPY or cutoff <= 0.0 or cutoff >= fs / 2.0:
+            return x
+        b, a = butter(N=1, Wn=cutoff / (fs / 2.0), btype="low")
+        return filtfilt(b, a, x, axis=-1)
+
+    def process(self, history: np.ndarray, tvec: np.ndarray, psys) -> dict:
+        """Build the PMU bundle.
+
+        Parameters
+        ----------
+        history : ndarray, shape (sys_size, nsteps)
+            Dense state history from ``integrate_system``.
+        tvec : ndarray, shape (nsteps,)
+            Simulation time vector.
+        psys : Psystem
+
+        Returns
+        -------
+        dict with keys: t, observed_buses_internal, observed_buses_psse,
+        V_mag, V_ang, I_mag, I_ang, branches, missing_mask_V, missing_mask_I,
+        pmu_class, filter_cutoff_hz_per_bus, rate_hz.
+        """
+        rng = np.random.default_rng(self.seed)
+
+        alg_size = psys.num_dof_alg
+        dif_size = psys.num_dof_dif
+        nbus = psys.nbuses
+        v_block_start = dif_size + alg_size
+
+        nsteps = history.shape[1]
+        sim_dt = float(tvec[1] - tvec[0]) if nsteps > 1 else 1.0
+        sim_rate = 1.0 / sim_dt
+        decim = max(1, int(round(sim_rate / self.rate_hz)))
+
+        v_all = history[v_block_start:v_block_start + 2 * nbus, :]
+
+        # Real/imag vs polar form depends on psys.power_injection. Detect:
+        if getattr(psys, "power_injection", False):
+            vm_full = v_all[0::2, :]
+            va_full = v_all[1::2, :]
+        else:
+            vr_full = v_all[0::2, :]
+            vi_full = v_all[1::2, :]
+            vm_full = np.sqrt(vr_full**2 + vi_full**2)
+            va_full = np.arctan2(vi_full, vr_full)
+
+        observed = self._resolve_observed(psys, rng)
+        n_obs = observed.size
+
+        is_p_class = rng.random(n_obs) < self.p_class_fraction
+        cutoffs = np.where(is_p_class, self.p_class_cutoff_hz, self.m_class_cutoff_hz)
+
+        vm_obs = np.empty((n_obs, nsteps))
+        va_obs = np.empty((n_obs, nsteps))
+        for k, (bus, cut) in enumerate(zip(observed, cutoffs)):
+            vm_obs[k, :] = self._lowpass(vm_full[bus, :], sim_rate, float(cut))
+            va_obs[k, :] = self._lowpass(np.unwrap(va_full[bus, :]), sim_rate, float(cut))
+
+        # Down-sample
+        sel = np.arange(0, nsteps, decim)
+        V_mag = vm_obs[:, sel]
+        V_ang = va_obs[:, sel]
+        t_out = tvec[sel]
+
+        # Branch currents
+        I_mag, I_ang, branches_obs = self._branch_currents(psys, v_all, observed, sel, sim_rate, cutoffs)
+
+        missing_V = self._draw_missing_mask(V_mag.shape, rng)
+        missing_I = self._draw_missing_mask(I_mag.shape, rng) if I_mag.size else np.zeros_like(I_mag, dtype=bool)
+
+        V_mag = np.where(missing_V, np.nan, V_mag)
+        V_ang = np.where(missing_V, np.nan, V_ang)
+        if I_mag.size:
+            I_mag = np.where(missing_I, np.nan, I_mag)
+            I_ang = np.where(missing_I, np.nan, I_ang)
+
+        int2ext = {v: k for k, v in getattr(psys, "ext2int", {}).items()}
+        observed_psse = [int2ext.get(int(b), int(b)) for b in observed]
+
+        return {
+            "t": t_out,
+            "observed_buses_internal": observed,
+            "observed_buses_psse": np.asarray(observed_psse),
+            "V_mag": V_mag,
+            "V_ang": V_ang,
+            "I_mag": I_mag,
+            "I_ang": I_ang,
+            "branches": branches_obs,
+            "missing_mask_V": missing_V,
+            "missing_mask_I": missing_I,
+            "pmu_class": np.where(is_p_class, "P", "M"),
+            "filter_cutoff_hz_per_bus": cutoffs,
+            "rate_hz": float(self.rate_hz),
+        }
+
+    def _branch_currents(self, psys, v_all, observed, sel, sim_rate, cutoffs):
+        observed_set = set(int(b) for b in observed)
+        chosen = [(k, br) for k, br in enumerate(psys.branches)
+                  if br.fr in observed_set or br.to in observed_set]
+        if not chosen:
+            return (np.zeros((0, sel.size)), np.zeros((0, sel.size)),
+                    np.zeros((0, 2), dtype=np.int64))
+
+        nbus = psys.nbuses
+        if getattr(psys, "power_injection", False):
+            vm = v_all[0::2, :]
+            va = v_all[1::2, :]
+            vr = vm * np.cos(va)
+            vi = vm * np.sin(va)
+        else:
+            vr = v_all[0::2, :]
+            vi = v_all[1::2, :]
+
+        Vc = vr + 1j * vi  # shape (nbus, nsteps)
+
+        nsteps = Vc.shape[1]
+        I_mag_full = np.empty((len(chosen), nsteps))
+        I_ang_full = np.empty((len(chosen), nsteps))
+        br_pairs = np.empty((len(chosen), 2), dtype=np.int64)
+
+        bus_to_obs_k = {int(b): k for k, b in enumerate(observed)}
+
+        for row, (br_idx, br) in enumerate(chosen):
+            z = complex(br.r, br.x)
+            if abs(z) < 1e-12:
+                I_series = np.zeros(nsteps, dtype=np.complex128)
+            else:
+                I_series = (Vc[br.fr, :] - Vc[br.to, :]) / z
+                if getattr(br, "sh", 0.0):
+                    I_series = I_series + 1j * br.sh / 2.0 * Vc[br.fr, :]
+            I_mag_full[row, :] = np.abs(I_series)
+            I_ang_full[row, :] = np.unwrap(np.angle(I_series))
+            br_pairs[row, :] = (br.fr, br.to)
+
+            obs_bus = br.fr if br.fr in bus_to_obs_k else br.to
+            cut = float(cutoffs[bus_to_obs_k[obs_bus]])
+            I_mag_full[row, :] = self._lowpass(I_mag_full[row, :], sim_rate, cut)
+            I_ang_full[row, :] = self._lowpass(I_ang_full[row, :], sim_rate, cut)
+
+        return I_mag_full[:, sel], I_ang_full[:, sel], br_pairs
+
+    def _draw_missing_mask(self, shape, rng) -> np.ndarray:
+        mask = np.zeros(shape, dtype=bool)
+        if self.missing_rate <= 0.0 or mask.size == 0:
+            return mask
+        n_channels, n_samples = shape
+        target_missing = self.missing_rate * n_samples
+        pmin, pmax = self.packet_size_range
+        for ch in range(n_channels):
+            placed = 0
+            while placed < target_missing:
+                pkt = int(rng.integers(pmin, pmax + 1))
+                start = int(rng.integers(0, max(1, n_samples - pkt)))
+                mask[ch, start:start + pkt] = True
+                placed += pkt
+        return mask
+
+
+def _to_internal(psys, bus):
+    if hasattr(psys, "ext2int") and bus in psys.ext2int:
+        return psys.ext2int[bus]
+    return int(bus)

--- a/uqgrid/osl/scenario.py
+++ b/uqgrid/osl/scenario.py
@@ -1,0 +1,246 @@
+"""High-level builder for Oscillation Source Location (OSL) test cases.
+
+End-to-end pipeline:
+    load_psse + add_dyr  ->  attach injectors  ->  integrate_system
+                          ->  PMUEmulator.process  ->  OSLCase
+
+The output OSLCase can be exported to an ``.npz`` (PMU signals) plus a
+``.json`` (metadata: source description, frequency, PMU class assignment,
+observed buses, seeds) — one row of Table III of the reference paper.
+
+Reference
+---------
+Maslennikov, S. and Wang, B. (2022). *Creation of Simulated Test Cases
+for the Oscillation Source Location Contest.* NREL/CP-6A40-81394.
+2022 IEEE PES General Meeting.
+https://www.nrel.gov/docs/fy22osti/81394.pdf
+
+Out of scope in this first cut (see plan): PSS auto-tuning, HVDC sources,
+DEF/OSLp scoring, EPRI-accurate P/M filter, PETSc integration path.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import numpy as np
+
+from uqgrid.core.psydef import Psystem
+from uqgrid.io.parse import load_psse, add_dyr
+from uqgrid.simulation.dynamics import integrate_system
+from uqgrid.simulation.config import IntegrationConfig
+
+from .injectors import ForcedOscillation, ColoredNoise, SignalInjector
+from .pmu import PMUEmulator
+
+
+@dataclass
+class OSLCase:
+    """One generated OSL test case: PMU signals + ground-truth metadata."""
+
+    pmu: Dict[str, Any]
+    metadata: Dict[str, Any]
+    raw_history: Optional[np.ndarray] = None
+    raw_tvec: Optional[np.ndarray] = None
+
+    def export(self, stem: Union[str, Path], include_raw: bool = False) -> Tuple[Path, Path]:
+        stem = Path(stem)
+        stem.parent.mkdir(parents=True, exist_ok=True)
+        npz_path = stem.with_suffix(".npz")
+        json_path = stem.with_suffix(".json")
+
+        npz_payload = {k: np.asarray(v) for k, v in self.pmu.items()
+                       if isinstance(v, (np.ndarray, list, tuple))}
+        # scalars/strings -> metadata only
+        if include_raw and self.raw_history is not None:
+            npz_payload["raw_history"] = self.raw_history
+            npz_payload["raw_tvec"] = self.raw_tvec
+
+        np.savez(npz_path, **npz_payload)
+        json_path.write_text(json.dumps(self.metadata, indent=2, default=_json_default))
+        return npz_path, json_path
+
+
+def build_osl_case(
+    raw: Union[str, Path],
+    dyr: Union[str, Path],
+    *,
+    forced_oscillations: Optional[List[ForcedOscillation]] = None,
+    colored_noise: Union[bool, ColoredNoise] = False,
+    extra_injectors: Optional[List[SignalInjector]] = None,
+    tend: float = 90.0,
+    dt: float = 1.0 / 240.0,
+    method: str = "beuler",
+    pmu: Optional[Union[PMUEmulator, Dict[str, Any]]] = None,
+    extra_config: Optional[Dict[str, Any]] = None,
+    label: Optional[str] = None,
+    keep_raw: bool = False,
+) -> OSLCase:
+    """Build one OSL case end-to-end.
+
+    Parameters
+    ----------
+    raw, dyr : path
+        PSSE RAW/DYR pair for the test system (e.g. ACTIVSg200).
+    forced_oscillations : list[ForcedOscillation]
+        Sources to inject. Use the convenience ``ForcedOscillation(...)``
+        constructor. Empty/None → no FO injected (ambient case).
+    colored_noise : bool | ColoredNoise
+        ``True`` → attach a default ColoredNoise instance. A
+        ``ColoredNoise`` instance is used directly. ``False`` → none.
+    extra_injectors : list[SignalInjector]
+        Any additional custom injectors to attach.
+    tend, dt, method : simulation controls passed to IntegrationConfig.
+    pmu : PMUEmulator | dict | None
+        Post-processor. A dict is treated as PMUEmulator(**dict). None
+        uses defaults (30 Hz, all buses observed, no missing samples).
+    extra_config : dict
+        Extra IntegrationConfig overrides (e.g. ``{"verbose": True}``).
+        Cannot include the keys this function sets (``tend, dt, method``).
+    label : str
+        Human label stored in metadata.
+    keep_raw : bool
+        If True, the dense simulation history is attached to the OSLCase
+        (and written by ``.export(..., include_raw=True)``).
+    """
+
+    if extra_config and any(k in extra_config for k in ("tend", "dt", "method")):
+        raise ValueError("extra_config must not redefine tend/dt/method.")
+
+    raw = Path(raw)
+    dyr = Path(dyr)
+    psys = load_psse(str(raw))
+    add_dyr(psys, str(dyr))
+    psys.createYbusComplex()
+
+    injectors: List[SignalInjector] = []
+    if forced_oscillations:
+        injectors.extend(forced_oscillations)
+    if colored_noise:
+        injectors.append(colored_noise if isinstance(colored_noise, ColoredNoise) else ColoredNoise())
+    if extra_injectors:
+        injectors.extend(extra_injectors)
+
+    for inj in injectors:
+        psys.add_signal_injector(inj)
+
+    cfg_kwargs = dict(tend=tend, dt=dt, method=method)
+    if extra_config:
+        cfg_kwargs.update(extra_config)
+    if cfg_kwargs.get("petsc", False) and injectors:
+        raise NotImplementedError(
+            "PETSc integration path does not yet honour signal_injectors. "
+            "TODO: hook DAE_petsc.evalFunction (uqgrid/simulation/dynamics.py:1153)."
+        )
+    config = IntegrationConfig(**cfg_kwargs)
+
+    results = integrate_system(psys, config)
+    history = results["history"]
+    tvec = results["tvec"]
+
+    if pmu is None:
+        emulator = PMUEmulator()
+    elif isinstance(pmu, PMUEmulator):
+        emulator = pmu
+    elif isinstance(pmu, dict):
+        emulator = PMUEmulator(**pmu)
+    else:
+        raise TypeError(f"pmu must be PMUEmulator | dict | None, got {type(pmu)!r}")
+
+    pmu_bundle = emulator.process(history, tvec, psys)
+
+    metadata = _build_metadata(
+        label=label,
+        raw=raw,
+        dyr=dyr,
+        psys=psys,
+        forced_oscillations=forced_oscillations or [],
+        colored_noise=colored_noise,
+        tend=tend,
+        dt=dt,
+        method=method,
+        emulator=emulator,
+        pmu_bundle=pmu_bundle,
+    )
+
+    return OSLCase(
+        pmu=pmu_bundle,
+        metadata=metadata,
+        raw_history=history if keep_raw else None,
+        raw_tvec=tvec if keep_raw else None,
+    )
+
+
+def _build_metadata(*, label, raw, dyr, psys, forced_oscillations, colored_noise,
+                    tend, dt, method, emulator, pmu_bundle) -> Dict[str, Any]:
+    sources = []
+    for fo in forced_oscillations:
+        sources.append({
+            "kind": fo.target[0],
+            "bus_user": fo.target[1],
+            "tag": fo.target[2] if len(fo.target) > 2 else None,
+            "freq_hz": float(fo.freq_hz),
+            "amplitude": float(fo.amplitude),
+            "t_start": float(fo.t_start),
+            "t_end": float(fo.t_end) if np.isfinite(fo.t_end) else None,
+            "waveform": fo.waveform,
+            "harmonics": list(fo.harmonics) if fo.harmonics else None,
+            "phase": float(fo.phase),
+        })
+
+    noise_meta: Optional[Dict[str, Any]]
+    if isinstance(colored_noise, ColoredNoise):
+        noise_meta = {
+            "sigma_lf": colored_noise.sigma_lf,
+            "sigma_hf": colored_noise.sigma_hf,
+            "tau_lf_range": list(colored_noise.tau_lf_range),
+            "apply_to_q": colored_noise.apply_to_q,
+            "seed": colored_noise.seed,
+        }
+    elif colored_noise:
+        noise_meta = {"defaults": True}
+    else:
+        noise_meta = None
+
+    return {
+        "label": label,
+        "reference": "NREL/CP-6A40-81394 (Maslennikov & Wang, 2022)",
+        "system": {
+            "raw": str(raw),
+            "dyr": str(dyr),
+            "nbuses": psys.nbuses,
+            "ngens": psys.ngens,
+            "nloads": psys.nloads,
+        },
+        "simulation": {
+            "tend": tend,
+            "dt": dt,
+            "method": method,
+        },
+        "sources": sources,
+        "colored_noise": noise_meta,
+        "pmu": {
+            "rate_hz": emulator.rate_hz,
+            "p_class_fraction": emulator.p_class_fraction,
+            "p_class_cutoff_hz": emulator.p_class_cutoff_hz,
+            "m_class_cutoff_hz": emulator.m_class_cutoff_hz,
+            "missing_rate": emulator.missing_rate,
+            "seed": emulator.seed,
+            "observed_buses_psse": [int(b) for b in pmu_bundle["observed_buses_psse"].tolist()],
+            "filter_note": (
+                "First-order Butterworth lowpass as a stand-in for the EPRI "
+                "P/M-class PMU emulator referenced in the paper."
+            ),
+        },
+    }
+
+
+def _json_default(obj):
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, (np.integer, np.floating)):
+        return obj.item()
+    raise TypeError(f"Not JSON serialisable: {type(obj)!r}")

--- a/uqgrid/simulation/dynamics.py
+++ b/uqgrid/simulation/dynamics.py
@@ -1871,6 +1871,10 @@ def integrate_system(
         for i in range(nsteps):
             if verbose:
                 logger.info("Step: %i. Time: %g (sec)", i, i * h)
+            if psys.signal_injectors:
+                t_now = i * h
+                for inj in psys.signal_injectors:
+                    inj.update(t_now, theta, psys)
             z, u, v, m = integrate(z,
                                 theta,
                                 h,

--- a/uqgrid/simulation/herk.py
+++ b/uqgrid/simulation/herk.py
@@ -197,6 +197,10 @@ def integrate_system_herk(psys, config, ctx=None):
     alg_size = psys.num_dof_alg
 
     for i in range(nsteps):
+        if psys.signal_injectors:
+            t_now = i * h
+            for inj in psys.signal_injectors:
+                inj.update(t_now, theta, psys)
         z = herk_step(z, theta, h, psys, A, b, c, F, J, tol, max_iter)
         history[:, i] = z
 


### PR DESCRIPTION
## Summary

Adds an optional subpackage `uqgrid.osl` for synthesizing labeled PMU
datasets in the style of the 2021 IEEE-NASPI Oscillation Source Location
(OSL) Contest, with two minimal hooks into the existing dynamics path.

Reference: Maslennikov, S. and Wang, B. (2022). *Creation of Simulated
Test Cases for the Oscillation Source Location Contest.* NREL/CP-6A40-81394,
2022 IEEE PES General Meeting.
[https://www.nrel.gov/docs/fy22osti/81394.pdf](https://www.nrel.gov/docs/fy22osti/81394.pdf)

## What's new

### `uqgrid/osl/` — new optional subpackage

* **`injectors.py`** — `SignalInjector` ABC and two concrete injectors:
  * `ForcedOscillation` — sine or rectangular forcing (with optional
    harmonics) on TGOV1 `pref`, SEXS `vref`, or load `p`/`q`. Targets
    accept a PSSE bus number (preferred) or internal index.
  * `ColoredNoise` — low-frequency (random walk, 0.5–5 s intervals) plus
    high-frequency components added to every load's P and Q.
* **`pmu.py`** — `PMUEmulator`: down-sample dense history to PMU rate,
  P/M-class first-order Butterworth lowpass configurable
  partial observability, missing-sample packets, V and I phasor output.
* **`scenario.py`** — `build_osl_case(...)` orchestrator and `OSLCase`
  dataclass. `.export(stem)` writes paired `<stem>.npz` (signals) +
  `<stem>.json` (metadata, one row of Table III of the paper).

### Two minimal touches to existing code

* `uqgrid/core/psydef.py` — `Psystem` gains `self.signal_injectors = []`
  alongside `fault_events`, plus an `add_signal_injector(...)` helper.
* `uqgrid/simulation/dynamics.py` (beuler loop) and
  `uqgrid/simulation/herk.py` (HERK loop) — single per-step hook
  calling `inj.update(t, theta, psys)` once per step, guarded by
  `if psys.signal_injectors:` so the empty-list path is bit-identical
  to prior behaviour.

PETSc / ARKIMEX path is intentionally out of scope for this first cut.
The builder raises `NotImplementedError` if `petsc=True` is combined with
active injectors (with a TODO pointing to `DAE_petsc.evalFunction`).

### Example script

`bin/activsg200_osl.py` — runs ACTIVSg200 with a governor FO at PSSE
bus 49 plus colored noise, post-processes through the PMU emulator, and
writes the case `.npz`/`.json` plus three PNGs (raw bus voltages, PMU
voltages, PMU branch currents). CLI flags for FO bus, frequency,
amplitude, start time, integration window, and seed.

### Tests

`tests/test_osl_scenario.py` (3 tests on the 2-bus PSSE fixture):

* `test_zero_overhead_when_no_injectors` — bit-identical regression
  guard for the integrator hook when no injector is attached.
* `test_forced_oscillation_resolves_and_mutates_theta` — verifies the
  injector resolves the correct `theta` index for a load target, leaves
  it untouched before `t_start`, mutates it to the expected sine value
  inside the window, and restores baseline after `t_end`.
* `test_build_osl_case_shape_and_export` — end-to-end pipeline runs,
  PMU bundle has correct shapes and PMU-class assignment, and
  `.export()` round-trips through `.npz` + `.json`.


## Quick start

```python
from uqgrid.osl import build_osl_case, ForcedOscillation

case = build_osl_case(
    raw="data/ACTIVSg200.raw",
    dyr="data/ACTIVSg200.dyr",
    forced_oscillations=[
        ForcedOscillation(target=("gov", 49), freq_hz=0.8,
                          amplitude=0.2, t_start=2.0, t_end=20.0),
    ],
    colored_noise=True,
    tend=20.0, dt=1/240,
    pmu=dict(rate_hz=30, observed_buses="50%", missing_rate=0.0005, seed=42),
    label="ACTIVSg200_case01",
)
case.export("cases/ACTIVSg200_case01")
```

Or end-to-end with plots:

```bash
python bin/activsg200_osl.py --tend 8.0 --outdir plots/osl
```
