### PR TITLE
Fix lazy PETSc initialization

### DIFF
--- a/bin/dynamics_driver.py
+++ b/bin/dynamics_driver.py
@@ -39,10 +39,6 @@ def parse_args():
     # Parse only the script arguments
     args = parser.parse_args(script_args)
 
-    # If PETSc is enabled, add its arguments to sys.argv
-    if args.petsc and petsc_args:
-        sys.argv = [sys.argv[0]] + petsc_args
-    
     try:
         config = IntegrationConfig(
             tend=args.tend,
@@ -55,6 +51,7 @@ def parse_args():
             comp_sens=args.comp_sens,
             fsolve=args.fsolve,
             petsc=args.petsc,
+            petsc_args=petsc_args,
             arkimex=args.arkimex
         )
     except ValueError as e:

--- a/bin/dynamics_partition_driver.py
+++ b/bin/dynamics_partition_driver.py
@@ -61,9 +61,6 @@ def parse_args(argv: List[str]):
         print("Error: specify only one of --slow-diff or --fast-diff.")
         sys.exit(1)
 
-    if args.petsc and petsc_args:
-        sys.argv = [sys.argv[0]] + petsc_args
-
     try:
         config = IntegrationConfig(
             tend=args.tend,
@@ -74,6 +71,7 @@ def parse_args(argv: List[str]):
             power_injection=False,
             verbose=args.verbose,
             petsc=args.petsc,
+            petsc_args=petsc_args,
             arkimex=args.arkimex,
             arkimex_slow_differential=slow_list,
             arkimex_fast_differential=fast_list,

--- a/tests/test_petsc_lazy_init.py
+++ b/tests/test_petsc_lazy_init.py
@@ -1,0 +1,136 @@
+import importlib.util
+import os
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+from uqgrid.simulation import dynamics
+from uqgrid.simulation.config import IntegrationConfig
+
+
+def _load_module(path: Path, module_name: str):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_import_dynamics_does_not_call_petsc_init(tmp_path):
+    fake_pkg = tmp_path / "petsc4py"
+    fake_pkg.mkdir()
+    (fake_pkg / "__init__.py").write_text(
+        "\n".join(
+            [
+                "init_calls = []",
+                "class _PETSc:",
+                "    pass",
+                "PETSc = _PETSc()",
+                "def init(args=None):",
+                "    init_calls.append(list(args or []))",
+                "    raise RuntimeError('petsc4py.init should not run during import')",
+            ]
+        )
+    )
+
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(fake_pkg.parent), str(repo_root), env.get("PYTHONPATH", "")]
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import uqgrid.simulation.dynamics; "
+            "import petsc4py; "
+            "assert petsc4py.init_calls == []",
+        ],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_petsc_config_initializes_with_only_petsc_args(monkeypatch):
+    calls = []
+    fake_petsc = object()
+    fake_petsc4py = types.ModuleType("petsc4py")
+    fake_petsc4py.PETSc = fake_petsc
+
+    def init(args=None):
+        calls.append(list(args or []))
+
+    fake_petsc4py.init = init
+    monkeypatch.setitem(sys.modules, "petsc4py", fake_petsc4py)
+    monkeypatch.setattr(dynamics, "petsc4py", None)
+    monkeypatch.setattr(dynamics, "PETSc", None)
+
+    disabled = IntegrationConfig(petsc=False, petsc_args=["-ignored"])
+    assert dynamics._get_petsc_for_config(disabled) is None
+    assert calls == []
+
+    enabled = IntegrationConfig(petsc=True, petsc_args=["-ksp_type", "gmres"])
+    assert dynamics._get_petsc_for_config(enabled) is fake_petsc
+    assert calls == [["-ksp_type", "gmres"]]
+
+
+def test_dynamics_driver_preserves_sys_argv_and_stores_petsc_args(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[1]
+    module = _load_module(repo_root / "bin" / "dynamics_driver.py", "test_dynamics_driver")
+    argv = [
+        "dynamics_driver.py",
+        "--raw",
+        "case.raw",
+        "--dyr",
+        "case.dyr",
+        "--petsc",
+        "--",
+        "-ts_monitor",
+        "-ksp_type",
+        "gmres",
+    ]
+    monkeypatch.setattr(sys, "argv", argv.copy())
+
+    raw, dyr, _, config, _ = module.parse_args()
+
+    assert sys.argv == argv
+    assert raw == "case.raw"
+    assert dyr == "case.dyr"
+    assert config.petsc is True
+    assert config.petsc_args == ["-ts_monitor", "-ksp_type", "gmres"]
+
+
+def test_partition_driver_preserves_sys_argv_and_stores_petsc_args(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[1]
+    module = _load_module(
+        repo_root / "bin" / "dynamics_partition_driver.py",
+        "test_dynamics_partition_driver",
+    )
+    argv = [
+        "dynamics_partition_driver.py",
+        "--raw",
+        "case.raw",
+        "--dyr",
+        "case.dyr",
+        "--petsc",
+        "--arkimex",
+        "--",
+        "-log_view",
+        ":petsc.log",
+    ]
+    outer_argv = ["pytest", "--some-option"]
+    monkeypatch.setattr(sys, "argv", outer_argv.copy())
+
+    args, config = module.parse_args(argv)
+
+    assert sys.argv == outer_argv
+    assert args.raw == "case.raw"
+    assert args.dyr == "case.dyr"
+    assert config.petsc is True
+    assert config.petsc_args == ["-log_view", ":petsc.log"]

--- a/uqgrid/simulation/config.py
+++ b/uqgrid/simulation/config.py
@@ -16,6 +16,10 @@ class IntegrationConfig(BaseModel):
     ton: float = Field(0.25, description="Fault activation time.")
     toff: float = Field(0.4, description="Fault deactivation time.")
     petsc: bool = Field(False, description="Enable PETSc integration.")
+    petsc_args: List[str] = Field(
+        default_factory=list,
+        description="PETSc-specific command-line options to pass to petsc4py.init.",
+    )
     solve_powerflow_dynamics: bool = Field(True, description="Solve power flow before dynamics.")
     arkimex: bool = Field(False, description="Use ARKIMEX integrator.")
     check_jacobian: bool = Field(False, description="Run FD Jacobian check (non-PETSc only).")

--- a/uqgrid/simulation/dynamics.py
+++ b/uqgrid/simulation/dynamics.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 
 import copy
 import math
-import sys
 from typing import Optional
 
 import numdifftools as nd
@@ -18,14 +17,36 @@ import logging
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
-# Optional: PETSC4py
-try:
-    import petsc4py
-    petsc4py.init(sys.argv)
-    from petsc4py import PETSc
-except ImportError:
-    petsc4py = None
-    logger.warning("PETSc4py not available. Some functionality will not be available.")
+# Optional PETSc bindings are initialized lazily from IntegrationConfig.petsc_args.
+petsc4py = None
+PETSc = None
+
+
+def _initialize_petsc(petsc_args=None):
+    global petsc4py, PETSc
+    if PETSc is not None:
+        return PETSc
+
+    try:
+        import petsc4py as _petsc4py
+    except ImportError as exc:
+        raise ImportError(
+            "PETSc integration requires petsc4py. Install UQGrid with the "
+            "'petsc' extra or set petsc=False."
+        ) from exc
+
+    _petsc4py.init(list(petsc_args or []))
+    from petsc4py import PETSc as _PETSc
+
+    petsc4py = _petsc4py
+    PETSc = _PETSc
+    return PETSc
+
+
+def _get_petsc_for_config(config):
+    if not config.petsc:
+        return None
+    return _initialize_petsc(config.petsc_args)
 
 from uqgrid.simulation.config import IntegrationConfig, IntegrationCtx
 from uqgrid.core import Psystem
@@ -1109,10 +1130,8 @@ def preallocate_hessian(psys):
 
     return Hsparse
 
-if petsc4py:
-    class DAE_petsc(object):
+class DAE_petsc(object):
         n = 1
-        comm = PETSc.COMM_SELF
         def __init__(self, psys, theta, J, tfon, tfoff):
             self.psys = psys
             self.theta = theta
@@ -1365,9 +1384,8 @@ if petsc4py:
                 Jfast.assemble()
             return True
 
-    class ALG_petsc(object):
+class ALG_petsc(object):
         n = 1
-        comm = PETSc.COMM_SELF
         def __init__(self, psys, theta, J):
             self.psys = psys
             self.theta = theta
@@ -1398,9 +1416,8 @@ if petsc4py:
             if J != P: J.assemble()
             return True
 
-    class ADJ_petsc(object):
+class ADJ_petsc(object):
         n = 1
-        comm = PETSc.COMM_SELF
         def __init__(self, psys, theta):
             self.psys = psys
             self.theta = theta
@@ -1679,7 +1696,9 @@ def integrate_system(
     if comp_sens and not petsc:
         raise ValueError("Sensitivities can only be computed with PETSc.")
 
-    if petsc4py and petsc:
+    PETSc = _get_petsc_for_config(config)
+
+    if PETSc is not None:
         if verbose:
             logger.info("Convert objects to PETSc format")
         nsize = jacobian.shape[0]


### PR DESCRIPTION
Delay PETSc initialization until the PETSc backend is explicitly enabled, and pass only PETSc-specific CLI args to ```petsc4py.init```