### PR TITLE
Add Q-limited power-flow initialization and validation

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -16,10 +16,16 @@ from uqgrid.io.parse import load_psse, add_dyr
 ## `uqgrid.simulation.config`
 
 ```python
-from uqgrid.simulation.config import IntegrationConfig, IntegrationCtx
+from uqgrid.simulation.config import (
+    IntegrationConfig,
+    IntegrationCtx,
+    PowerFlowValidationConfig,
+)
 ```
 
 - `IntegrationConfig`: Validated settings for time integration.
+- `PowerFlowValidationConfig`: Optional strict operating-point checks performed
+  before dynamic initialization.
 - `IntegrationCtx`: Optional container for custom initial conditions and
   parameter overrides.
 
@@ -45,11 +51,19 @@ from uqgrid.simulation.dynamics import integrate_system
 ## `uqgrid.simulation.pflow`
 
 ```python
-from uqgrid.simulation.pflow import runpf
+from uqgrid.simulation.pflow import (
+    PowerFlowValidationError,
+    runpf,
+    validate_power_flow_solution,
+)
 ```
 
 - `runpf(psys, verbose=False) -> PowerFlowSolution`: Compute steady-state
   voltages and injections before dynamics.
+- `validate_power_flow_solution`: Return JSON-safe operating-point diagnostics
+  without modifying the solution.
+- `PowerFlowValidationError`: Raised before initialization when enabled
+  validation fails.
 - `compute_pinj_alt`: Alternative formulation for power-injection Jacobians.
 
 ## `uqgrid.core.psydef`

--- a/docs/user-guide/dynamics-simulation.md
+++ b/docs/user-guide/dynamics-simulation.md
@@ -59,6 +59,19 @@ config = IntegrationConfig(
     comp_sens=False,
     fsolve=False,
     petsc=True,
+    enforce_q_limits=False,
+    q_limit_tolerance=1e-8,
+    max_q_limit_iterations=None,
+    power_flow_validation={
+        "enabled": False,
+        "residual_tolerance": 1e-8,
+        "generator_limit_tolerance": 1e-6,
+        "voltage_min": None,
+        "voltage_max": None,
+        "branch_loading_max": None,
+        "branch_limit_tolerance": 1e-5,
+        "active_set_voltage_tolerance": 1e-6,
+    },
     check_jacobian=False,
     jacobian_check_tol=1e-6,
     jacobian_check_top_k=10,
@@ -75,10 +88,39 @@ Key fields:
 - **comp_sens**: Enable adjoint-based sensitivities (requires PETSc).
 - **petsc**: Switch to PETSc-backed integrators for improved robustness and
   adjoint capabilities.
+- **enforce_q_limits**: Enforce non-slack PV generator reactive-power limits
+  during the power flow used for dynamic initialization.
+- **q_limit_tolerance**: Per-unit tolerance for activating a generator
+  reactive-power limit.
+- **max_q_limit_iterations**: Optional cap on active-set power-flow solves.
+- **power_flow_validation**: Optional final operating-point checks performed
+  after PF convergence and before dynamic device initialization.
 - **check_jacobian**: Run a finite-difference Jacobian check (non-PETSc only).
 - **jacobian_check_tol**: Absolute tolerance for reporting FD mismatches.
 - **jacobian_check_top_k**: Number of mismatches to report.
 - **jacobian_check_csv**: Optional CSV file path for mismatch report.
+
+### Initial reactive-power limits
+
+Set `enforce_q_limits=True` to project generator reactive dispatch onto its
+RAW/MATPOWER bounds before dynamic initialization. If a non-slack PV bus cannot
+hold its voltage setpoint within aggregate generator Q capability, the power
+flow switches that bus to PQ and solves again. The same initialization is used
+for PETSc, backward Euler, HERK2, and HERK4.
+
+This constrains the operating point only. It does not impose generator
+reactive-power or exciter field-voltage limits during the dynamic trajectory.
+
+### Final operating-point validation
+
+Validation is disabled by default. When enabled, UQGrid checks the final Newton
+residual, finite voltages, generator P/Q limits, optional voltage and branch
+loading bounds, Q-limit active-set consistency, and one slack bus per electrical
+island. A failed check raises `PowerFlowValidationError` before
+`initialize_system()` or PETSc setup.
+
+Successful backward Euler, PETSc, HERK2, and HERK4 runs include the JSON-safe
+diagnostics under `results["power_flow_diagnostics"]`.
 
 ### Jacobian diagnostics (optional)
 

--- a/docs/user-guide/dynamics-simulation.md
+++ b/docs/user-guide/dynamics-simulation.md
@@ -59,7 +59,7 @@ config = IntegrationConfig(
     comp_sens=False,
     fsolve=False,
     petsc=True,
-    enforce_q_limits=False,
+    enforce_q_limits=True,
     q_limit_tolerance=1e-8,
     max_q_limit_iterations=None,
     power_flow_validation={
@@ -102,11 +102,13 @@ Key fields:
 
 ### Initial reactive-power limits
 
-Set `enforce_q_limits=True` to project generator reactive dispatch onto its
-RAW/MATPOWER bounds before dynamic initialization. If a non-slack PV bus cannot
-hold its voltage setpoint within aggregate generator Q capability, the power
-flow switches that bus to PQ and solves again. The same initialization is used
-for PETSc, backward Euler, HERK2, and HERK4.
+Q-limit enforcement is enabled by default and projects generator reactive
+dispatch onto its RAW/MATPOWER bounds before dynamic initialization. Set
+`enforce_q_limits=False` only when an unconstrained legacy operating point is
+required. If a non-slack PV bus cannot hold its voltage setpoint within
+aggregate generator Q capability, the power flow switches that bus to PQ and
+solves again. The same initialization is used for PETSc, backward Euler,
+HERK2, and HERK4.
 
 This constrains the operating point only. It does not impose generator
 reactive-power or exciter field-voltage limits during the dynamic trajectory.

--- a/scripts/run/README.md
+++ b/scripts/run/README.md
@@ -491,12 +491,12 @@ configured separately under `integration`:
 
 `operating_point.q_limit_mitigation` controls candidate preparation and
 screening. `integration.enforce_q_limits` controls the final initialization PF
-used by backward Euler, PETSc, HERK2, or HERK4. Enable the integration setting
-when the dynamic replay must preserve generator Q feasibility even after the
-system is reloaded in a worker. These limits apply only to the initial
-operating point; dynamic exciter and field-voltage limits are separate models.
-When final validation is enabled, a violation rejects the fault replay before
-dynamic initialization. The fault diagnostic record includes the structured
+used by backward Euler, PETSc, HERK2, or HERK4 and defaults to `true`. Set it to
+`false` only when an unconstrained legacy operating point is required. These
+limits apply only to the initial operating point; dynamic exciter and
+field-voltage limits are separate models. Final validation remains opt-in.
+When enabled, a validation failure rejects the fault replay before dynamic
+initialization. The fault diagnostic record includes the structured
 `power_flow_validation` result.
 
 ### Available Models

--- a/scripts/run/README.md
+++ b/scripts/run/README.md
@@ -468,6 +468,37 @@ solve. This trades fixed voltage control for fixed reactive output at the
 generator limit. The temporary bus-type changes are restored before dynamics
 are launched. It is not ACOPF and does not modify core UQGrid PF behavior.
 
+The final power flow performed immediately before dynamic initialization is
+configured separately under `integration`:
+
+```json
+"integration": {
+    "enforce_q_limits": true,
+    "q_limit_tolerance": 1e-8,
+    "max_q_limit_iterations": null,
+    "power_flow_validation": {
+        "enabled": true,
+        "residual_tolerance": 1e-8,
+        "generator_limit_tolerance": 1e-6,
+        "voltage_min": 0.9,
+        "voltage_max": 1.1,
+        "branch_loading_max": 1.0,
+        "branch_limit_tolerance": 1e-5,
+        "active_set_voltage_tolerance": 1e-6
+    }
+}
+```
+
+`operating_point.q_limit_mitigation` controls candidate preparation and
+screening. `integration.enforce_q_limits` controls the final initialization PF
+used by backward Euler, PETSc, HERK2, or HERK4. Enable the integration setting
+when the dynamic replay must preserve generator Q feasibility even after the
+system is reloaded in a worker. These limits apply only to the initial
+operating point; dynamic exciter and field-voltage limits are separate models.
+When final validation is enabled, a violation rejects the fault replay before
+dynamic initialization. The fault diagnostic record includes the structured
+`power_flow_validation` result.
+
 ### Available Models
 
 | Model | Buses | Description |

--- a/scripts/run/generate_scenarios.py
+++ b/scripts/run/generate_scenarios.py
@@ -1569,7 +1569,7 @@ def _integration_config_from_dict(integration_config=None):
         toff=int_cfg.get("toff", 0.4),
         verbose=int_cfg.get("verbose", False),
         petsc=int_cfg.get("petsc", True),
-        enforce_q_limits=int_cfg.get("enforce_q_limits", False),
+        enforce_q_limits=int_cfg.get("enforce_q_limits", True),
         q_limit_tolerance=int_cfg.get("q_limit_tolerance", 1e-8),
         max_q_limit_iterations=int_cfg.get("max_q_limit_iterations"),
         power_flow_validation=int_cfg.get("power_flow_validation", {}),
@@ -2265,7 +2265,7 @@ def run_single_scenario_worker(
             toff=int_cfg.get('toff', 0.4),            # Fault clearing time [s]
             verbose=int_cfg.get('verbose', False),
             petsc=int_cfg.get('petsc', True),
-            enforce_q_limits=int_cfg.get('enforce_q_limits', False),
+            enforce_q_limits=int_cfg.get('enforce_q_limits', True),
             q_limit_tolerance=int_cfg.get('q_limit_tolerance', 1e-8),
             max_q_limit_iterations=int_cfg.get('max_q_limit_iterations'),
             power_flow_validation=int_cfg.get('power_flow_validation', {}),
@@ -3451,7 +3451,7 @@ def get_default_config(model_name: str) -> dict:
             "toff": 0.4,               # Fault clearing time [s]
             "verbose": False,
             "petsc": True,
-            "enforce_q_limits": False,
+            "enforce_q_limits": True,
             "q_limit_tolerance": 1e-8,
             "max_q_limit_iterations": None,
             "power_flow_validation": {
@@ -3710,7 +3710,7 @@ def main(config_path: str = None):
                 "toff": 0.4,
                 "verbose": false,
                 "petsc": true,
-                "enforce_q_limits": false,
+                "enforce_q_limits": true,
                 "q_limit_tolerance": 1e-8,
                 "max_q_limit_iterations": null,
                 "power_flow_validation": {
@@ -3861,7 +3861,7 @@ Examples:
         else:
             max_total_attempts = int(max_total_attempts)
 
-    # Integration configuration (with defaults for backward compatibility)
+    # Integration configuration
     integration_cfg = config.get("integration", {})
     validation_cfg = integration_cfg.get("power_flow_validation", {}) or {}
     integration_config = {
@@ -3872,7 +3872,7 @@ Examples:
         "toff": integration_cfg.get("toff", 0.4),
         "verbose": integration_cfg.get("verbose", False),
         "petsc": integration_cfg.get("petsc", True),
-        "enforce_q_limits": integration_cfg.get("enforce_q_limits", False),
+        "enforce_q_limits": integration_cfg.get("enforce_q_limits", True),
         "q_limit_tolerance": integration_cfg.get("q_limit_tolerance", 1e-8),
         "max_q_limit_iterations": integration_cfg.get("max_q_limit_iterations"),
         "power_flow_validation": {

--- a/scripts/run/generate_scenarios.py
+++ b/scripts/run/generate_scenarios.py
@@ -212,7 +212,7 @@ from joblib import Parallel, delayed
 
 from uqgrid.simulation.dynamics import integrate_system
 from uqgrid.simulation.config import IntegrationConfig
-from uqgrid.simulation.pflow import runpf
+from uqgrid.simulation.pflow import PowerFlowValidationError, runpf
 from uqgrid.io.parse import load_psse, add_dyr
 from uqgrid.core.psydef import Bus
 
@@ -1569,6 +1569,10 @@ def _integration_config_from_dict(integration_config=None):
         toff=int_cfg.get("toff", 0.4),
         verbose=int_cfg.get("verbose", False),
         petsc=int_cfg.get("petsc", True),
+        enforce_q_limits=int_cfg.get("enforce_q_limits", False),
+        q_limit_tolerance=int_cfg.get("q_limit_tolerance", 1e-8),
+        max_q_limit_iterations=int_cfg.get("max_q_limit_iterations"),
+        power_flow_validation=int_cfg.get("power_flow_validation", {}),
     )
 
 
@@ -1863,11 +1867,17 @@ def _run_fault_with_operating_point_worker(
         try:
             sim = integrate_system(psys, _integration_config_from_dict(integration_config))
             diverged = False
+            diagnostics["power_flow_validation"] = sim.get(
+                "power_flow_diagnostics"
+            )
         except Exception as e:
             print(f"Simulation failed for scenario {scenario_id}: {str(e)}")
             sim = {"history": None, "tvec": None}
             diverged = True
             diagnostics["simulation_error"] = str(e)
+            if isinstance(e, PowerFlowValidationError):
+                diagnostics["reject_reason"] = "power_flow_validation_failed"
+                diagnostics["power_flow_validation"] = e.diagnostics
 
         diagnostics["simulation_diverged"] = diverged
         diagnostics["file"] = None if diverged else _simulation_file_path(scenario_id)
@@ -2254,17 +2264,27 @@ def run_single_scenario_worker(
             ton=int_cfg.get('ton', 0.25),             # Fault onset time [s]
             toff=int_cfg.get('toff', 0.4),            # Fault clearing time [s]
             verbose=int_cfg.get('verbose', False),
-            petsc=int_cfg.get('petsc', True)
+            petsc=int_cfg.get('petsc', True),
+            enforce_q_limits=int_cfg.get('enforce_q_limits', False),
+            q_limit_tolerance=int_cfg.get('q_limit_tolerance', 1e-8),
+            max_q_limit_iterations=int_cfg.get('max_q_limit_iterations'),
+            power_flow_validation=int_cfg.get('power_flow_validation', {}),
         )
 
         try:
             sim = integrate_system(psys, cfg)
             diverged = False
+            diagnostics["power_flow_validation"] = sim.get(
+                "power_flow_diagnostics"
+            )
         except Exception as e:
             print(f"Simulation failed for scenario {scenario_id}: {str(e)}")
             sim = {"history": None, "tvec": None}
             diverged = True
             diagnostics["simulation_error"] = str(e)
+            if isinstance(e, PowerFlowValidationError):
+                diagnostics["reject_reason"] = "power_flow_validation_failed"
+                diagnostics["power_flow_validation"] = e.diagnostics
 
         diagnostics["simulation_diverged"] = diverged
         diagnostics["file"] = None if diverged else f"simulation_data/scenario_{scenario_id}.npz"
@@ -3430,7 +3450,20 @@ def get_default_config(model_name: str) -> dict:
             "ton": 0.25,               # Fault onset time [s]
             "toff": 0.4,               # Fault clearing time [s]
             "verbose": False,
-            "petsc": True
+            "petsc": True,
+            "enforce_q_limits": False,
+            "q_limit_tolerance": 1e-8,
+            "max_q_limit_iterations": None,
+            "power_flow_validation": {
+                "enabled": False,
+                "residual_tolerance": 1e-8,
+                "generator_limit_tolerance": 1e-6,
+                "voltage_min": 0.9,
+                "voltage_max": 1.1,
+                "branch_loading_max": 1.0,
+                "branch_limit_tolerance": 1e-5,
+                "active_set_voltage_tolerance": 1e-6
+            }
         }
     }
 
@@ -3676,7 +3709,20 @@ def main(config_path: str = None):
                 "ton": 0.25,
                 "toff": 0.4,
                 "verbose": false,
-                "petsc": true
+                "petsc": true,
+                "enforce_q_limits": false,
+                "q_limit_tolerance": 1e-8,
+                "max_q_limit_iterations": null,
+                "power_flow_validation": {
+                    "enabled": false,
+                    "residual_tolerance": 1e-8,
+                    "generator_limit_tolerance": 1e-6,
+                    "voltage_min": 0.9,
+                    "voltage_max": 1.1,
+                    "branch_loading_max": 1.0,
+                    "branch_limit_tolerance": 1e-5,
+                    "active_set_voltage_tolerance": 1e-6
+                }
             }
         }
 
@@ -3817,6 +3863,7 @@ Examples:
 
     # Integration configuration (with defaults for backward compatibility)
     integration_cfg = config.get("integration", {})
+    validation_cfg = integration_cfg.get("power_flow_validation", {}) or {}
     integration_config = {
         "tend": integration_cfg.get("tend", 10.0),
         "dt": integration_cfg.get("dt", 1/120.0),
@@ -3824,7 +3871,28 @@ Examples:
         "ton": integration_cfg.get("ton", 0.25),
         "toff": integration_cfg.get("toff", 0.4),
         "verbose": integration_cfg.get("verbose", False),
-        "petsc": integration_cfg.get("petsc", True)
+        "petsc": integration_cfg.get("petsc", True),
+        "enforce_q_limits": integration_cfg.get("enforce_q_limits", False),
+        "q_limit_tolerance": integration_cfg.get("q_limit_tolerance", 1e-8),
+        "max_q_limit_iterations": integration_cfg.get("max_q_limit_iterations"),
+        "power_flow_validation": {
+            "enabled": validation_cfg.get("enabled", False),
+            "residual_tolerance": validation_cfg.get(
+                "residual_tolerance", 1e-8
+            ),
+            "generator_limit_tolerance": validation_cfg.get(
+                "generator_limit_tolerance", 1e-6
+            ),
+            "voltage_min": validation_cfg.get("voltage_min"),
+            "voltage_max": validation_cfg.get("voltage_max"),
+            "branch_loading_max": validation_cfg.get("branch_loading_max"),
+            "branch_limit_tolerance": validation_cfg.get(
+                "branch_limit_tolerance", 1e-5
+            ),
+            "active_set_voltage_tolerance": validation_cfg.get(
+                "active_set_voltage_tolerance", 1e-6
+            ),
+        },
     }
 
     # -------------------------------------------------------------------------
@@ -3917,6 +3985,24 @@ Examples:
     print(f"  - Fault clearing (toff): {integration_config['toff']} s")
     print(f"  - Power injection: {integration_config['power_injection']}")
     print(f"  - PETSc solver: {integration_config['petsc']}")
+    print(f"  - Enforce PF Q limits: {integration_config['enforce_q_limits']}")
+    print(f"  - PF Q-limit tolerance: {integration_config['q_limit_tolerance']}")
+    print(
+        "  - PF Q-limit max solves: "
+        f"{integration_config['max_q_limit_iterations']}"
+    )
+    validation_summary = integration_config["power_flow_validation"]
+    print(f"  - Validate final PF: {validation_summary['enabled']}")
+    if validation_summary["enabled"]:
+        print(
+            "  - Final PF voltage range: "
+            f"{validation_summary['voltage_min']} to "
+            f"{validation_summary['voltage_max']}"
+        )
+        print(
+            "  - Final PF branch loading max: "
+            f"{validation_summary['branch_loading_max']}"
+        )
     print(f"  - Verbose: {integration_config['verbose']}")
     print("=" * 60 + "\n")
 

--- a/tests/test_generate_scenarios_operating_point.py
+++ b/tests/test_generate_scenarios_operating_point.py
@@ -49,6 +49,141 @@ def _dummy_export_psys():
     return SimpleNamespace(export_state_metadata=lambda: None)
 
 
+def test_integration_config_adapter_preserves_q_limit_controls(gs):
+    cfg = gs._integration_config_from_dict({
+        "petsc": True,
+        "enforce_q_limits": True,
+        "q_limit_tolerance": 2e-7,
+        "max_q_limit_iterations": 11,
+        "power_flow_validation": {
+            "enabled": True,
+            "voltage_min": 0.9,
+            "voltage_max": 1.1,
+            "branch_loading_max": 1.0,
+        },
+    })
+
+    assert cfg.petsc is True
+    assert cfg.enforce_q_limits is True
+    assert cfg.q_limit_tolerance == pytest.approx(2e-7)
+    assert cfg.max_q_limit_iterations == 11
+    assert cfg.power_flow_validation.enabled is True
+    assert cfg.power_flow_validation.voltage_min == pytest.approx(0.9)
+    assert cfg.power_flow_validation.voltage_max == pytest.approx(1.1)
+    assert cfg.power_flow_validation.branch_loading_max == pytest.approx(1.0)
+
+
+def test_default_scenario_config_includes_q_limit_controls(gs):
+    integration = gs.get_default_config("IEEE-9")["integration"]
+
+    assert integration["enforce_q_limits"] is False
+    assert integration["q_limit_tolerance"] == pytest.approx(1e-8)
+    assert integration["max_q_limit_iterations"] is None
+    validation = integration["power_flow_validation"]
+    assert validation["enabled"] is False
+    assert validation["residual_tolerance"] == pytest.approx(1e-8)
+    assert validation["generator_limit_tolerance"] == pytest.approx(1e-6)
+    assert validation["voltage_min"] == pytest.approx(0.9)
+    assert validation["voltage_max"] == pytest.approx(1.1)
+    assert validation["branch_loading_max"] == pytest.approx(1.0)
+
+
+def _fault_worker_inputs():
+    scenario = {
+        "sample_idx": 0,
+        "fault_location": 1,
+        "fault_impedance": 1e-4,
+        "operating_point_id": "op-0",
+        "accepted_operating_point_index": 0,
+    }
+    operating_point = {
+        "operating_point_id": "op-0",
+        "accepted_operating_point_index": 0,
+        "p_load_scaled": np.array([0.5]),
+        "q_load_scaled": np.array([-0.2]),
+        "p_gen_scaled": np.array([0.5]),
+        "q_gen_scaled": np.array([0.2]),
+        "p_load_noise": np.array([0.0]),
+        "q_load_noise": np.array([0.0]),
+        "p_gen_noise": np.array([0.0]),
+        "q_gen_noise": np.array([0.0]),
+        "load_scale": 1.0,
+        "load_mean_shift": 0.0,
+        "diagnostics": {},
+    }
+    return scenario, operating_point
+
+
+def _fake_fault_psys():
+    class BusStub:
+        def set_vinit(self, vmag, vang):
+            self.vmag = vmag
+            self.vang = vang
+
+    return SimpleNamespace(
+        buses=[BusStub(), BusStub()],
+        set_load_pq=lambda *args: None,
+        set_gen_pq=lambda *args: None,
+        add_busfault=lambda *args: None,
+        createYbusComplex=lambda: None,
+    )
+
+
+def test_fault_worker_preserves_successful_pf_validation(
+        gs, tmp_path, monkeypatch):
+    scenario, operating_point = _fault_worker_inputs()
+    validation = {"valid": True, "failure_reasons": []}
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(gs, "_load_power_system", lambda *args: _fake_fault_psys())
+    monkeypatch.setattr(
+        gs,
+        "integrate_system",
+        lambda *args: {
+            "history": np.zeros((2, 2)),
+            "tvec": np.array([0.0, 0.1]),
+            "power_flow_diagnostics": validation,
+        },
+    )
+
+    result = gs._run_fault_with_operating_point_worker(
+        "case.raw",
+        "case.dyr",
+        scenario,
+        "scenario-0",
+        operating_point,
+        {"power_flow_validation": {"enabled": True}},
+    )
+
+    assert result["diverged"] is False
+    assert result["diagnostics"]["power_flow_validation"] == validation
+
+
+def test_fault_worker_preserves_failed_pf_validation(
+        gs, tmp_path, monkeypatch):
+    scenario, operating_point = _fault_worker_inputs()
+    validation = {"valid": False, "failure_reasons": ["gen_p_limit"]}
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(gs, "_load_power_system", lambda *args: _fake_fault_psys())
+
+    def fail_validation(*args):
+        raise gs.PowerFlowValidationError(validation)
+
+    monkeypatch.setattr(gs, "integrate_system", fail_validation)
+
+    result = gs._run_fault_with_operating_point_worker(
+        "case.raw",
+        "case.dyr",
+        scenario,
+        "scenario-0",
+        operating_point,
+        {"power_flow_validation": {"enabled": True}},
+    )
+
+    assert result["diverged"] is True
+    assert result["diagnostics"]["reject_reason"] == "power_flow_validation_failed"
+    assert result["diagnostics"]["power_flow_validation"] == validation
+
+
 def test_stress_load_preserves_load_power_factor_with_no_noise(gs):
     base_p = np.array([1.0, 2.0, 0.0])
     base_q = np.array([0.4, 0.8, 0.5])

--- a/tests/test_generate_scenarios_operating_point.py
+++ b/tests/test_generate_scenarios_operating_point.py
@@ -76,7 +76,7 @@ def test_integration_config_adapter_preserves_q_limit_controls(gs):
 def test_default_scenario_config_includes_q_limit_controls(gs):
     integration = gs.get_default_config("IEEE-9")["integration"]
 
-    assert integration["enforce_q_limits"] is False
+    assert integration["enforce_q_limits"] is True
     assert integration["q_limit_tolerance"] == pytest.approx(1e-8)
     assert integration["max_q_limit_iterations"] is None
     validation = integration["power_flow_validation"]
@@ -86,6 +86,13 @@ def test_default_scenario_config_includes_q_limit_controls(gs):
     assert validation["voltage_min"] == pytest.approx(0.9)
     assert validation["voltage_max"] == pytest.approx(1.1)
     assert validation["branch_loading_max"] == pytest.approx(1.0)
+
+    adapted = gs._integration_config_from_dict({})
+    assert adapted.enforce_q_limits is True
+    assert adapted.power_flow_validation.enabled is False
+
+    legacy = gs._integration_config_from_dict({"enforce_q_limits": False})
+    assert legacy.enforce_q_limits is False
 
 
 def _fault_worker_inputs():

--- a/tests/test_herk.py
+++ b/tests/test_herk.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from uqgrid.io.parse import add_dyr, load_psse
+from uqgrid.simulation import dynamics
 from uqgrid.simulation.config import IntegrationConfig
 from uqgrid.simulation.dynamics import (
     initialize_system,
@@ -98,6 +99,57 @@ def _build_ieee9_no_fault(data_dir):
     add_dyr(psys, os.path.join(data_dir, "ieee9bus.dyr"))
     psys.createYbusComplex()
     return psys
+
+
+@pytest.mark.parametrize(
+    ("method", "gen_index", "bound_name", "bound_value", "side"),
+    [
+        ("beuler", 1, "qgub", 0.02, "upper"),
+        ("beuler", 2, "qglb", -0.05, "lower"),
+        ("herk2", 1, "qgub", 0.02, "upper"),
+        ("herk4", 1, "qgub", 0.02, "upper"),
+    ],
+)
+def test_integration_config_enforces_initial_q_limits(
+        data_dir, monkeypatch, method, gen_index, bound_name, bound_value, side):
+    psys = _build_ieee9_no_fault(data_dir)
+    setattr(psys.gens[gen_index], bound_name, bound_value)
+    psys.add_busfault(4, 1e-4)
+    captured = []
+    original_runpf = dynamics.runpf
+
+    def recording_runpf(*args, **kwargs):
+        result = original_runpf(*args, **kwargs)
+        captured.append(result)
+        return result
+
+    monkeypatch.setattr(dynamics, "runpf", recording_runpf)
+    cfg = IntegrationConfig(
+        method=method,
+        steps=3,
+        dt=1e-4,
+        power_injection=False,
+        petsc=False,
+        ton=10.0,
+        toff=11.0,
+        enforce_q_limits=True,
+        power_flow_validation={
+            "enabled": True,
+            "voltage_min": 0.9,
+            "voltage_max": 1.1,
+        },
+    )
+
+    result = integrate_system(psys, cfg)
+
+    assert len(captured) == 1
+    assert captured[0].q_limit_enforced
+    assert captured[0].q_limit_events[0]["side"] == side
+    assert captured[0].gen_qsch[gen_index] == pytest.approx(bound_value)
+    assert result["power_flow_diagnostics"] == captured[0].validation
+    assert result["power_flow_diagnostics"]["valid"]
+    differential = result["history"][:psys.num_dof_dif]
+    assert np.max(np.abs(differential - differential[:, [0]])) < 1e-8
 
 
 def _build_ieee9_gov_no_fault(data_dir):

--- a/tests/test_integration_config.py
+++ b/tests/test_integration_config.py
@@ -29,12 +29,13 @@ def test_integration_config_rejects_both_fast_and_slow_lists():
 def test_integration_config_q_limit_defaults():
     cfg = IntegrationConfig()
 
-    assert cfg.enforce_q_limits is False
+    assert cfg.enforce_q_limits is True
     assert cfg.q_limit_tolerance == pytest.approx(1e-8)
     assert cfg.max_q_limit_iterations is None
     assert cfg.power_flow_validation.enabled is False
     assert cfg.power_flow_validation.voltage_min is None
     assert cfg.power_flow_validation.branch_loading_max is None
+    assert IntegrationConfig(enforce_q_limits=False).enforce_q_limits is False
 
 
 @pytest.mark.parametrize(

--- a/tests/test_integration_config.py
+++ b/tests/test_integration_config.py
@@ -1,5 +1,7 @@
+import numpy as np
 import pytest
 
+from uqgrid.simulation import dynamics
 from uqgrid.simulation.config import IntegrationConfig
 
 
@@ -22,3 +24,86 @@ def test_integration_config_rejects_both_fast_and_slow_lists():
             arkimex_fast_differential=[1, 3],
             arkimex_slow_differential=[0, 2],
         )
+
+
+def test_integration_config_q_limit_defaults():
+    cfg = IntegrationConfig()
+
+    assert cfg.enforce_q_limits is False
+    assert cfg.q_limit_tolerance == pytest.approx(1e-8)
+    assert cfg.max_q_limit_iterations is None
+    assert cfg.power_flow_validation.enabled is False
+    assert cfg.power_flow_validation.voltage_min is None
+    assert cfg.power_flow_validation.branch_loading_max is None
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"q_limit_tolerance": -1e-8},
+        {"max_q_limit_iterations": 0},
+    ],
+)
+def test_integration_config_rejects_invalid_q_limit_controls(kwargs):
+    with pytest.raises(ValueError):
+        IntegrationConfig(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "validation",
+    [
+        {"residual_tolerance": -1e-8},
+        {"generator_limit_tolerance": -1e-6},
+        {"branch_loading_max": 0.0},
+        {"branch_limit_tolerance": -1e-5},
+        {"active_set_voltage_tolerance": -1e-6},
+        {"voltage_min": 1.1, "voltage_max": 0.9},
+    ],
+)
+def test_integration_config_rejects_invalid_power_flow_validation(validation):
+    with pytest.raises(ValueError):
+        IntegrationConfig(power_flow_validation=validation)
+
+
+@pytest.mark.parametrize("petsc", [False, True])
+def test_shared_initializer_forwards_q_limit_controls(monkeypatch, petsc):
+    calls = []
+    pf_solution = object()
+    z0 = np.array([1.0])
+    theta = np.array([2.0])
+    psys = object()
+
+    def fake_runpf(received_psys, **kwargs):
+        calls.append((received_psys, kwargs))
+        return pf_solution
+
+    def fake_initialize_system(received_psys, received_pf):
+        assert received_psys is psys
+        assert received_pf is pf_solution
+        return z0, theta
+
+    monkeypatch.setattr(dynamics, "runpf", fake_runpf)
+    monkeypatch.setattr(dynamics, "initialize_system", fake_initialize_system)
+    cfg = IntegrationConfig(
+        petsc=petsc,
+        enforce_q_limits=True,
+        q_limit_tolerance=2e-7,
+        max_q_limit_iterations=9,
+    )
+
+    actual_pf, actual_z0, actual_theta = dynamics._initialize_system_from_config(
+        psys, cfg,
+    )
+
+    assert actual_pf is pf_solution
+    assert actual_z0 is z0
+    assert actual_theta is theta
+    assert calls == [(
+        psys,
+        {
+            "verbose": False,
+            "enforce_q_limits": True,
+            "q_limit_tolerance": 2e-7,
+            "max_q_limit_iterations": 9,
+        },
+    )]

--- a/tests/test_pflow.py
+++ b/tests/test_pflow.py
@@ -7,7 +7,8 @@ import cmath
 import numpy as np
 import scipy.io as sio
 from uqgrid.io.parse import load_matpower, load_psse
-from uqgrid.simulation.pflow import runpf
+from uqgrid.core.psydef import Bus
+from uqgrid.simulation.pflow import _project_reactive_dispatch, runpf
 
 EPS = 1e-8
 
@@ -89,3 +90,83 @@ def test_power_flow_from_psse(data_dir):
         computed_angle = v[2 * bus_idx + 1] * rad2ang
         assert np.isclose(computed_angle, expected_angle, rtol=rtol), \
             f'Bus ({bus_idx}) voltage angle differs: expected {expected_angle}, got {computed_angle}'
+
+
+def test_reactive_dispatch_projection_respects_individual_limits():
+    dispatch = _project_reactive_dispatch(
+        total_q=0.8,
+        lower=np.array([-0.2, 0.0]),
+        upper=np.array([0.2, 1.0]),
+    )
+
+    np.testing.assert_allclose(dispatch, [0.2, 0.6])
+    assert np.sum(dispatch) == pytest.approx(0.8)
+
+
+def test_power_flow_q_limit_enforcement_is_opt_in(data_dir):
+    psys = load_matpower(os.path.join(data_dir, "case9.m"))
+    psys.gens[1].qgub = 0.02
+    psys.createYbusComplex()
+
+    result = runpf(psys, verbose=False)
+
+    assert result.gen_qsch[1] > psys.gens[1].qgub
+    assert result.bus_types[1] == Bus.PV
+    assert not result.q_limit_enforced
+    assert result.q_limit_events == []
+
+
+def test_power_flow_qmax_active_set_switches_pv_bus_to_pq(data_dir):
+    psys = load_matpower(os.path.join(data_dir, "case9.m"))
+    psys.gens[1].qgub = 0.02
+    original_voltage_setpoint = psys.buses[1].v0m
+    psys.createYbusComplex()
+
+    result = runpf(psys, verbose=False, enforce_q_limits=True)
+
+    assert result.gen_qsch[1] == pytest.approx(psys.gens[1].qgub)
+    assert result.bus_types[1] == Bus.PQ
+    assert result.v_magnitudes[1] < original_voltage_setpoint
+    assert result.q_limit_enforced
+    assert result.q_limit_iterations == 2
+    assert result.q_limit_events[0]["side"] == "upper"
+    assert psys.buses[1].type == Bus.PV
+    assert psys.gens[1].qsch != pytest.approx(psys.gens[1].qgub)
+
+
+def test_power_flow_qmin_active_set_switches_pv_bus_to_pq(data_dir):
+    psys = load_matpower(os.path.join(data_dir, "case9.m"))
+    psys.gens[2].qglb = -0.05
+    psys.createYbusComplex()
+
+    result = runpf(psys, verbose=False, enforce_q_limits=True)
+
+    assert result.gen_qsch[2] == pytest.approx(psys.gens[2].qglb)
+    assert result.bus_types[2] == Bus.PQ
+    assert result.q_limit_events[0]["side"] == "lower"
+
+
+def test_power_flow_projects_q_across_generators_before_switching_bus(data_dir):
+    psys = load_matpower(os.path.join(data_dir, "case9.m"))
+    psys.gens[1].qgub = 0.02
+    psys.add_gen(
+        bus=1,
+        idx_name="2",
+        psch=0.0,
+        qsch=0.0,
+        pgub=100.0,
+        pglb=0.0,
+        qgub=100.0,
+        qglb=-100.0,
+    )
+    psys.createYbusComplex()
+
+    result = runpf(psys, verbose=False, enforce_q_limits=True)
+
+    assert result.bus_types[1] == Bus.PV
+    assert result.q_limit_events == []
+    assert result.gen_qsch[1] == pytest.approx(psys.gens[1].qgub)
+    assert result.gen_qsch[-1] > result.gen_qsch[1]
+    assert np.sum(result.gen_qsch[[1, -1]]) == pytest.approx(
+        result.s_inj_vector[2*1 + 1]
+    )

--- a/tests/test_pflow.py
+++ b/tests/test_pflow.py
@@ -103,12 +103,12 @@ def test_reactive_dispatch_projection_respects_individual_limits():
     assert np.sum(dispatch) == pytest.approx(0.8)
 
 
-def test_power_flow_q_limit_enforcement_is_opt_in(data_dir):
+def test_power_flow_q_limit_enforcement_can_be_disabled(data_dir):
     psys = load_matpower(os.path.join(data_dir, "case9.m"))
     psys.gens[1].qgub = 0.02
     psys.createYbusComplex()
 
-    result = runpf(psys, verbose=False)
+    result = runpf(psys, verbose=False, enforce_q_limits=False)
 
     assert result.gen_qsch[1] > psys.gens[1].qgub
     assert result.bus_types[1] == Bus.PV
@@ -122,7 +122,7 @@ def test_power_flow_qmax_active_set_switches_pv_bus_to_pq(data_dir):
     original_voltage_setpoint = psys.buses[1].v0m
     psys.createYbusComplex()
 
-    result = runpf(psys, verbose=False, enforce_q_limits=True)
+    result = runpf(psys, verbose=False)
 
     assert result.gen_qsch[1] == pytest.approx(psys.gens[1].qgub)
     assert result.bus_types[1] == Bus.PQ

--- a/tests/test_power_flow_validation.py
+++ b/tests/test_power_flow_validation.py
@@ -1,0 +1,242 @@
+import json
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from uqgrid.core.psydef import Bus
+from uqgrid.io.parse import load_matpower
+from uqgrid.simulation import dynamics
+from uqgrid.simulation.config import IntegrationConfig
+from uqgrid.simulation.pflow import (
+    PowerFlowValidationError,
+    compute_branch_loading_diagnostics,
+    runpf,
+    validate_power_flow_solution,
+)
+
+
+@pytest.fixture
+def case9():
+    data_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data"
+    )
+    psys = load_matpower(os.path.join(data_dir, "case9.m"))
+    psys.createYbusComplex()
+    solution = runpf(psys, enforce_q_limits=True)
+    return psys, solution
+
+
+def _validate(psys, solution, **overrides):
+    options = {
+        "residual_tolerance": 1e-8,
+        "generator_limit_tolerance": 1e-6,
+        "voltage_min": 0.9,
+        "voltage_max": 1.1,
+        "branch_loading_max": None,
+        "branch_limit_tolerance": 1e-5,
+        "active_set_voltage_tolerance": 1e-6,
+    }
+    options.update(overrides)
+    return validate_power_flow_solution(psys, solution, **options)
+
+
+def test_valid_solution_produces_json_safe_diagnostics(case9):
+    psys, solution = case9
+
+    diagnostics = _validate(psys, solution)
+
+    assert diagnostics["valid"]
+    assert diagnostics["failure_reasons"] == []
+    assert diagnostics["island_slack"]["invalid_island_count"] == 0
+    json.dumps(diagnostics, allow_nan=False)
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"residual_tolerance": -1e-8},
+        {"generator_limit_tolerance": -1e-6},
+        {"branch_loading_max": 0.0},
+        {"branch_limit_tolerance": -1e-5},
+        {"active_set_voltage_tolerance": -1e-6},
+        {"voltage_min": 1.1, "voltage_max": 0.9},
+    ],
+)
+def test_direct_validation_rejects_invalid_options(case9, options):
+    psys, solution = case9
+
+    with pytest.raises(ValueError):
+        validate_power_flow_solution(psys, solution, **options)
+
+
+def test_validation_accumulates_residual_voltage_and_generator_failures(case9):
+    psys, solution = case9
+    solution.residual_norm = 1e-3
+    solution.v_magnitudes[3] = 0.8
+    solution.v_magnitudes[4] = 1.2
+    solution.gen_psch[1] = psys.gens[1].pgub + 0.1
+    solution.gen_qsch[2] = psys.gens[2].qglb - 0.1
+
+    diagnostics = _validate(psys, solution)
+
+    assert diagnostics["valid"] is False
+    assert diagnostics["failure_reasons"] == [
+        "pf_residual",
+        "gen_p_limit",
+        "gen_q_limit",
+        "voltage_low",
+        "voltage_high",
+    ]
+    assert diagnostics["gen_p"]["violation_count"] == 1
+    assert diagnostics["gen_q"]["violation_count"] == 1
+
+
+def test_validation_rejects_nonfinite_voltage_with_json_safe_output(case9):
+    psys, solution = case9
+    solution.v_magnitudes[3] = np.nan
+
+    diagnostics = _validate(psys, solution)
+
+    assert "nonfinite_voltage" in diagnostics["failure_reasons"]
+    json.dumps(diagnostics, allow_nan=False)
+
+
+def test_branch_loading_tolerance_accepts_and_rejects_same_solution(case9):
+    psys, solution = case9
+    branch = compute_branch_loading_diagnostics(psys, solution)["loading_top"][0]
+    branch_index = branch["branch_index"]
+    apparent_power = max(branch["s_from_mva"], branch["s_to_mva"])
+    psys.branches[branch_index].rateA = apparent_power / 1.0000027227879946
+
+    accepted = _validate(
+        psys,
+        solution,
+        branch_loading_max=1.0,
+        branch_limit_tolerance=1e-5,
+    )
+    rejected = _validate(
+        psys,
+        solution,
+        branch_loading_max=1.0,
+        branch_limit_tolerance=1e-7,
+    )
+
+    assert accepted["branch"]["loading_max"] == pytest.approx(1.0000027227879946)
+    assert accepted["valid"]
+    assert "branch_overload" in rejected["failure_reasons"]
+
+
+@pytest.mark.parametrize(
+    ("gen_index", "bound_name", "bound_value", "side", "voltage_offset"),
+    [
+        (1, "qgub", 0.02, "upper", 1e-3),
+        (2, "qglb", -0.05, "lower", -1e-3),
+    ],
+)
+def test_active_set_complementarity_is_validated(
+        case9, gen_index, bound_name, bound_value, side, voltage_offset):
+    psys, _ = case9
+    setattr(psys.gens[gen_index], bound_name, bound_value)
+    solution = runpf(psys, enforce_q_limits=True)
+    bus_index = psys.gens[gen_index].bus
+    assert solution.q_limit_events[0]["side"] == side
+    solution.v_magnitudes[bus_index] = (
+        psys.buses[bus_index].v0m + voltage_offset
+    )
+
+    diagnostics = _validate(psys, solution)
+
+    assert "active_set_inconsistent" in diagnostics["failure_reasons"]
+    assert diagnostics["active_set"]["violation_count"] == 1
+
+
+def test_validation_requires_one_slack_per_island(case9):
+    psys, solution = case9
+    psys.buses[1].type = Bus.SLACK
+
+    diagnostics = _validate(psys, solution)
+
+    assert "invalid_slack_topology" in diagnostics["failure_reasons"]
+    assert diagnostics["island_slack"]["invalid_island_count"] == 1
+
+
+def test_validation_error_is_raised_before_dynamic_initialization(
+        case9, monkeypatch):
+    psys, solution = case9
+    solution.residual_norm = 1e-3
+    initialized = False
+
+    def fake_runpf(*args, **kwargs):
+        return solution
+
+    def fake_initialize_system(*args, **kwargs):
+        nonlocal initialized
+        initialized = True
+        raise AssertionError("initialize_system must not run")
+
+    monkeypatch.setattr(dynamics, "runpf", fake_runpf)
+    monkeypatch.setattr(dynamics, "initialize_system", fake_initialize_system)
+    config = IntegrationConfig(
+        power_flow_validation={
+            "enabled": True,
+            "residual_tolerance": 1e-8,
+        },
+    )
+
+    with pytest.raises(PowerFlowValidationError) as exc_info:
+        dynamics._initialize_system_from_config(psys, config)
+
+    assert initialized is False
+    assert exc_info.value.diagnostics["failure_reasons"] == ["pf_residual"]
+
+
+def test_disabled_validation_preserves_initialization(case9, monkeypatch):
+    psys, solution = case9
+    solution.residual_norm = 1e-3
+    z0 = np.array([1.0])
+    theta = np.array([2.0])
+
+    monkeypatch.setattr(dynamics, "runpf", lambda *args, **kwargs: solution)
+    monkeypatch.setattr(
+        dynamics,
+        "initialize_system",
+        lambda *args, **kwargs: (z0, theta),
+    )
+
+    actual_solution, actual_z0, actual_theta = (
+        dynamics._initialize_system_from_config(psys, IntegrationConfig())
+    )
+
+    assert actual_solution.validation is None
+    assert actual_z0 is z0
+    assert actual_theta is theta
+
+
+def test_validation_failure_precedes_petsc_setup(monkeypatch):
+    diagnostics = {"valid": False, "failure_reasons": ["gen_q_limit"]}
+    petsc_requested = False
+
+    def fail_initialization(*args, **kwargs):
+        raise PowerFlowValidationError(diagnostics)
+
+    def request_petsc(*args, **kwargs):
+        nonlocal petsc_requested
+        petsc_requested = True
+        return object()
+
+    monkeypatch.setattr(
+        dynamics, "_initialize_system_from_config", fail_initialization,
+    )
+    monkeypatch.setattr(dynamics, "_get_petsc_for_config", request_petsc)
+    psys = SimpleNamespace(power_injection=False)
+    config = IntegrationConfig(
+        petsc=True,
+        power_flow_validation={"enabled": True},
+    )
+
+    with pytest.raises(PowerFlowValidationError):
+        dynamics.integrate_system(psys, config)
+
+    assert petsc_requested is False

--- a/tests/test_pssedyn.py
+++ b/tests/test_pssedyn.py
@@ -248,6 +248,48 @@ def test_static_generator_initialization_and_jacobian(data_dir, tmp_path):
     assert mismatches == []
 
 
+def test_petsc_uses_q_limited_initial_power_flow(data_dir, monkeypatch):
+    pytest.importorskip("petsc4py")
+    from uqgrid.simulation import dynamics
+
+    psys = load_psse(raw_filename=os.path.join(data_dir, "ieee9_v33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "ieee9bus.dyr"))
+    psys.gens[1].qgub = 0.02
+    psys.add_busfault(4, 1e-4)
+    psys.createYbusComplex()
+    captured = []
+    original_runpf = dynamics.runpf
+
+    def recording_runpf(*args, **kwargs):
+        result = original_runpf(*args, **kwargs)
+        captured.append(result)
+        return result
+
+    monkeypatch.setattr(dynamics, "runpf", recording_runpf)
+    config = IntegrationConfig(
+        steps=2,
+        dt=1.0 / 120.0,
+        power_injection=False,
+        petsc=True,
+        ton=10.0,
+        toff=11.0,
+        enforce_q_limits=True,
+        power_flow_validation={
+            "enabled": True,
+            "voltage_min": 0.9,
+            "voltage_max": 1.1,
+        },
+    )
+
+    result = integrate_system(psys, config)
+
+    assert len(captured) == 1
+    assert captured[0].q_limit_events[0]["side"] == "upper"
+    assert captured[0].gen_qsch[1] == pytest.approx(psys.gens[1].qgub)
+    assert result["power_flow_diagnostics"] == captured[0].validation
+    assert result["history"].shape[1] == 2
+
+
 def test_static_generators_reject_inconsistent_voltage_setpoints(data_dir, tmp_path):
     psys = load_psse(raw_filename=os.path.join(data_dir, "ieee9_v33.raw"))
     psys.add_gen(bus=1, idx_name="extra", psch=0.0, qsch=0.0, vset=0.95)

--- a/tests/test_pypower_validation.py
+++ b/tests/test_pypower_validation.py
@@ -44,17 +44,17 @@ def _ppc_from_matpower(case_path):
 def test_pypower_matches_uqgrid_powerflow(case_file, data_dir):
     case_path = os.path.join(data_dir, case_file)
 
-    # UQGrid power flow
+    # Compare the same unconstrained PF formulation in both implementations.
     psys = load_matpower(case_path)
     psys.createYbusComplex()
-    res = runpf(psys, verbose=False)
+    res = runpf(psys, verbose=False, enforce_q_limits=False)
     v = res.v_vector
     vmag_uq = v[0::2]
     vang_uq = v[1::2]
 
     # PYPOWER power flow
     ppc = _ppc_from_matpower(case_path)
-    ppopt = ppoption(VERBOSE=0, OUT_ALL=0)
+    ppopt = ppoption(VERBOSE=0, OUT_ALL=0, ENFORCE_Q_LIMS=0)
     results, success = pp_runpf(ppc, ppopt)
     assert success
 

--- a/uqgrid/__init__.py
+++ b/uqgrid/__init__.py
@@ -12,8 +12,16 @@ __version__ = "0.1.0"
 from .simulation.dynamics import integrate_system, initialize_system
 from .core.psydef import Psystem
 from .io.parse import load_psse, add_dyr, load_matpower, load_gic
-from .simulation.pflow import runpf
-from .simulation.config import IntegrationConfig, IntegrationCtx
+from .simulation.pflow import (
+    PowerFlowValidationError,
+    runpf,
+    validate_power_flow_solution,
+)
+from .simulation.config import (
+    IntegrationConfig,
+    IntegrationCtx,
+    PowerFlowValidationConfig,
+)
 
 # Check if PETSc is available
 try:

--- a/uqgrid/simulation/__init__.py
+++ b/uqgrid/simulation/__init__.py
@@ -2,4 +2,4 @@
 
 from .dynamics import integrate_system, initialize_system, initialize_sensitivities, preallocate_jacobian, coord_to_sparse, preallocate_hessian, compute_equilibrium, compute_rhs_jacobian
 from .jacobian_check import finite_difference_jacobian, compare_jacobians, build_index_map
-from .pflow import runpf
+from .pflow import PowerFlowValidationError, runpf, validate_power_flow_solution

--- a/uqgrid/simulation/config.py
+++ b/uqgrid/simulation/config.py
@@ -43,7 +43,7 @@ class IntegrationConfig(BaseModel):
         description="PETSc-specific command-line options to pass to petsc4py.init.",
     )
     enforce_q_limits: bool = Field(
-        False,
+        True,
         description="Enforce non-slack PV generator Q limits during initial power flow.",
     )
     q_limit_tolerance: float = Field(

--- a/uqgrid/simulation/config.py
+++ b/uqgrid/simulation/config.py
@@ -3,6 +3,28 @@ from typing import Any, List, Optional
 from pydantic import BaseModel, Field, field_validator, model_validator
 import numpy as np
 
+
+class PowerFlowValidationConfig(BaseModel):
+    enabled: bool = False
+    residual_tolerance: float = Field(1e-8, ge=0.0)
+    generator_limit_tolerance: float = Field(1e-6, ge=0.0)
+    voltage_min: Optional[float] = None
+    voltage_max: Optional[float] = None
+    branch_loading_max: Optional[float] = Field(None, gt=0.0)
+    branch_limit_tolerance: float = Field(1e-5, ge=0.0)
+    active_set_voltage_tolerance: float = Field(1e-6, ge=0.0)
+
+    @model_validator(mode="after")
+    def validate_voltage_range(self):
+        if (
+            self.voltage_min is not None
+            and self.voltage_max is not None
+            and self.voltage_min > self.voltage_max
+        ):
+            raise ValueError("power_flow_validation.voltage_min must not exceed voltage_max")
+        return self
+
+
 class IntegrationConfig(BaseModel):
     power_injection: bool = False
     tend: float = Field(10.0, description="Integration end time in seconds.")
@@ -19,6 +41,24 @@ class IntegrationConfig(BaseModel):
     petsc_args: List[str] = Field(
         default_factory=list,
         description="PETSc-specific command-line options to pass to petsc4py.init.",
+    )
+    enforce_q_limits: bool = Field(
+        False,
+        description="Enforce non-slack PV generator Q limits during initial power flow.",
+    )
+    q_limit_tolerance: float = Field(
+        1e-8,
+        ge=0.0,
+        description="Per-unit tolerance for initial power-flow Q-limit activation.",
+    )
+    max_q_limit_iterations: Optional[int] = Field(
+        None,
+        ge=1,
+        description="Maximum active-set power-flow solves; defaults to the PV-bus count plus one.",
+    )
+    power_flow_validation: PowerFlowValidationConfig = Field(
+        default_factory=PowerFlowValidationConfig,
+        description="Optional final operating-point checks before dynamic initialization.",
     )
     solve_powerflow_dynamics: bool = Field(True, description="Solve power flow before dynamics.")
     arkimex: bool = Field(False, description="Use ARKIMEX integrator.")

--- a/uqgrid/simulation/dynamics.py
+++ b/uqgrid/simulation/dynamics.py
@@ -50,7 +50,13 @@ def _get_petsc_for_config(config):
 
 from uqgrid.simulation.config import IntegrationConfig, IntegrationCtx
 from uqgrid.core import Psystem
-from uqgrid.simulation.pflow import runpf, compute_pinj_alt, PowerFlowSolution
+from uqgrid.simulation.pflow import (
+    PowerFlowSolution,
+    PowerFlowValidationError,
+    compute_pinj_alt,
+    runpf,
+    validate_power_flow_solution,
+)
 from uqgrid.simulation.gradients import gradient_p, gradient_xp, gradient_pp
 from uqgrid.simulation.residual import residual_function
 from uqgrid.simulation.herk import integrate_system_herk
@@ -937,6 +943,36 @@ def initialize_system(psys: Psystem, pf_solution: PowerFlowSolution):
     return sysvec, theta
 
 
+def _initialize_system_from_config(psys: Psystem, config: IntegrationConfig):
+    """Solve and initialize the operating point specified by an integration config."""
+    pf_solution = runpf(
+        psys,
+        verbose=False,
+        enforce_q_limits=config.enforce_q_limits,
+        q_limit_tolerance=config.q_limit_tolerance,
+        max_q_limit_iterations=config.max_q_limit_iterations,
+    )
+    validation = config.power_flow_validation
+    if validation.enabled:
+        pf_solution.validation = validate_power_flow_solution(
+            psys,
+            pf_solution,
+            residual_tolerance=validation.residual_tolerance,
+            generator_limit_tolerance=validation.generator_limit_tolerance,
+            voltage_min=validation.voltage_min,
+            voltage_max=validation.voltage_max,
+            branch_loading_max=validation.branch_loading_max,
+            branch_limit_tolerance=validation.branch_limit_tolerance,
+            active_set_voltage_tolerance=(
+                validation.active_set_voltage_tolerance
+            ),
+        )
+        if not pf_solution.validation["valid"]:
+            raise PowerFlowValidationError(pf_solution.validation)
+    z0, theta = initialize_system(psys, pf_solution)
+    return pf_solution, z0, theta
+
+
 def initialize_sensitivities(volt, p_inj, psys, z, u, v):
 
     alg_size = psys.num_dof_alg
@@ -1614,8 +1650,9 @@ def integrate_system(
     psys.power_injection=power_injection
 
     # retrieve parameters
-    pf_solution = runpf(psys, verbose=False)
-    z0, theta = initialize_system(psys, pf_solution)
+    pf_solution, z0, theta = _initialize_system_from_config(psys, config)
+    if pf_solution.validation is not None:
+        results["power_flow_diagnostics"] = pf_solution.validation
 
     # Use context if provided, otherwise fallback to config attributes
     z0_user = ctx.z0_user if ctx is not None else getattr(config, 'z0_user', None)

--- a/uqgrid/simulation/herk.py
+++ b/uqgrid/simulation/herk.py
@@ -133,10 +133,9 @@ def integrate_system_herk(psys, config, ctx=None):
     import math
 
     from uqgrid.simulation.dynamics import (
-        initialize_system,
+        _initialize_system_from_config,
         preallocate_jacobian,
     )
-    from uqgrid.simulation.pflow import runpf
 
     if config.petsc:
         raise ValueError("HERK driver does not support PETSc.")
@@ -159,8 +158,7 @@ def integrate_system_herk(psys, config, ctx=None):
 
     psys.power_injection = config.power_injection
 
-    pf_solution = runpf(psys, verbose=False)
-    z0, theta = initialize_system(psys, pf_solution)
+    pf_solution, z0, theta = _initialize_system_from_config(psys, config)
 
     z0_user = ctx.z0_user if ctx is not None else getattr(config, "z0_user", None)
     theta_user = ctx.theta_user if ctx is not None else getattr(config, "theta_user", None)
@@ -225,4 +223,7 @@ def integrate_system_herk(psys, config, ctx=None):
     if nsteps - 1 < step_off and len(psys.fault_events) > 0:
         psys.fault_events[0].remove()
 
-    return {"tvec": tvec, "history": history}
+    results = {"tvec": tvec, "history": history}
+    if pf_solution.validation is not None:
+        results["power_flow_diagnostics"] = pf_solution.validation
+    return results

--- a/uqgrid/simulation/pflow.py
+++ b/uqgrid/simulation/pflow.py
@@ -823,11 +823,11 @@ def validate_power_flow_solution(
 def runpf(
         psys,
         verbose=False,
-        enforce_q_limits=False,
+        enforce_q_limits=True,
         q_limit_tolerance=1e-8,
         max_q_limit_iterations=None,
 ):
-    """Solve AC power flow, optionally enforcing non-slack PV generator Q limits.
+    """Solve AC power flow, enforcing non-slack PV generator Q limits by default.
 
     Q-limit enforcement uses an outer active set. After each Newton solve, the
     required aggregate generator Q at every PV bus is compared with the summed

--- a/uqgrid/simulation/pflow.py
+++ b/uqgrid/simulation/pflow.py
@@ -1,4 +1,5 @@
 import numpy as np
+import networkx as nx
 from numba import jit
 from scipy.sparse import csr_matrix
 from scipy import optimize
@@ -27,12 +28,34 @@ class PowerFlowSolution:
         self.gen_psch = np.zeros(num_gens)
         self.gen_qsch = np.zeros(num_gens)
 
+        # Q-limit active-set diagnostics. These remain populated with the
+        # original bus types and empty events when limit enforcement is off.
+        self.bus_types = np.zeros(num_buses, dtype=np.int64)
+        self.q_limit_enforced = False
+        self.q_limit_iterations = 0
+        self.q_limit_events = []
+        self.residual_norm = None
+        self.validation = None
+
     def __str__(self):
         return (f"PowerFlowSolution:\n"
                 f"  V_magnitudes: {self.v_magnitudes[:3]}... ({len(self.v_magnitudes)} buses)\n"
                 f"  V_angles: {self.v_angles[:3]}... ({len(self.v_angles)} buses)\n"
                 f"  Gen Ps Psch entries: {len(self.gen_psch)}\n"
                 f"  Gen Qs Qsch entries: {len(self.gen_qsch)}")
+
+
+class PowerFlowValidationError(RuntimeError):
+    """Raised when an enabled final operating-point validation fails."""
+
+    def __init__(self, diagnostics):
+        self.diagnostics = diagnostics
+        reasons = ", ".join(diagnostics.get("failure_reasons", []))
+        super().__init__(
+            "Power-flow operating-point validation failed"
+            + (f": {reasons}" if reasons else "")
+        )
+
 
 @jit(nopython=True, cache=True)
 def resfun(F, x, vmag, vang, Pinj, Qinj, ybus_mat,
@@ -287,7 +310,535 @@ def compute_pinj_alt(v, Sinj, ybus_mat, graph_mat, nbus):
             Sinj[2*fr_bus + 1] += vmag_i*vmag_j*(gij*np.sin(angleij)
                 - bij*np.cos(angleij))
 
-def runpf(psys, verbose=False):
+
+def _project_reactive_dispatch(total_q, lower, upper, tolerance=1e-10):
+    """Project equal Q sharing onto generator bounds while preserving the sum."""
+    lower = np.asarray(lower, dtype=float)
+    upper = np.asarray(upper, dtype=float)
+    if lower.shape != upper.shape:
+        raise ValueError("Reactive-power lower and upper bounds must have matching shapes")
+    if lower.size == 0:
+        raise ValueError("Cannot dispatch reactive power at a bus with no generators")
+    if np.any(lower > upper):
+        raise ValueError("Reactive-power lower bound exceeds upper bound")
+
+    lower_sum = float(np.sum(lower))
+    upper_sum = float(np.sum(upper))
+    if total_q < lower_sum - tolerance or total_q > upper_sum + tolerance:
+        raise ValueError(
+            f"Reactive-power target {total_q:.6e} is outside aggregate bounds "
+            f"[{lower_sum:.6e}, {upper_sum:.6e}]"
+        )
+
+    target = float(np.clip(total_q, lower_sum, upper_sum))
+    dispatch = np.zeros_like(lower)
+    free = np.ones(lower.size, dtype=bool)
+    remaining = target
+
+    while np.any(free):
+        share = remaining / int(np.sum(free))
+        below = free & (share < lower)
+        above = free & (share > upper)
+
+        if not np.any(below) and not np.any(above):
+            dispatch[free] = share
+            break
+
+        if np.any(below):
+            dispatch[below] = lower[below]
+            remaining -= float(np.sum(dispatch[below]))
+            free[below] = False
+        if np.any(above):
+            dispatch[above] = upper[above]
+            remaining -= float(np.sum(dispatch[above]))
+            free[above] = False
+
+    mismatch = target - float(np.sum(dispatch))
+    if abs(mismatch) > tolerance:
+        if mismatch > 0.0:
+            adjustable = np.where(dispatch < upper - tolerance)[0]
+        else:
+            adjustable = np.where(dispatch > lower + tolerance)[0]
+        if adjustable.size == 0:
+            raise RuntimeError("Reactive-power projection failed to preserve its sum")
+        dispatch[adjustable[0]] += mismatch
+
+    return dispatch
+
+
+def _power_flow_indices(bus_type):
+    """Return Newton unknown indices for the supplied working bus types."""
+    pq_bus = np.where(bus_type == Bus.PQ, 1, 0)
+    pq_idx = np.where(pq_bus == 1, np.cumsum(pq_bus), pq_bus) - 1
+
+    pqv_bus = (
+        np.where(bus_type == Bus.PQ, 1, 0)
+        + np.where(bus_type == Bus.PV, 1, 0)
+    )
+    pqv_idx = np.where(pqv_bus == 1, np.cumsum(pqv_bus), pqv_bus) - 1
+    return pq_idx, pqv_idx
+
+
+def _solve_power_flow_once(psys, bus_type, vmag, vang, Pinj, Qinj, verbose, pass_idx):
+    """Solve one Newton power flow for a fixed active set of bus types."""
+    nslack = int(np.sum(bus_type == Bus.SLACK))
+    npv = int(np.sum(bus_type == Bus.PV))
+    npq = int(np.sum(bus_type == Bus.PQ))
+
+    if verbose:
+        logger.info(
+            "Solving power flow pass %d with nslack: %d, nPV: %d, nPQ: %d",
+            pass_idx,
+            nslack,
+            npv,
+            npq,
+        )
+
+    pq_idx, pqv_idx = _power_flow_indices(bus_type)
+    x0 = np.zeros(2*npq + npv)
+
+    for i in range(psys.nbuses):
+        if pq_idx[i] >= 0:
+            x0[pq_idx[i]] = vmag[i]
+        if pqv_idx[i] >= 0:
+            x0[npq + pqv_idx[i]] = vang[i]
+
+    fun = lambda x: resfun_wrapper(
+        x, vmag, vang, Pinj, Qinj, psys.ybus_mat, bus_type,
+        pq_idx, pqv_idx, psys.graph_mat,
+    )
+    jac = lambda x: jac_wrapper(
+        x, vmag, vang, Pinj, Qinj, psys.ybus_mat, bus_type,
+        pq_idx, pqv_idx, psys.graph_mat,
+    )
+
+    if verbose:
+        logger.info(
+            "[Power Flow] Initial residual norm: %.6e",
+            np.linalg.norm(fun(x0)),
+        )
+
+    sol, info = nonlin_solve(
+        fun, x0, jacobian=jac, full_output=True, f_tol=1e-9,
+    )
+
+    if not info["success"]:
+        logger.error(info["message"])
+        raise Exception("Power flow solution did not converge")
+
+    for i in range(psys.nbuses):
+        if pq_idx[i] >= 0:
+            vmag[i] = sol[pq_idx[i]]
+        if pqv_idx[i] >= 0:
+            vang[i] = sol[npq + pqv_idx[i]]
+
+    residual_norm = float(np.linalg.norm(fun(sol)))
+    if verbose:
+        logger.info("[Power Flow] Final residual norm: %.6e", residual_norm)
+        logger.info("Power flow pass %d converged.", pass_idx)
+
+    return vmag, vang, residual_norm
+
+
+def _solved_power_injections(psys, vmag, vang):
+    """Return solved bus injections and implied total generator dispatch."""
+    voltage = np.array([vmag, vang]).T.flatten()
+    sinj = np.zeros(2*psys.nbuses)
+    compute_pinj_alt(
+        voltage, sinj, psys.ybus_mat, psys.graph_mat, psys.nbuses,
+    )
+
+    sgen = np.copy(sinj)
+    for load in psys.loads:
+        sgen[2*load.bus] += load.pload
+        sgen[2*load.bus + 1] -= load.qload
+    return voltage, sinj, sgen
+
+
+def _reactive_injections(psys, q_gen):
+    """Build the specified bus Q-injection vector for a Newton pass."""
+    qinj = np.zeros(psys.nbuses, dtype=float)
+    for gen_index, gen in enumerate(psys.gens):
+        qinj[gen.bus] += q_gen[gen_index]
+    for load in psys.loads:
+        qinj[load.bus] += load.qload
+    return qinj
+
+
+def _json_value(value):
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def _generator_limit_diagnostics(psys, values, lower, upper, tolerance, top_n=10):
+    values = np.asarray(values, dtype=float)
+    lower = np.asarray(lower, dtype=float)
+    upper = np.asarray(upper, dtype=float)
+    lower_violation = np.maximum(lower - values, 0.0)
+    upper_violation = np.maximum(values - upper, 0.0)
+    violation = np.maximum(lower_violation, upper_violation)
+    violating = np.where(violation > tolerance)[0]
+    ordered = sorted(violating, key=lambda index: violation[index], reverse=True)
+
+    top = []
+    for gen_index in ordered[:top_n]:
+        gen = psys.gens[int(gen_index)]
+        bus = psys.buses[gen.bus]
+        side = (
+            "lower"
+            if lower_violation[gen_index] > upper_violation[gen_index]
+            else "upper"
+        )
+        top.append({
+            "gen_index": int(gen_index),
+            "gen_id": str(gen.idx),
+            "bus_index": int(gen.bus),
+            "bus_id": _json_value(bus.id),
+            "value": float(values[gen_index]),
+            "lower": float(lower[gen_index]),
+            "upper": float(upper[gen_index]),
+            "violation": float(violation[gen_index]),
+            "side": side,
+            "is_slack": bool(bus.type == Bus.SLACK),
+        })
+
+    return {
+        "violation_count": int(violating.size),
+        "violation_max": float(np.max(violation)) if violation.size else 0.0,
+        "violation_total_abs": (
+            float(np.sum(violation[violating])) if violating.size else 0.0
+        ),
+        "violation_top": top,
+    }
+
+
+def compute_branch_loading_diagnostics(psys, pf_solution, top_n=10):
+    """Return JSON-safe branch apparent-power loading diagnostics."""
+    voltages = pf_solution.v_magnitudes * np.exp(1j * pf_solution.v_angles)
+    records = []
+
+    for branch_index, branch in enumerate(psys.branches):
+        rate = float(getattr(branch, "rateA", 0.0))
+        if rate <= 0.0:
+            continue
+
+        tap = float(branch.tap)
+        shift = float(branch.shift)
+        if tap > 0.0:
+            tpsh = tap * np.exp(1j * np.pi / 180.0 * shift)
+        else:
+            tap = 1.0
+            tpsh = 1.0
+
+        impedance = branch.r + 1j * branch.x
+        if abs(impedance) <= 1e-12:
+            continue
+        y_series = 1.0 / impedance
+        y_shunt = 1j * 0.5 * branch.sh
+        v_from = voltages[branch.fr]
+        v_to = voltages[branch.to]
+        if not np.isfinite(v_from) or not np.isfinite(v_to):
+            continue
+        i_from = ((y_series + y_shunt) / (tap * tap)) * v_from - (
+            y_series / np.conj(tpsh)
+        ) * v_to
+        i_to = -(y_series / tpsh) * v_from + (y_series + y_shunt) * v_to
+        s_from_mva = abs(v_from * np.conj(i_from)) * psys.basemva
+        s_to_mva = abs(v_to * np.conj(i_to)) * psys.basemva
+        loading = max(s_from_mva, s_to_mva) / rate
+        records.append({
+            "branch_index": int(branch_index),
+            "from_bus_index": int(branch.fr),
+            "to_bus_index": int(branch.to),
+            "from_bus_id": _json_value(psys.buses[branch.fr].id),
+            "to_bus_id": _json_value(psys.buses[branch.to].id),
+            "rateA_mva": rate,
+            "s_from_mva": float(s_from_mva),
+            "s_to_mva": float(s_to_mva),
+            "loading": float(loading),
+        })
+
+    records.sort(key=lambda record: record["loading"], reverse=True)
+    return {
+        "available": bool(records),
+        "rated_branch_count": len(records),
+        "loading_max": records[0]["loading"] if records else None,
+        "loading_argmax": records[0]["branch_index"] if records else None,
+        "loading_above_one_count": int(
+            sum(record["loading"] > 1.0 for record in records)
+        ),
+        "loading_top": records[:top_n],
+    }
+
+
+def _island_slack_diagnostics(psys):
+    graph = nx.Graph()
+    graph.add_nodes_from(range(psys.nbuses))
+    graph.add_edges_from((branch.fr, branch.to) for branch in psys.branches)
+
+    islands = []
+    invalid = 0
+    for island_index, component in enumerate(nx.connected_components(graph)):
+        buses = sorted(int(bus) for bus in component)
+        slack_buses = [
+            bus for bus in buses if psys.buses[bus].type == Bus.SLACK
+        ]
+        if len(slack_buses) != 1:
+            invalid += 1
+        islands.append({
+            "island_index": int(island_index),
+            "bus_count": len(buses),
+            "bus_index_sample": buses[:10],
+            "slack_bus_count": len(slack_buses),
+            "slack_bus_indices": slack_buses,
+            "slack_bus_ids": [
+                _json_value(psys.buses[bus].id) for bus in slack_buses
+            ],
+        })
+
+    return {
+        "island_count": len(islands),
+        "invalid_island_count": invalid,
+        "islands": islands,
+    }
+
+
+def _active_set_consistency_diagnostics(psys, pf_solution, tolerance):
+    latest_events = {
+        int(event["bus_index"]): event for event in pf_solution.q_limit_events
+    }
+    violations = []
+    for bus_index, event in latest_events.items():
+        vm = float(pf_solution.v_magnitudes[bus_index])
+        vset = float(psys.buses[bus_index].v0m)
+        side = event["side"]
+        if side == "upper":
+            violation = max(vm - vset, 0.0)
+        else:
+            violation = max(vset - vm, 0.0)
+        if violation > tolerance:
+            violations.append({
+                "bus_index": bus_index,
+                "bus_id": _json_value(psys.buses[bus_index].id),
+                "side": side,
+                "voltage": vm,
+                "voltage_setpoint": vset,
+                "violation": float(violation),
+            })
+
+    violations.sort(key=lambda record: record["violation"], reverse=True)
+    return {
+        "checked_bus_count": len(latest_events),
+        "violation_count": len(violations),
+        "violation_max": (
+            violations[0]["violation"] if violations else 0.0
+        ),
+        "violation_top": violations[:10],
+    }
+
+
+def _slack_margin_diagnostics(psys, pf_solution):
+    records = []
+    for gen_index, gen in enumerate(psys.gens):
+        if psys.buses[gen.bus].type != Bus.SLACK:
+            continue
+        p = float(pf_solution.gen_psch[gen_index])
+        q = float(pf_solution.gen_qsch[gen_index])
+        records.append({
+            "gen_index": int(gen_index),
+            "gen_id": str(gen.idx),
+            "bus_index": int(gen.bus),
+            "bus_id": _json_value(psys.buses[gen.bus].id),
+            "p": p,
+            "pmin": float(gen.pglb),
+            "pmax": float(gen.pgub),
+            "p_lower_margin": p - float(gen.pglb),
+            "p_upper_margin": float(gen.pgub) - p,
+            "q": q,
+            "qmin": float(gen.qglb),
+            "qmax": float(gen.qgub),
+            "q_lower_margin": q - float(gen.qglb),
+            "q_upper_margin": float(gen.qgub) - q,
+        })
+    return records
+
+
+def validate_power_flow_solution(
+        psys,
+        pf_solution,
+        *,
+        residual_tolerance=1e-8,
+        generator_limit_tolerance=1e-6,
+        voltage_min=None,
+        voltage_max=None,
+        branch_loading_max=None,
+        branch_limit_tolerance=1e-5,
+        active_set_voltage_tolerance=1e-6,
+):
+    """Validate a solved operating point without modifying it."""
+    tolerances = {
+        "residual_tolerance": residual_tolerance,
+        "generator_limit_tolerance": generator_limit_tolerance,
+        "branch_limit_tolerance": branch_limit_tolerance,
+        "active_set_voltage_tolerance": active_set_voltage_tolerance,
+    }
+    for name, value in tolerances.items():
+        if value < 0.0:
+            raise ValueError(f"{name} must be non-negative")
+    if (
+        voltage_min is not None
+        and voltage_max is not None
+        and voltage_min > voltage_max
+    ):
+        raise ValueError("voltage_min must not exceed voltage_max")
+    if branch_loading_max is not None and branch_loading_max <= 0.0:
+        raise ValueError("branch_loading_max must be positive")
+
+    failure_reasons = []
+
+    def fail(reason):
+        if reason not in failure_reasons:
+            failure_reasons.append(reason)
+
+    residual_norm = pf_solution.residual_norm
+    residual_valid = (
+        residual_norm is not None
+        and np.isfinite(residual_norm)
+        and residual_norm <= residual_tolerance
+    )
+    if not residual_valid:
+        fail("pf_residual")
+
+    finite_voltage = bool(
+        np.all(np.isfinite(pf_solution.v_magnitudes))
+        and np.all(np.isfinite(pf_solution.v_angles))
+    )
+    if not finite_voltage:
+        fail("nonfinite_voltage")
+
+    p_lower = np.array([gen.pglb for gen in psys.gens], dtype=float)
+    p_upper = np.array([gen.pgub for gen in psys.gens], dtype=float)
+    q_lower = np.array([gen.qglb for gen in psys.gens], dtype=float)
+    q_upper = np.array([gen.qgub for gen in psys.gens], dtype=float)
+    p_limits = _generator_limit_diagnostics(
+        psys,
+        pf_solution.gen_psch,
+        p_lower,
+        p_upper,
+        generator_limit_tolerance,
+    )
+    q_limits = _generator_limit_diagnostics(
+        psys,
+        pf_solution.gen_qsch,
+        q_lower,
+        q_upper,
+        generator_limit_tolerance,
+    )
+    if p_limits["violation_count"]:
+        fail("gen_p_limit")
+    if q_limits["violation_count"]:
+        fail("gen_q_limit")
+
+    finite_magnitudes = pf_solution.v_magnitudes[
+        np.isfinite(pf_solution.v_magnitudes)
+    ]
+    solved_voltage_min = (
+        float(np.min(finite_magnitudes)) if finite_magnitudes.size else None
+    )
+    solved_voltage_max = (
+        float(np.max(finite_magnitudes)) if finite_magnitudes.size else None
+    )
+    if (
+        voltage_min is not None
+        and solved_voltage_min is not None
+        and solved_voltage_min < voltage_min
+    ):
+        fail("voltage_low")
+    if (
+        voltage_max is not None
+        and solved_voltage_max is not None
+        and solved_voltage_max > voltage_max
+    ):
+        fail("voltage_high")
+
+    branch = compute_branch_loading_diagnostics(psys, pf_solution)
+    if (
+        branch_loading_max is not None
+        and branch["loading_max"] is not None
+        and branch["loading_max"] > branch_loading_max + branch_limit_tolerance
+    ):
+        fail("branch_overload")
+
+    active_set = _active_set_consistency_diagnostics(
+        psys, pf_solution, active_set_voltage_tolerance,
+    )
+    if active_set["violation_count"]:
+        fail("active_set_inconsistent")
+
+    island_slack = _island_slack_diagnostics(psys)
+    if island_slack["invalid_island_count"]:
+        fail("invalid_slack_topology")
+
+    diagnostics = {
+        "valid": not failure_reasons,
+        "failure_reasons": failure_reasons,
+        "residual_norm": (
+            float(residual_norm)
+            if residual_norm is not None and np.isfinite(residual_norm)
+            else None
+        ),
+        "residual_tolerance": float(residual_tolerance),
+        "finite_voltage": finite_voltage,
+        "voltage_min": solved_voltage_min,
+        "voltage_max": solved_voltage_max,
+        "voltage_lower_bound": (
+            float(voltage_min) if voltage_min is not None else None
+        ),
+        "voltage_upper_bound": (
+            float(voltage_max) if voltage_max is not None else None
+        ),
+        "generator_limit_tolerance": float(generator_limit_tolerance),
+        "gen_p": p_limits,
+        "gen_q": q_limits,
+        "slack_generators": _slack_margin_diagnostics(psys, pf_solution),
+        "branch": {
+            **branch,
+            "loading_limit": (
+                float(branch_loading_max)
+                if branch_loading_max is not None
+                else None
+            ),
+            "limit_tolerance": float(branch_limit_tolerance),
+        },
+        "active_set": {
+            **active_set,
+            "voltage_tolerance": float(active_set_voltage_tolerance),
+        },
+        "island_slack": island_slack,
+    }
+    return diagnostics
+
+
+def runpf(
+        psys,
+        verbose=False,
+        enforce_q_limits=False,
+        q_limit_tolerance=1e-8,
+        max_q_limit_iterations=None,
+):
+    """Solve AC power flow, optionally enforcing non-slack PV generator Q limits.
+
+    Q-limit enforcement uses an outer active set. After each Newton solve, the
+    required aggregate generator Q at every PV bus is compared with the summed
+    generator limits. A violated bus is projected to the corresponding limits,
+    switched to PQ, and solved again. Feasible multi-generator buses retain PV
+    control and use bounded equal sharing of their aggregate reactive output.
+
+    The input ``psys`` bus types and generator schedules are not modified.
+    """
+    if q_limit_tolerance < 0.0:
+        raise ValueError("q_limit_tolerance must be non-negative")
 
     # Slack  (1) variables: p, q. parameters: vmag, vang.
     # PV gen (2) variables: q, vang. parameters: P, vmag.
@@ -298,146 +849,171 @@ def runpf(psys, verbose=False):
     # vang: voltage angle vector (buses 1 to n)
     # x0: vector of unknowns
 
-    bus_type = np.zeros(psys.nbuses)
+    original_bus_type = np.zeros(psys.nbuses, dtype=np.int64)
     vmag = np.zeros(psys.nbuses, dtype=float)
     vang = np.zeros(psys.nbuses, dtype=float)
     Pinj = np.zeros(psys.nbuses, dtype=float)
-    Qinj = np.zeros(psys.nbuses, dtype=float)
 
     for i in range(psys.nbuses):
         vmag[i] = psys.buses[i].v0m
         vang[i] = psys.buses[i].v0a
-        bus_type[i] = psys.buses[i].type
+        original_bus_type[i] = psys.buses[i].type
 
     for gen in psys.gens:
         Pinj[gen.bus] += gen.psch
-        Qinj[gen.bus] += gen.qsch
 
     for load in psys.loads:
         Pinj[load.bus] -= load.pload
-        Qinj[load.bus] += load.qload
+    bus_to_gen = psys.create_bus_to_gen_map()
+    working_bus_type = np.copy(original_bus_type)
+    q_dispatch = np.array([gen.qsch for gen in psys.gens], dtype=float)
+    qinj = _reactive_injections(psys, q_dispatch)
+    q_limit_events = []
 
-    nslack = np.sum(bus_type == Bus.SLACK)
-    nPV = np.sum(bus_type == Bus.PV)
-    nPQ = np.sum(bus_type == Bus.PQ)
+    if max_q_limit_iterations is None:
+        max_q_limit_iterations = int(np.sum(original_bus_type == Bus.PV)) + 1
+    if max_q_limit_iterations < 1:
+        raise ValueError("max_q_limit_iterations must be at least 1")
 
-    if verbose:
-        logger.info(
-            "Solving power flow with nslack: %d, nPV: %d, nPQ: %d",
-            nslack,
-            nPV,
-            nPQ,
+    pass_idx = 0
+    residual_norm = None
+    while True:
+        pass_idx += 1
+        vmag, vang, residual_norm = _solve_power_flow_once(
+            psys,
+            working_bus_type,
+            vmag,
+            vang,
+            Pinj,
+            qinj,
+            verbose,
+            pass_idx,
+        )
+        voltage, sinj_solved, sgen_dispatch = _solved_power_injections(
+            psys, vmag, vang,
         )
 
-    x0 = np.zeros(2*nPQ + nPV)
+        if not enforce_q_limits:
+            break
 
-    # indexing for PQ buses
-    PQ_bus = np.where(bus_type == Bus.PQ, 1, 0)
-    PQ_idx = (np.where(PQ_bus == 1, np.cumsum(PQ_bus), PQ_bus) - 1)
+        switched = False
+        for bus_index in np.where(working_bus_type == Bus.PV)[0]:
+            gen_indices = bus_to_gen[bus_index]
+            if not gen_indices:
+                raise ValueError(
+                    f"PV bus {psys.buses[bus_index].id} with no generator"
+                )
 
-    # indexing for PQ and PV buses
-    PQV_bus = (np.where(bus_type == Bus.PQ, 1, 0) +
-        np.where(bus_type == Bus.PV, 1, 0))
-    PQV_idx = (np.where(PQV_bus == 1, np.cumsum(PQV_bus), PQV_bus) - 1)
+            lower = np.array(
+                [psys.gens[index].qglb for index in gen_indices],
+                dtype=float,
+            )
+            upper = np.array(
+                [psys.gens[index].qgub for index in gen_indices],
+                dtype=float,
+            )
+            if np.any(lower > upper):
+                raise ValueError(
+                    f"Reactive-power bounds are invalid at bus "
+                    f"{psys.buses[bus_index].id}"
+                )
 
-    # these index sets are used to build the x0 vector.
-    #         [vmag] ~ 1 ... nPQ
-    #   x0 =  [vang] ~ 1 ... nPV
+            q_required = float(sgen_dispatch[2*bus_index + 1])
+            lower_sum = float(np.sum(lower))
+            upper_sum = float(np.sum(upper))
+            side = None
+            if q_required > upper_sum + q_limit_tolerance:
+                side = "upper"
+                fixed_q = upper
+            elif q_required < lower_sum - q_limit_tolerance:
+                side = "lower"
+                fixed_q = lower
+            else:
+                fixed_q = _project_reactive_dispatch(
+                    q_required,
+                    lower,
+                    upper,
+                    tolerance=q_limit_tolerance,
+                )
 
-    for i in range(psys.nbuses):
-        if PQ_idx[i] >= 0:
-            x0[PQ_idx[i]] = psys.buses[i].v0m
+            q_dispatch[gen_indices] = fixed_q
+            if side is None:
+                continue
 
-        if PQV_idx[i] >= 0:
-            x0[nPQ + PQV_idx[i]] = psys.buses[i].v0a
+            working_bus_type[bus_index] = Bus.PQ
+            switched = True
+            q_limit_events.append({
+                "pass": pass_idx,
+                "bus_index": int(bus_index),
+                "bus_id": psys.buses[bus_index].id,
+                "side": side,
+                "q_required": q_required,
+                "q_limit": upper_sum if side == "upper" else lower_sum,
+                "generator_indices": [int(index) for index in gen_indices],
+                "generator_q": [float(value) for value in fixed_q],
+            })
 
-    # pack data structures
-    fun = lambda x : resfun_wrapper(x, vmag, vang, Pinj, Qinj, psys.ybus_mat, bus_type,
-            PQ_idx, PQV_idx, psys.graph_mat)
-    jac = lambda x : jac_wrapper(x, vmag, vang, Pinj, Qinj, psys.ybus_mat, bus_type,
-            PQ_idx, PQV_idx, psys.graph_mat)
+        if not switched:
+            break
+        if pass_idx >= max_q_limit_iterations:
+            raise RuntimeError(
+                "Reactive-power active set did not stabilize within "
+                f"{max_q_limit_iterations} Newton solves"
+            )
+        qinj = _reactive_injections(psys, q_dispatch)
 
-    # https://github.com/scipy/scipy/blob/main/scipy/optimize/_nonlin.py#L116
-    # The only solver in SciPy that allowed me to pass a sparse Jacobian
-    if verbose:
-        initial_residual = fun(x0)
-        logger.info(
-            "[Power Flow] Initial residual norm: %.6e",
-            np.linalg.norm(initial_residual),
-        )
-    
-    sol, info = nonlin_solve(fun, x0, jacobian=jac, full_output=True, f_tol=1e-9)
-    
-    if verbose:
-        final_residual = fun(sol)
-        logger.info(
-            "[Power Flow] Final residual norm: %.6e",
-            np.linalg.norm(final_residual),
-        )
-
-    if info["success"]:
-        if verbose:
-            logger.info("Power flow converged.")
-    else:
-        logger.error(info["message"])
-        raise Exception("Power flow solution did not converge")
-    
-    # Create PowerFlowSolution object to store results
     pf_solution = PowerFlowSolution(psys.nbuses, psys.ngens)
-
-    # retrieve voltage magnitudes and angles
-    for i in range(psys.nbuses):
-        if PQ_idx[i] >= 0:
-            vmag[i] = sol[PQ_idx[i]]
-
-        if PQV_idx[i] >= 0:
-            vang[i] = sol[nPQ + PQV_idx[i]]
-
     pf_solution.v_magnitudes = np.copy(vmag)
     pf_solution.v_angles = np.copy(vang)
-
-    # Populate the flat v_vector in pf_solution
-    pf_solution.v_vector = np.array([pf_solution.v_magnitudes, pf_solution.v_angles]).T.flatten()
-
-    # Compute power injections (sinj_solved) based on the solved voltages
-    sinj_solved = np.zeros(len(pf_solution.v_vector))
-    compute_pinj_alt(pf_solution.v_vector, sinj_solved, psys.ybus_mat, psys.graph_mat, psys.nbuses)
+    pf_solution.v_vector = voltage
     pf_solution.s_inj_vector = sinj_solved
+    pf_solution.bus_types = np.copy(working_bus_type)
+    pf_solution.q_limit_enforced = bool(enforce_q_limits)
+    pf_solution.q_limit_iterations = pass_idx
+    pf_solution.q_limit_events = q_limit_events
+    pf_solution.residual_norm = residual_norm
 
-    bus_to_gen = psys.create_bus_to_gen_map()
+    for gen_index, gen in enumerate(psys.gens):
+        pf_solution.gen_psch[gen_index] = gen.psch
+        pf_solution.gen_qsch[gen_index] = gen.qsch
 
-    # now we compute a vector of generations by substracting the load to sinj
-    sgen_dispatch = np.copy(sinj_solved)
+    switched_pv_buses = {
+        event["bus_index"] for event in q_limit_events
+    }
+    for bus_index, bus_obj in enumerate(psys.buses):
+        gen_indices = bus_to_gen[bus_index]
+        if bus_obj.type in (Bus.PV, Bus.SLACK) and not gen_indices:
+            raise ValueError(f"Generator bus {bus_obj.id} with no generator")
 
-    for load in psys.loads:
-        sgen_dispatch[2*load.bus] += load.pload
-        sgen_dispatch[2*load.bus + 1] -= load.qload
-    
-    for (bus_idx_internal, bus_obj) in enumerate(psys.buses):
-        # For all generators, copy their original Psch unless they are on a slack bus
-        # For all generators, copy their original Qsch unless they are on a slack or PV bus
-        # This ensures gens on PQ buses retain their input Psch/Qsch.
-        for gen_orig_idx in bus_to_gen[bus_idx_internal]:
-            # Start by assuming original values from psys.gens
-            # The psys.gens objects are read-only in this function's context.
-            pf_solution.gen_psch[gen_orig_idx] = psys.gens[gen_orig_idx].psch
-            pf_solution.gen_qsch[gen_orig_idx] = psys.gens[gen_orig_idx].qsch
-
-        ngen_on_bus = len(bus_to_gen[bus_idx_internal]) #
-        if bus_obj.type == Bus.PV: # PV bus
-            if ngen_on_bus == 0: #
-                raise ValueError(f"PV bus {bus_obj.id} with no generator")
-            q_to_dispatch = sgen_dispatch[2*bus_idx_internal + 1] / ngen_on_bus
-            for gen_orig_idx in bus_to_gen[bus_idx_internal]:
-                # Psch is fixed from input for PV bus gens (already set above)
-                pf_solution.gen_qsch[gen_orig_idx] = q_to_dispatch
-        elif bus_obj.type == Bus.SLACK: # Slack bus
-            if ngen_on_bus == 0:
-                raise ValueError(f"Slack bus {bus_obj.id} with no generator")
-            p_to_dispatch = sgen_dispatch[2*bus_idx_internal] / ngen_on_bus
-            q_to_dispatch = sgen_dispatch[2*bus_idx_internal + 1] / ngen_on_bus
-            for gen_orig_idx in bus_to_gen[bus_idx_internal]:
-                pf_solution.gen_psch[gen_orig_idx] = p_to_dispatch
-                pf_solution.gen_qsch[gen_orig_idx] = q_to_dispatch
+        if bus_obj.type == Bus.SLACK:
+            p_share = sgen_dispatch[2*bus_index] / len(gen_indices)
+            q_share = sgen_dispatch[2*bus_index + 1] / len(gen_indices)
+            for gen_index in gen_indices:
+                pf_solution.gen_psch[gen_index] = p_share
+                pf_solution.gen_qsch[gen_index] = q_share
+        elif bus_index in switched_pv_buses:
+            pf_solution.gen_qsch[gen_indices] = q_dispatch[gen_indices]
+        elif bus_obj.type == Bus.PV:
+            q_required = float(sgen_dispatch[2*bus_index + 1])
+            if enforce_q_limits:
+                lower = np.array(
+                    [psys.gens[index].qglb for index in gen_indices],
+                    dtype=float,
+                )
+                upper = np.array(
+                    [psys.gens[index].qgub for index in gen_indices],
+                    dtype=float,
+                )
+                q_values = _project_reactive_dispatch(
+                    q_required,
+                    lower,
+                    upper,
+                    tolerance=q_limit_tolerance,
+                )
+            else:
+                q_values = np.full(
+                    len(gen_indices), q_required / len(gen_indices),
+                )
+            pf_solution.gen_qsch[gen_indices] = q_values
 
     return pf_solution


### PR DESCRIPTION
## Summary

This PR adds default-on reactive-power limit enforcement to the power flow used
for dynamic initialization, together with an opt-in structured validation stage
for the final operating point.

Q-limit enforcement defaults to enabled. Callers that require the legacy
unconstrained operating point can set `enforce_q_limits=false`. Final validation
remains disabled unless explicitly configured because voltage and branch-loading
thresholds are model-specific.

This branch is also the temporary PF dependency base for
`feature-acopf-init` while review proceeds. The dependent branch tracks this
branch directly rather than a GitHub merge-preview ref.

## Active-set power flow

- Enforces non-slack PV generator Q limits by default; explicit opt-out remains
  available with `enforce_q_limits=false`.
- Uses bounded sharing for multiple generators at the same PV bus.
- Projects violated generators to the applicable Q bound, switches the bus from
  PV to PQ in the working active set, and repeats the Newton solve until the
  active set stabilizes.
- Leaves the input system's persistent bus types and generator schedules
  unchanged.
- Records the final Newton residual, active-set iterations, bus types, and
  Q-limit events in `PowerFlowSolution`.

The active set does not enforce slack-generator Q limits or perform slack
redispatch.

## Configuration and validation

`IntegrationConfig` accepts:

```json
{
  "enforce_q_limits": true,
  "q_limit_tolerance": 1e-8,
  "max_q_limit_iterations": null,
  "power_flow_validation": {
    "enabled": true,
    "residual_tolerance": 1e-8,
    "generator_limit_tolerance": 1e-6,
    "voltage_min": 0.9,
    "voltage_max": 1.1,
    "branch_loading_max": 1.0,
    "branch_limit_tolerance": 1e-5,
    "active_set_voltage_tolerance": 1e-6
  }
}
```

When enabled, final PF validation checks:

- Newton residual and finite voltage magnitudes/angles.
- Generator P/Q limits, including slack generators and generators on PQ buses.
- Optional voltage and `rateA` branch-loading bounds.
- Q-limit active-set complementarity.
- Exactly one slack bus per connected electrical island.

Validation failures raise `PowerFlowValidationError` before dynamic device
initialization or PETSc setup. Successful diagnostics are returned as
`results["power_flow_diagnostics"]`.

Backward Euler, PETSc, HERK2, and HERK4 use the same shared PF initialization.
Changes in the dynamics modules are limited to this initialization plumbing; no
dynamic limiter or integration-method behavior is added.

## ACTIVSg500 validation

The local ACTIVSg500 RAW/DYR case was checked with the strict configuration
shown above:

- 29 Q-limit activations over 3 PF solves.
- PF residual: `3.10e-12`.
- Initialized DAE residual infinity norm: `1.99e-12`.
- Generator P violations: `0`.
- Generator Q violations: `0`.
- Active-set inconsistencies: `0`.
- Voltage range: `0.98256` to `1.04` p.u.
- Maximum branch loading: `1.0000027`; accepted by the configured `1e-5`
  branch-limit tolerance.
- Electrical islands: `1`, with exactly one slack bus.
- All 56 SEXS exciters initialized within `EMIN/EMAX`.
- Initial SEXS `Efd` range: `1.60229` to `3.02779`.
- Five undisturbed steps at `dt=1/120 s` produced zero measured state drift.

For the undisturbed check, a fault was registered with activation scheduled
beyond the simulation horizon because the existing integration cleanup assumes
at least one fault event.

## Tests

Latest default-change verification using the project Python environment:

```text
55 passed                          focused PF/config/scenario defaults
104 passed, 2 deselected           broader non-PETSc focused suite
156 passed, 2 skipped, 10 deselected  tracked non-PETSc/non-adjoint suite
```

PETSc runtime tests cannot run inside the local desktop sandbox because MPI is
prevented from opening its listener socket. Solver-independent configuration
forwarding remains covered, and workstation PETSc validation is part of the
dependent feature validation.

The tracked run excludes local untracked `tests/test_state_metadata_export.py`.
That local test expects `bus_num` and `device_number` fields not currently
provided by state-metadata export. It is absent from this PR and unrelated to
the PF changes.

## Out of scope

- Dynamic SEXS or `Efd` limit enforcement.
- Slack-limit enforcement or slack redispatch.
- Transformer tap or switched-shunt control.
- ACOPF behavior.
- The existing zero-fault-event cleanup assumption.
