### PR TITLE
Normalize dynamic integration time grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ psys.set_load_parameters(np.zeros(psys.nloads))
 config = IntegrationConfig(
     tend=2.0,
     dt=1.0 / 120.0,
+    method="cn",
     ton=0.10,
     toff=0.15,
     petsc=True,

--- a/bin/dynamics_driver.py
+++ b/bin/dynamics_driver.py
@@ -27,6 +27,10 @@ def parse_args():
     parser.add_argument('--tend', type=float, default=10.0, help='Integration end time in seconds.')
     parser.add_argument('--dt', type=float, default=1.0/120.0, help='Time step in seconds.')
     parser.add_argument('--steps', type=int, default=-1, help='Number of integration steps.')
+    parser.add_argument(
+        '--method', choices=['beuler', 'cn', 'herk2', 'herk4'],
+        default='beuler', help='Integration method.'
+    )
     parser.add_argument('--verbose', action='store_true', help='Enable verbose output.')
     parser.add_argument('--comp_sens', action='store_true', help='Compute sensitivities.')
     parser.add_argument('--fsolve', action='store_true', help='Use fsolve for nonlinear equations.')
@@ -46,6 +50,7 @@ def parse_args():
             ton=args.ton,
             toff=args.toff,
             steps=args.steps,
+            method=args.method,
             power_injection=False,
             verbose=args.verbose,
             comp_sens=args.comp_sens,

--- a/bin/dynamics_partition_driver.py
+++ b/bin/dynamics_partition_driver.py
@@ -43,6 +43,10 @@ def parse_args(argv: List[str]):
     parser.add_argument('--tend', type=float, default=1.0, help='Simulation end time in seconds.')
     parser.add_argument('--dt', type=float, default=1.0 / 120.0, help='Time step in seconds.')
     parser.add_argument('--steps', type=int, default=-1, help='Number of fixed steps to run.')
+    parser.add_argument(
+        '--method', choices=['beuler', 'cn', 'herk2', 'herk4'],
+        default='beuler', help='Integration method.'
+    )
     parser.add_argument('--ton', type=float, default=0.1, help='Fault activation time.')
     parser.add_argument('--toff', type=float, default=0.2, help='Fault clearing time.')
     parser.add_argument('--verbose', action='store_true', help='Enable verbose logging.')
@@ -68,6 +72,7 @@ def parse_args(argv: List[str]):
             ton=args.ton,
             toff=args.toff,
             steps=args.steps,
+            method=args.method,
             power_injection=False,
             verbose=args.verbose,
             petsc=args.petsc,

--- a/docs/user-guide/dynamics-simulation.md
+++ b/docs/user-guide/dynamics-simulation.md
@@ -26,8 +26,8 @@ psys.add_busfault(bus=1, rfault=0.01)
 ```
 
 The first fault registered is toggled automatically using `IntegrationConfig.ton`
-(fault-on time) and `IntegrationConfig.toff` (fault clearing time). Multiple
-faults can be registered when more elaborate sequencing is needed.
+(fault-on time) and `IntegrationConfig.toff` (fault clearing time). The automatic
+scheduler currently supports one fault event.
 
 ## Initialize with a power flow
 
@@ -52,6 +52,7 @@ from uqgrid.simulation.config import IntegrationConfig
 config = IntegrationConfig(
     tend=10.0,
     dt=1.0 / 120.0,
+    method="cn",
     ton=0.25,
     toff=0.40,
     steps=-1,
@@ -83,9 +84,12 @@ Key fields:
 
 - **tend**: Final simulation time (seconds).
 - **dt**: Integration step size (seconds).
-- **steps**: Optional fixed number of steps (overrides `tend` when positive).
+- **steps**: Number of nominal advances. A positive value overrides `tend` and
+  produces `steps + 1` base samples, including `t=0`.
+- **method**: `"beuler"`, `"cn"`, `"herk2"`, or `"herk4"`.
 - **ton/toff**: Fault activation and removal times.
-- **comp_sens**: Enable adjoint-based sensitivities (requires PETSc).
+- **comp_sens**: Enable adjoint-based sensitivities (requires PETSc and
+  `method="cn"`).
 - **petsc**: Switch to PETSc-backed integrators for improved robustness and
   adjoint capabilities.
 - **enforce_q_limits**: Enforce non-slack PV generator reactive-power limits
@@ -99,6 +103,29 @@ Key fields:
 - **jacobian_check_tol**: Absolute tolerance for reporting FD mismatches.
 - **jacobian_check_top_k**: Number of mismatches to report.
 - **jacobian_check_csv**: Optional CSV file path for mismatch report.
+
+### Integration methods
+
+| Configuration | Backend |
+|---|---|
+| `method="beuler", petsc=False` | Native backward Euler |
+| `method="beuler", petsc=True` | PETSc `TSBEULER` |
+| `method="cn", petsc=True` | PETSc `TSCN` |
+| `method="herk2", petsc=False` | HERK2 |
+| `method="herk4", petsc=False` | HERK4 |
+| `arkimex=True, petsc=True` | PETSc ARKIMEX |
+
+`cn` is explicitly mapped to PETSc `TSCN`. This is not the same as selecting
+the midpoint form of `TSTHETA`; PETSc distinguishes endpoint Crank-Nicolson
+from its theta-method midpoint formulation for DAEs. See the
+[PETSc TSTHETA documentation](https://petsc.org/release/manualpages/TS/TSTHETA/).
+
+`cn` requires PETSc, HERK requires the native backend, and ARKIMEX cannot be
+combined with `cn` or HERK. The library default remains `method="beuler"`.
+Configurations that previously omitted `method` therefore select backward
+Euler. PETSc command-line options may tune solver internals, but options that
+override the configured TS type, time step, horizon, exact-final-time policy,
+or adaptivity are rejected.
 
 ### Initial reactive-power limits
 
@@ -149,17 +176,23 @@ results = integrate_system(psys, config)
 ```
 
 The solver returns a dictionary with time stamps (`tvec`), state trajectory
-(`history`), and optional adjoint outputs when sensitivities are enabled.
-
-When PETSc is unavailable, UQGrid falls back to the pure-Python integrator with
-the same interface.
+(`history`), and optional adjoint outputs when sensitivities are enabled. The
+first column of `history` is the initialized state at `t=0`.
 
 ## Interpret the trajectory
 
 Generator speed deviations, bus voltages, and other state variables can be
-plotted directly from the result arrays. Fault transitions occur immediately
-after the step in which the simulation time first exceeds `ton` or `toff`; a
-zero-step Newton solve re-establishes the algebraic manifold at each transition.
+plotted directly from the result arrays. With `steps=N`, the regular grid runs
+from `0` through `N*dt` and contains `N+1` samples. With `steps=-1`, integration
+ends exactly at `tend`; a shortened final interval is added when needed.
+
+Exact `ton`, `toff`, and `tend` values are inserted when they are off the regular
+grid, so fault events can add samples beyond the base count. Timestamps are
+strictly increasing and are stored once. The fault is active on `[ton, toff)`.
+At each transition, UQGrid holds differential states fixed, solves the
+algebraic equations for the new topology, and stores that post-switch state.
+`ton=0` is rejected when a fault is registered because both the initialized and
+post-switch states cannot occupy the single `t=0` sample.
 
 ```python
 import matplotlib.pyplot as plt
@@ -172,14 +205,25 @@ plt.title("Generator speed response after Bus 1 fault")
 plt.show()
 ```
 
+This normalized time contract changes the axes and potentially the TSI values of
+trajectories produced by older releases. Do not append corrected trajectories to
+an existing dense-history dataset created with the previous convention.
+
 ## Sensitivities and post-processing
 
-Setting `comp_sens=True` and `petsc=True` activates the adjoint solve and adds:
+Setting `comp_sens=True`, `petsc=True`, and `method="cn"` activates the
+adjoint solve and adds:
 
 - `adjoint_cost`: Scalar performance index over the simulated interval.
 - `adjoint_gradient_trajectory`: Contribution from the trajectory (`μᵢ`).
 - `adjoint_gradient_initial`: Contribution from the initial condition (`λᵢ ∂y₀/∂p`).
 - `adjoint_gradient_complete`: Sum of trajectory and initial-condition terms.
+
+Faulted adjoints replay the saved trajectory by time segment and apply the
+fixed-differential algebraic projection jump at each topology transition.
+Backward Euler remains supported for forward PETSc simulation, but its integral
+adjoint is rejected because that combination does not satisfy the repository's
+finite-difference validation.
 
 Example: rank loads by their influence on the monitored quantity.
 

--- a/scripts/run/README.md
+++ b/scripts/run/README.md
@@ -243,6 +243,7 @@ baseline config may omit those optional fields and still run.
     "integration": {
         "tend": 10.0,
         "dt": 0.008333333333333333,
+        "method": "cn",
         "power_injection": false,
         "ton": 0.25,
         "toff": 0.4,
@@ -305,11 +306,34 @@ baseline config may omit those optional fields and still run.
 | | `diagnostics_summary_file` | JSON path for aggregate diagnostics summary |
 | **integration** | `tend` | Simulation end time [s] |
 | | `dt` | Integration time step [s] (default: 1/120) |
+| | `method` | `"beuler"`, `"cn"`, `"herk2"`, or `"herk4"`; omitted values default to backward Euler |
 | | `power_injection` | Use power injection model |
 | | `ton` | Fault onset time [s] |
 | | `toff` | Fault clearing time [s] |
 | | `verbose` | Enable verbose solver output |
 | | `petsc` | Use PETSc solver |
+
+### Time Grid and PETSc Method
+
+`steps=N` means N integration advances and N+1 base samples, including the
+initialized state at `t=0`. With `steps=-1`, the final sample is exactly at
+`tend`, including a shortened last interval when required. Exact off-grid fault
+application and clearing times are inserted into the stored grid. Event samples
+contain the post-switch algebraic state, and the fault is active on
+`[ton, toff)`.
+
+Set `method="cn"` explicitly for PETSc Crank-Nicolson (`TSCN`). Omitting
+`method` selects backward Euler, including when `petsc=true`. Native HERK2/HERK4
+require `petsc=false`; PETSc ARKIMEX is selected separately with
+`arkimex=true`. PETSc options cannot override the configured method or time
+grid. Histories generated before this normalized contract have different time
+axes and should not be appended to corrected dense-history datasets.
+
+Adjoint sensitivities (`comp_sens=true`) require `petsc=true` and
+`method="cn"`. Faulted adjoints use reverse topology segments and algebraic
+projection jump conditions. Forward PETSc backward Euler remains supported,
+but its integral adjoint is rejected because it does not pass finite-difference
+validation.
 
 ### Perturbation and Operating-Point Workflow
 

--- a/scripts/run/config/config_IEEE-39.json
+++ b/scripts/run/config/config_IEEE-39.json
@@ -29,6 +29,7 @@
     "integration": {
         "tend": 10.0,
         "dt": 0.008333333333333333,
+        "method": "cn",
         "power_injection": false,
         "ton": 0.25,
         "toff": 0.4,

--- a/scripts/run/config/config_IEEE-39_stress.json
+++ b/scripts/run/config/config_IEEE-39_stress.json
@@ -49,6 +49,7 @@
     "integration": {
         "tend": 10.0,
         "dt": 0.008333333333333333,
+        "method": "cn",
         "power_injection": false,
         "ton": 0.25,
         "toff": 0.4,

--- a/scripts/run/config/config_IEEE-9.json
+++ b/scripts/run/config/config_IEEE-9.json
@@ -29,6 +29,7 @@
     "integration": {
         "tend": 10.0,
         "dt": 0.008333333333333333,
+        "method": "cn",
         "power_injection": false,
         "ton": 0.25,
         "toff": 0.4,

--- a/scripts/run/config/config_IEEE-9_stress.json
+++ b/scripts/run/config/config_IEEE-9_stress.json
@@ -49,6 +49,7 @@
     "integration": {
         "tend": 10.0,
         "dt": 0.008333333333333333,
+        "method": "cn",
         "power_injection": false,
         "ton": 0.25,
         "toff": 0.4,

--- a/scripts/run/generate_scenarios.py
+++ b/scripts/run/generate_scenarios.py
@@ -1564,6 +1564,7 @@ def _integration_config_from_dict(integration_config=None):
     return IntegrationConfig(
         tend=int_cfg.get("tend", 10.0),
         dt=int_cfg.get("dt", 1 / 120.0),
+        method=int_cfg.get("method", "beuler"),
         power_injection=int_cfg.get("power_injection", False),
         ton=int_cfg.get("ton", 0.25),
         toff=int_cfg.get("toff", 0.4),
@@ -2005,6 +2006,7 @@ def run_single_scenario_worker(
 
         - 'tend': Simulation end time in seconds (default: 10.0)
         - 'dt': Time step in seconds (default: 1/120.0)
+        - 'method': beuler, cn, herk2, or herk4 (default: beuler)
         - 'power_injection': Use power injection model (default: False)
         - 'ton': Fault onset time in seconds (default: 0.25)
         - 'toff': Fault clearing time in seconds (default: 0.4)
@@ -2260,6 +2262,7 @@ def run_single_scenario_worker(
         cfg = IntegrationConfig(
             tend=int_cfg.get('tend', 10.0),           # Simulation end time [s]
             dt=int_cfg.get('dt', 1/120.0),            # Time step [s]
+            method=int_cfg.get('method', 'beuler'),
             power_injection=int_cfg.get('power_injection', False),
             ton=int_cfg.get('ton', 0.25),             # Fault onset time [s]
             toff=int_cfg.get('toff', 0.4),            # Fault clearing time [s]
@@ -3446,6 +3449,7 @@ def get_default_config(model_name: str) -> dict:
         "integration": {
             "tend": 10.0,              # Simulation end time [s]
             "dt": 0.008333333333333333, # Time step [s] (1/120)
+            "method": "cn",
             "power_injection": False,
             "ton": 0.25,               # Fault onset time [s]
             "toff": 0.4,               # Fault clearing time [s]
@@ -3705,6 +3709,7 @@ def main(config_path: str = None):
             "integration": {
                 "tend": 10.0,
                 "dt": 0.008333333333333333,
+                "method": "cn",
                 "power_injection": false,
                 "ton": 0.25,
                 "toff": 0.4,
@@ -3867,6 +3872,7 @@ Examples:
     integration_config = {
         "tend": integration_cfg.get("tend", 10.0),
         "dt": integration_cfg.get("dt", 1/120.0),
+        "method": integration_cfg.get("method", "beuler"),
         "power_injection": integration_cfg.get("power_injection", False),
         "ton": integration_cfg.get("ton", 0.25),
         "toff": integration_cfg.get("toff", 0.4),
@@ -3981,6 +3987,7 @@ Examples:
     print(f"Integration:")
     print(f"  - End time (tend): {integration_config['tend']} s")
     print(f"  - Time step (dt): {integration_config['dt']:.6f} s")
+    print(f"  - Method: {integration_config['method']}")
     print(f"  - Fault onset (ton): {integration_config['ton']} s")
     print(f"  - Fault clearing (toff): {integration_config['toff']} s")
     print(f"  - Power injection: {integration_config['power_injection']}")

--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -62,7 +62,8 @@ def test_config():
         power_injection=False,
         verbose=False,
         comp_sens=True,
-        petsc=True
+        petsc=True,
+        method="cn",
     )
 
 

--- a/tests/test_generate_scenarios_operating_point.py
+++ b/tests/test_generate_scenarios_operating_point.py
@@ -52,6 +52,7 @@ def _dummy_export_psys():
 def test_integration_config_adapter_preserves_q_limit_controls(gs):
     cfg = gs._integration_config_from_dict({
         "petsc": True,
+        "method": "cn",
         "enforce_q_limits": True,
         "q_limit_tolerance": 2e-7,
         "max_q_limit_iterations": 11,
@@ -64,6 +65,7 @@ def test_integration_config_adapter_preserves_q_limit_controls(gs):
     })
 
     assert cfg.petsc is True
+    assert cfg.method == "cn"
     assert cfg.enforce_q_limits is True
     assert cfg.q_limit_tolerance == pytest.approx(2e-7)
     assert cfg.max_q_limit_iterations == 11
@@ -76,6 +78,7 @@ def test_integration_config_adapter_preserves_q_limit_controls(gs):
 def test_default_scenario_config_includes_q_limit_controls(gs):
     integration = gs.get_default_config("IEEE-9")["integration"]
 
+    assert integration["method"] == "cn"
     assert integration["enforce_q_limits"] is True
     assert integration["q_limit_tolerance"] == pytest.approx(1e-8)
     assert integration["max_q_limit_iterations"] is None
@@ -88,6 +91,7 @@ def test_default_scenario_config_includes_q_limit_controls(gs):
     assert validation["branch_loading_max"] == pytest.approx(1.0)
 
     adapted = gs._integration_config_from_dict({})
+    assert adapted.method == "beuler"
     assert adapted.enforce_q_limits is True
     assert adapted.power_flow_validation.enabled is False
 

--- a/tests/test_herk.py
+++ b/tests/test_herk.py
@@ -5,7 +5,7 @@ import pytest
 
 from uqgrid.io.parse import add_dyr, load_psse
 from uqgrid.simulation import dynamics
-from uqgrid.simulation.config import IntegrationConfig
+from uqgrid.simulation.config import IntegrationConfig, IntegrationCtx
 from uqgrid.simulation.dynamics import (
     initialize_system,
     integrate_system,
@@ -39,12 +39,9 @@ def test_config_defaults_preserve_beuler():
     assert cfg.herk_alg_max_iter == 50
 
 
-def test_unknown_method_raises(data_dir):
-    psys = _build_two_bus_psys(data_dir)
-    cfg = IntegrationConfig(method="bogus", tend=0.0, steps=1, petsc=False)
-
-    with pytest.raises(ValueError, match="Unknown integration method: bogus"):
-        integrate_system(psys, cfg)
+def test_unknown_method_raises():
+    with pytest.raises(ValueError, match="method"):
+        IntegrationConfig(method="bogus", tend=0.0, steps=1, petsc=False)
 
 
 def test_beuler_regression_unchanged(data_dir):
@@ -71,6 +68,86 @@ def test_beuler_regression_unchanged(data_dir):
 
     assert np.array_equal(res_default["tvec"], res_explicit["tvec"])
     assert np.allclose(res_default["history"], res_explicit["history"])
+
+
+@pytest.mark.parametrize("method", ["beuler", "herk2", "herk4"])
+def test_fixed_step_drivers_store_initial_state_and_common_grid(data_dir, method):
+    psys = _build_two_bus_no_fault(data_dir)
+    pf_solution = runpf(psys, verbose=False)
+    z0, theta = initialize_system(psys, pf_solution)
+    ctx = IntegrationCtx()
+    ctx.set_initial_conditions(z0.copy())
+    ctx.set_theta(theta.copy())
+    config = IntegrationConfig(
+        method=method,
+        steps=3,
+        dt=0.01,
+        petsc=False,
+        ton=10.0,
+        toff=11.0,
+        power_injection=True,
+    )
+
+    result = integrate_system(psys, config, ctx)
+
+    np.testing.assert_allclose(result["tvec"], [0.0, 0.01, 0.02, 0.03])
+    np.testing.assert_allclose(result["history"][:, 0], z0)
+    assert result["history"].shape[1] == 4
+
+
+@pytest.mark.parametrize("method", ["beuler", "herk2", "herk4"])
+def test_fixed_step_fault_transitions_use_exact_post_switch_states(
+        data_dir, method):
+    psys = _build_two_bus_psys(data_dir)
+    pf_solution = runpf(psys, verbose=False)
+    z0, theta = initialize_system(psys, pf_solution)
+    ctx = IntegrationCtx()
+    ctx.set_initial_conditions(z0.copy())
+    ctx.set_theta(theta.copy())
+    psys.fault_events[0].apply()
+    config = IntegrationConfig(
+        method=method,
+        steps=4,
+        dt=0.01,
+        petsc=False,
+        ton=0.015,
+        toff=0.027,
+        power_injection=True,
+    )
+
+    result = integrate_system(psys, config, ctx)
+
+    expected_times = [0.0, 0.01, 0.015, 0.02, 0.027, 0.03, 0.04]
+    np.testing.assert_allclose(result["tvec"], expected_times)
+    np.testing.assert_allclose(result["history"][:, 0], z0)
+    assert np.all(np.diff(result["tvec"]) > 0.0)
+
+    residual = np.zeros_like(z0)
+    fault = psys.fault_events[0]
+    fault.remove()
+    residual_function(residual, result["history"][:, 1], theta, psys)
+    assert np.linalg.norm(residual[psys.num_dof_dif:], np.inf) < 1e-8
+    fault.apply()
+    residual_function(residual, result["history"][:, 2], theta, psys)
+    assert np.linalg.norm(residual[psys.num_dof_dif:], np.inf) < 1e-8
+    fault.remove()
+    residual_function(residual, result["history"][:, 4], theta, psys)
+    assert np.linalg.norm(residual[psys.num_dof_dif:], np.inf) < 1e-8
+    assert fault.active is False
+
+
+def test_fault_at_initial_time_is_rejected(data_dir):
+    psys = _build_two_bus_psys(data_dir)
+    config = IntegrationConfig(
+        steps=1,
+        dt=0.01,
+        petsc=False,
+        ton=0.0,
+        toff=0.01,
+    )
+
+    with pytest.raises(ValueError, match="ton=0"):
+        integrate_system(psys, config)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration_config.py
+++ b/tests/test_integration_config.py
@@ -6,13 +6,21 @@ from uqgrid.simulation.config import IntegrationConfig
 
 
 def test_integration_config_accepts_slow_partition():
-    cfg = IntegrationConfig(arkimex=True, arkimex_slow_differential=[0, 2, 4])
+    cfg = IntegrationConfig(
+        petsc=True,
+        arkimex=True,
+        arkimex_slow_differential=[0, 2, 4],
+    )
     assert cfg.arkimex_slow_differential == [0, 2, 4]
     assert cfg.arkimex_fast_differential is None
 
 
 def test_integration_config_accepts_fast_partition():
-    cfg = IntegrationConfig(arkimex=True, arkimex_fast_differential=[1, 3])
+    cfg = IntegrationConfig(
+        petsc=True,
+        arkimex=True,
+        arkimex_fast_differential=[1, 3],
+    )
     assert cfg.arkimex_fast_differential == [1, 3]
     assert cfg.arkimex_slow_differential is None
 
@@ -20,6 +28,7 @@ def test_integration_config_accepts_fast_partition():
 def test_integration_config_rejects_both_fast_and_slow_lists():
     with pytest.raises(ValueError):
         IntegrationConfig(
+            petsc=True,
             arkimex=True,
             arkimex_fast_differential=[1, 3],
             arkimex_slow_differential=[0, 2],
@@ -36,6 +45,59 @@ def test_integration_config_q_limit_defaults():
     assert cfg.power_flow_validation.voltage_min is None
     assert cfg.power_flow_validation.branch_loading_max is None
     assert IntegrationConfig(enforce_q_limits=False).enforce_q_limits is False
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"dt": 0.0}, "greater than 0"),
+        ({"steps": 0}, "positive integer"),
+        ({"steps": -2}, "positive integer"),
+        ({"ton": 0.2, "toff": 0.1}, "toff"),
+        ({"method": "bogus"}, "method"),
+        ({"method": "cn"}, "requires `petsc=True`"),
+        ({"method": "herk2", "petsc": True}, "requires `petsc=False`"),
+        ({"comp_sens": True, "petsc": True}, "method='cn'"),
+        ({"comp_sens": True, "petsc": False}, "petsc=True"),
+        ({"arkimex": True}, "requires `petsc=True`"),
+        (
+            {"arkimex": True, "petsc": True, "method": "cn"},
+            "cannot be combined",
+        ),
+        (
+            {"petsc": True, "petsc_args": ["-ts_type", "cn"]},
+            "cannot override",
+        ),
+        (
+            {"petsc": True, "petsc_args": ["-ts_dt=0.01"]},
+            "cannot override",
+        ),
+    ],
+)
+def test_integration_config_rejects_invalid_time_contract(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        IntegrationConfig(**kwargs)
+
+
+def test_integration_config_accepts_explicit_petsc_methods():
+    assert IntegrationConfig(petsc=True, method="beuler").method == "beuler"
+    assert IntegrationConfig(petsc=True, method="cn").method == "cn"
+    assert IntegrationConfig(
+        petsc=True, method="cn", comp_sens=True
+    ).comp_sens is True
+
+
+def test_petsc_method_mapping_is_explicit():
+    class FakePETSc:
+        class TS:
+            class Type:
+                BEULER = "beuler"
+                CN = "cn"
+                ARKIMEX = "arkimex"
+
+    assert dynamics._petsc_ts_type(FakePETSc, "beuler", False) == "beuler"
+    assert dynamics._petsc_ts_type(FakePETSc, "cn", False) == "cn"
+    assert dynamics._petsc_ts_type(FakePETSc, "beuler", True) == "arkimex"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_integration_timing.py
+++ b/tests/test_integration_timing.py
@@ -1,0 +1,147 @@
+import numpy as np
+import pytest
+
+from uqgrid.simulation.timing import build_integration_schedule
+
+
+def test_explicit_steps_include_initial_sample():
+    schedule = build_integration_schedule(
+        dt=0.01,
+        tend=99.0,
+        steps=3,
+        ton=10.0,
+        toff=11.0,
+        has_fault=False,
+    )
+
+    np.testing.assert_allclose(schedule.times, [0.0, 0.01, 0.02, 0.03])
+    assert schedule.fault_on_index is None
+    assert schedule.fault_off_index is None
+
+
+def test_schedule_includes_exact_horizon_and_off_grid_fault_times():
+    schedule = build_integration_schedule(
+        dt=0.01,
+        tend=0.035,
+        steps=-1,
+        ton=0.015,
+        toff=0.027,
+        has_fault=True,
+    )
+
+    np.testing.assert_allclose(
+        schedule.times,
+        [0.0, 0.01, 0.015, 0.02, 0.027, 0.03, 0.035],
+    )
+    assert schedule.fault_on_index == 2
+    assert schedule.fault_off_index == 4
+
+
+def test_schedule_deduplicates_aligned_fault_times():
+    schedule = build_integration_schedule(
+        dt=0.01,
+        tend=0.03,
+        steps=-1,
+        ton=0.01,
+        toff=0.02,
+        has_fault=True,
+    )
+
+    np.testing.assert_allclose(schedule.times, [0.0, 0.01, 0.02, 0.03])
+    assert schedule.fault_on_index == 1
+    assert schedule.fault_off_index == 2
+    assert np.all(np.diff(schedule.times) > 0.0)
+
+
+def test_fault_beyond_horizon_is_not_inserted():
+    schedule = build_integration_schedule(
+        dt=0.01,
+        tend=0.03,
+        steps=-1,
+        ton=0.04,
+        toff=0.05,
+        has_fault=True,
+    )
+
+    np.testing.assert_allclose(schedule.times, [0.0, 0.01, 0.02, 0.03])
+    assert schedule.fault_on_index is None
+    assert schedule.fault_off_index is None
+
+
+def test_fault_active_through_horizon_has_no_clear_index():
+    schedule = build_integration_schedule(
+        dt=0.01,
+        tend=0.03,
+        steps=-1,
+        ton=0.015,
+        toff=0.04,
+        has_fault=True,
+    )
+
+    np.testing.assert_allclose(schedule.times, [0.0, 0.01, 0.015, 0.02, 0.03])
+    assert schedule.fault_on_index == 2
+    assert schedule.fault_off_index is None
+
+
+def test_fault_clearing_at_horizon_uses_final_sample():
+    schedule = build_integration_schedule(
+        dt=0.01,
+        tend=0.035,
+        steps=-1,
+        ton=0.015,
+        toff=0.035,
+        has_fault=True,
+    )
+
+    assert schedule.fault_off_index == len(schedule.times) - 1
+    assert schedule.times[-1] == pytest.approx(0.035)
+
+
+@pytest.mark.parametrize(
+    "overrides, match",
+    [
+        ({"dt": 0.0}, "dt must be positive"),
+        ({"steps": 0}, "steps must be -1 or a positive integer"),
+        ({"steps": -2}, "steps must be -1 or a positive integer"),
+        ({"tend": -1.0}, "tend must be non-negative"),
+        ({"ton": -1.0}, "ton must be non-negative"),
+        ({"ton": 0.02, "toff": 0.01}, "toff must be"),
+    ],
+)
+def test_schedule_rejects_invalid_controls(overrides, match):
+    kwargs = {
+        "dt": 0.01,
+        "tend": 0.03,
+        "steps": -1,
+        "ton": 0.01,
+        "toff": 0.02,
+        "has_fault": False,
+    }
+    kwargs.update(overrides)
+
+    with pytest.raises(ValueError, match=match):
+        build_integration_schedule(**kwargs)
+
+
+def test_schedule_rejects_fault_at_initial_time():
+    with pytest.raises(ValueError, match="ton=0"):
+        build_integration_schedule(
+            dt=0.01,
+            tend=0.03,
+            steps=-1,
+            ton=0.0,
+            toff=0.02,
+            has_fault=True,
+        )
+
+
+def test_schedule_rejects_fault_time_that_deduplicates_to_zero():
+    with pytest.raises(ValueError, match="ton=0"):
+        build_integration_schedule(
+            dt=0.01,
+            tend=0.03,
+            steps=-1,
+            ton=1e-14,
+            toff=0.02,
+            has_fault=True,
+        )

--- a/tests/test_petsc_lazy_init.py
+++ b/tests/test_petsc_lazy_init.py
@@ -90,6 +90,8 @@ def test_dynamics_driver_preserves_sys_argv_and_stores_petsc_args(monkeypatch):
         "--dyr",
         "case.dyr",
         "--petsc",
+        "--method",
+        "cn",
         "--",
         "-ts_monitor",
         "-ksp_type",
@@ -103,6 +105,7 @@ def test_dynamics_driver_preserves_sys_argv_and_stores_petsc_args(monkeypatch):
     assert raw == "case.raw"
     assert dyr == "case.dyr"
     assert config.petsc is True
+    assert config.method == "cn"
     assert config.petsc_args == ["-ts_monitor", "-ksp_type", "gmres"]
 
 

--- a/tests/test_pssedyn.py
+++ b/tests/test_pssedyn.py
@@ -10,7 +10,7 @@ from uqgrid.simulation.jacobian_check import compare_jacobians
 from uqgrid.io.parse import load_psse, add_dyr
 from uqgrid.simulation.pflow import runpf
 from uqgrid.simulation.residual import residual_function
-from uqgrid.simulation.config import IntegrationConfig
+from uqgrid.simulation.config import IntegrationConfig, IntegrationCtx
 
 EPS = 1e-10  # Tolerance for floating-point comparisons
 
@@ -83,6 +83,19 @@ def test_two_bus_system(data_dir):
 
     # Extract simulation history
     history = res["history"]
+    np.testing.assert_allclose(res["tvec"][[0, -1]], [0.0, config.tend])
+
+    # The PSSE trace repeats the pre-switch state at each event time. UQGrid's
+    # normalized contract stores the post-switch algebraic state there, so
+    # compare every sample except the two topology boundaries.
+    comparison_mask = np.ones(history.shape[1], dtype=bool)
+    comparison_mask[np.isclose(res["tvec"], config.ton)] = False
+    comparison_mask[np.isclose(res["tvec"], config.toff)] = False
+    history = history[:, comparison_mask]
+    volt1_p = volt1_p[comparison_mask]
+    volt2_p = volt2_p[comparison_mask]
+    eq_p = eq_p[comparison_mask]
+    speed = speed[comparison_mask]
 
     gen = psys.gendyn[0]
     dif_ptr = gen.dif_ptr
@@ -248,7 +261,8 @@ def test_static_generator_initialization_and_jacobian(data_dir, tmp_path):
     assert mismatches == []
 
 
-def test_petsc_uses_q_limited_initial_power_flow(data_dir, monkeypatch):
+@pytest.mark.parametrize("method", ["beuler", "cn"])
+def test_petsc_uses_q_limited_initial_power_flow(data_dir, monkeypatch, method):
     pytest.importorskip("petsc4py")
     from uqgrid.simulation import dynamics
 
@@ -271,6 +285,7 @@ def test_petsc_uses_q_limited_initial_power_flow(data_dir, monkeypatch):
         dt=1.0 / 120.0,
         power_injection=False,
         petsc=True,
+        method=method,
         ton=10.0,
         toff=11.0,
         enforce_q_limits=True,
@@ -287,7 +302,154 @@ def test_petsc_uses_q_limited_initial_power_flow(data_dir, monkeypatch):
     assert captured[0].q_limit_events[0]["side"] == "upper"
     assert captured[0].gen_qsch[1] == pytest.approx(psys.gens[1].qgub)
     assert result["power_flow_diagnostics"] == captured[0].validation
-    assert result["history"].shape[1] == 2
+    assert result["history"].shape[1] == 3
+    np.testing.assert_allclose(result["tvec"], [0.0, config.dt, 2 * config.dt])
+
+
+def test_petsc_steps_truncate_fault_interval(data_dir, monkeypatch):
+    pytest.importorskip("petsc4py")
+
+    psys = load_psse(raw_filename=os.path.join(data_dir, "ieee9_v33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "ieee9bus.dyr"))
+    psys.add_busfault(4, 1e-4)
+    psys.createYbusComplex()
+    fault = psys.fault_events[0]
+    events = []
+    original_apply = fault.apply
+    original_remove = fault.remove
+
+    def recording_apply():
+        events.append("apply")
+        original_apply()
+
+    def recording_remove():
+        events.append("remove")
+        original_remove()
+
+    monkeypatch.setattr(fault, "apply", recording_apply)
+    monkeypatch.setattr(fault, "remove", recording_remove)
+    config = IntegrationConfig(
+        steps=3,
+        dt=1.0 / 120.0,
+        power_injection=False,
+        petsc=True,
+        ton=1.0 / 120.0,
+        toff=10.0,
+    )
+
+    result = integrate_system(psys, config)
+
+    assert result["tvec"][-1] == pytest.approx(3.0 / 120.0)
+    assert np.max(result["tvec"]) <= 3.0 / 120.0 + 1e-12
+    assert "apply" in events
+    assert events[-1] == "remove"
+    assert fault.active is False
+
+
+@pytest.mark.parametrize("method", ["beuler", "cn"])
+def test_petsc_uses_exact_off_grid_fault_transitions(data_dir, method):
+    pytest.importorskip("petsc4py")
+
+    psys = load_psse(raw_filename=os.path.join(data_dir, "ieee9_v33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "ieee9bus.dyr"))
+    psys.add_busfault(4, 1e-4)
+    psys.createYbusComplex()
+    pf_solution = runpf(psys, verbose=False, enforce_q_limits=True)
+    z0, theta = initialize_system(psys, pf_solution)
+    ctx = IntegrationCtx()
+    ctx.set_initial_conditions(z0.copy())
+    ctx.set_theta(theta.copy())
+    psys.fault_events[0].apply()
+    dt = 1.0 / 120.0
+    config = IntegrationConfig(
+        method=method,
+        steps=4,
+        dt=dt,
+        power_injection=False,
+        petsc=True,
+        ton=1.5 * dt,
+        toff=2.7 * dt,
+    )
+
+    result = integrate_system(psys, config, ctx)
+
+    expected_times = [0.0, dt, 1.5 * dt, 2 * dt, 2.7 * dt, 3 * dt, 4 * dt]
+    np.testing.assert_allclose(result["tvec"], expected_times)
+    np.testing.assert_allclose(result["history"][:, 0], z0)
+    assert np.all(np.diff(result["tvec"]) > 0.0)
+
+    residual = np.zeros_like(z0)
+    fault = psys.fault_events[0]
+    fault.remove()
+    residual_function(residual, result["history"][:, 1], theta, psys)
+    assert np.linalg.norm(residual[psys.num_dof_dif:], np.inf) < 1e-8
+    fault.apply()
+    residual_function(residual, result["history"][:, 2], theta, psys)
+    assert np.linalg.norm(residual[psys.num_dof_dif:], np.inf) < 1e-8
+    fault.remove()
+    residual_function(residual, result["history"][:, 4], theta, psys)
+    assert np.linalg.norm(residual[psys.num_dof_dif:], np.inf) < 1e-8
+    assert fault.active is False
+
+
+def test_petsc_arkimex_uses_common_grid_without_fault(data_dir):
+    pytest.importorskip("petsc4py")
+
+    psys = load_psse(raw_filename=os.path.join(data_dir, "2bus_33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "GENROU.dyr"))
+    psys.createYbusComplex()
+    config = IntegrationConfig(
+        petsc=True,
+        arkimex=True,
+        steps=2,
+        dt=0.01,
+        ton=10.0,
+        toff=11.0,
+        power_injection=True,
+    )
+
+    result = integrate_system(psys, config)
+
+    np.testing.assert_allclose(result["tvec"], [0.0, 0.01, 0.02])
+    assert result["history"].shape[1] == 3
+
+
+def test_petsc_arkimex_uses_exact_off_grid_fault_transitions(data_dir):
+    pytest.importorskip("petsc4py")
+
+    psys = load_psse(raw_filename=os.path.join(data_dir, "2bus_33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "GENROU.dyr"))
+    psys.add_busfault(1, 1.0)
+    psys.createYbusComplex()
+    pf_solution = runpf(psys, verbose=False)
+    z0, theta = initialize_system(psys, pf_solution)
+    ctx = IntegrationCtx()
+    ctx.set_initial_conditions(z0.copy())
+    ctx.set_theta(theta.copy())
+    config = IntegrationConfig(
+        petsc=True,
+        arkimex=True,
+        steps=4,
+        dt=0.01,
+        ton=0.015,
+        toff=0.027,
+        power_injection=True,
+    )
+
+    result = integrate_system(psys, config, ctx)
+
+    np.testing.assert_allclose(
+        result["tvec"], [0.0, 0.01, 0.015, 0.02, 0.027, 0.03, 0.04]
+    )
+    residual = np.zeros_like(z0)
+    fault = psys.fault_events[0]
+    fault.apply()
+    residual_function(residual, result["history"][:, 2], theta, psys)
+    assert np.linalg.norm(residual[psys.num_dof_dif:], np.inf) < 1e-8
+    fault.remove()
+    residual_function(residual, result["history"][:, 4], theta, psys)
+    assert np.linalg.norm(residual[psys.num_dof_dif:], np.inf) < 1e-8
+    assert fault.active is False
 
 
 def test_static_generators_reject_inconsistent_voltage_setpoints(data_dir, tmp_path):

--- a/uqgrid/simulation/config.py
+++ b/uqgrid/simulation/config.py
@@ -27,16 +27,22 @@ class PowerFlowValidationConfig(BaseModel):
 
 class IntegrationConfig(BaseModel):
     power_injection: bool = False
-    tend: float = Field(10.0, description="Integration end time in seconds.")
-    dt: float = Field(1.0 / 120.0, description="Time step in seconds.")
-    steps: int = Field(-1, description="Number of integration steps. If >0, overrides tend.")
+    tend: float = Field(10.0, ge=0.0, description="Integration end time in seconds.")
+    dt: float = Field(1.0 / 120.0, gt=0.0, description="Nominal time step in seconds.")
+    steps: int = Field(
+        -1,
+        description=(
+            "Number of nominal integration advances. If positive, overrides "
+            "tend and produces steps + 1 base samples including t=0."
+        ),
+    )
     verbose: bool = Field(False, description="Enable verbose output.")
     comp_sens: bool = Field(False, description="Compute first and second-order sensitivities.")
     fsolve: bool = Field(False, description="Use fsolve for solving nonlinear equations.")
     newton_tol: float = Field(1e-10, gt=0.0, description="Newton residual norm tolerance.")
     newton_max_iter: int = Field(500, gt=0, description="Maximum Newton iterations per integration step.")
-    ton: float = Field(0.25, description="Fault activation time.")
-    toff: float = Field(0.4, description="Fault deactivation time.")
+    ton: float = Field(0.25, ge=0.0, description="Fault activation time.")
+    toff: float = Field(0.4, ge=0.0, description="Fault deactivation time.")
     petsc: bool = Field(False, description="Enable PETSc integration.")
     petsc_args: List[str] = Field(
         default_factory=list,
@@ -80,31 +86,76 @@ class IntegrationConfig(BaseModel):
             " must be treated as fast in the ARKIMEX fast/slow split."
         ),
     )
-    method: str = Field("beuler", description="Integrator method: beuler | herk2 | herk4.")
+    method: str = Field(
+        "beuler",
+        description="Integrator method: beuler | cn | herk2 | herk4.",
+    )
     herk_alg_tol: float = Field(1e-10, gt=0.0, description="HERK stage algebraic tolerance.")
     herk_alg_max_iter: int = Field(50, gt=0, description="HERK stage Newton max iterations.")
 
-    @field_validator('tend', 'dt', 'ton', 'toff', mode='after')
-    def positive_values(cls, v, info: Any):
-        if v < 0:
-            raise ValueError(f"`{info.field_name}` must be non-negative.")
-        return v
-
     @field_validator('steps', mode='after')
     def steps_non_negative(cls, v, info: Any):
-        if v < -1:
-            raise ValueError("`steps` must be -1 or a non-negative integer.")
+        if v == 0 or v < -1:
+            raise ValueError("`steps` must be -1 or a positive integer.")
         return v
 
+    @field_validator("method")
+    def supported_method(cls, value):
+        if value not in {"beuler", "cn", "herk2", "herk4"}:
+            raise ValueError(
+                "`method` must be one of: beuler, cn, herk2, herk4."
+            )
+        return value
+
     @model_validator(mode="after")
-    def validate_partition_spec(cls, values):
-        slow = values.arkimex_slow_differential
-        fast = values.arkimex_fast_differential
+    def validate_integration_contract(self):
+        slow = self.arkimex_slow_differential
+        fast = self.arkimex_fast_differential
         if slow is not None and fast is not None:
             raise ValueError(
                 "Specify only one of `arkimex_slow_differential` or `arkimex_fast_differential`."
             )
-        return values
+        if self.toff < self.ton:
+            raise ValueError("`toff` must be greater than or equal to `ton`.")
+        if self.method == "cn" and not self.petsc:
+            raise ValueError("`method='cn'` requires `petsc=True`.")
+        if self.method in {"herk2", "herk4"} and self.petsc:
+            raise ValueError(f"`method='{self.method}'` requires `petsc=False`.")
+        if self.comp_sens and (not self.petsc or self.method != "cn"):
+            raise ValueError(
+                "`comp_sens=True` requires `petsc=True` and `method='cn'`."
+            )
+        if self.arkimex:
+            if not self.petsc:
+                raise ValueError("`arkimex=True` requires `petsc=True`.")
+            if self.method != "beuler":
+                raise ValueError(
+                    "`arkimex=True` cannot be combined with `cn`, `herk2`, or `herk4`."
+                )
+
+        reserved_petsc_options = {
+            "ts_type",
+            "ts_theta_theta",
+            "ts_theta_endpoint",
+            "ts_dt",
+            "ts_max_time",
+            "ts_max_steps",
+            "ts_exact_final_time",
+            "ts_time_span",
+            "ts_adapt_type",
+        }
+        conflicts = sorted({
+            arg.lstrip("-").split("=", 1)[0]
+            for arg in self.petsc_args
+            if arg.startswith("-")
+            and arg.lstrip("-").split("=", 1)[0] in reserved_petsc_options
+        })
+        if conflicts:
+            raise ValueError(
+                "PETSc options cannot override IntegrationConfig method or time grid: "
+                + ", ".join(f"-{name}" for name in conflicts)
+            )
+        return self
     
 class IntegrationCtx:
     def __init__(self):

--- a/uqgrid/simulation/dynamics.py
+++ b/uqgrid/simulation/dynamics.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import copy
-import math
 from typing import Optional
 
 import numdifftools as nd
@@ -48,6 +47,43 @@ def _get_petsc_for_config(config):
         return None
     return _initialize_petsc(config.petsc_args)
 
+
+def _petsc_ts_type(PETSc, method, arkimex):
+    if arkimex:
+        return PETSc.TS.Type.ARKIMEX
+    if method == "beuler":
+        return PETSc.TS.Type.BEULER
+    if method == "cn":
+        return PETSc.TS.Type.CN
+    raise ValueError(f"Unsupported PETSc integration method: {method}")
+
+
+def _algebraic_projection_adjoint(
+        psys, state, theta, jacobian, lambda_values, mu_values):
+    """Apply the adjoint jump for a fixed-differential algebraic projection."""
+    ndiff = psys.num_dof_dif
+    residual_jacobian(jacobian, state, theta, psys)
+    algebraic_jacobian = jacobian[ndiff:, ndiff:].tocsc()
+    differential_jacobian = jacobian[ndiff:, :ndiff]
+    multiplier = spsolve(
+        algebraic_jacobian.transpose().tocsc(),
+        lambda_values[ndiff:],
+    )
+
+    parameter_jacobian = preallocate_jacobian_parameters(psys)
+    residual_jacobian_parameters(parameter_jacobian, state, theta, psys)
+
+    projected_lambda = np.array(lambda_values, copy=True)
+    projected_lambda[:ndiff] -= np.asarray(
+        differential_jacobian.transpose().dot(multiplier)
+    ).ravel()
+    projected_lambda[ndiff:] = 0.0
+    projected_mu = np.array(mu_values, copy=True)
+    projected_mu -= np.asarray(
+        parameter_jacobian[ndiff:, :].transpose().dot(multiplier)
+    ).ravel()
+    return projected_lambda, projected_mu
+
 from uqgrid.simulation.config import IntegrationConfig, IntegrationCtx
 from uqgrid.core import Psystem
 from uqgrid.simulation.pflow import (
@@ -61,6 +97,7 @@ from uqgrid.simulation.gradients import gradient_p, gradient_xp, gradient_pp
 from uqgrid.simulation.residual import residual_function
 from uqgrid.simulation.herk import integrate_system_herk
 from uqgrid.simulation.jacobian import residual_jacobian
+from uqgrid.simulation.timing import build_integration_schedule
 from uqgrid.utils.tools import (
     matprint,
     csr_mult_row,
@@ -1168,12 +1205,10 @@ def preallocate_hessian(psys):
 
 class DAE_petsc(object):
         n = 1
-        def __init__(self, psys, theta, J, tfon, tfoff):
+        def __init__(self, psys, theta, J):
             self.psys = psys
             self.theta = theta
             self.J = J
-            self.tfon = tfon
-            self.tfoff = tfoff
 
             # ARKIMEX INFORMATION
             self.slow_indices = None
@@ -1206,17 +1241,6 @@ class DAE_petsc(object):
             self.ts_ref = ts
         
         def evalFunction(self, ts, t, x, xdot, f):
-            # This operation is redundant but necessary for the correct
-            # computation of the adjoint in the backward run. Might
-            # not generalize when we consider multiple faults.
-            # (TODO): consider using TSEvent.
-            if t < self.tfon:
-                self.psys.fault_events[0].remove()
-            elif t > self.tfoff:
-                self.psys.fault_events[0].remove()
-            else:
-                self.psys.fault_events[0].apply()
-
             start, end = x.getOwnershipRange()
             NDIFFEQ = self.psys.num_dof_dif
             xx = np.array(x[start:end])
@@ -1227,12 +1251,6 @@ class DAE_petsc(object):
             f.assemble()
         
         def evalJacobian(self, ts, t, x, xdot, a, J, P):
-            if t < self.tfon:
-                self.psys.fault_events[0].remove()
-            elif t > self.tfoff:
-                self.psys.fault_events[0].remove()
-            else:
-                self.psys.fault_events[0].apply()
             start, end = x.getOwnershipRange()
             NDIFFEQ = self.psys.num_dof_dif
             xx = np.array(x[start:end])
@@ -1635,7 +1653,7 @@ def integrate_system(
     arkimex = config.arkimex
     method = config.method
 
-    if method == "beuler":
+    if method in {"beuler", "cn"}:
         pass
     elif method in {"herk2", "herk4"}:
         return integrate_system_herk(psys, config, ctx)
@@ -1713,16 +1731,19 @@ def integrate_system(
                 for m in mismatches:
                     writer.writerow(m)
 
-    # calculate nsteps
-    h = dt
-    if steps > 0:
-        nsteps = steps
-    else:
-        nsteps = int(math.floor(tend/dt)) + 1
-
-    # hacky fault event time step calculation
-    step_on = int(ton/h)
-    step_off = int(toff/h)
+    has_fault = bool(psys.fault_events)
+    schedule = build_integration_schedule(
+        dt=dt,
+        tend=tend,
+        steps=steps,
+        ton=ton,
+        toff=toff,
+        has_fault=has_fault,
+    )
+    tvec = schedule.times
+    fault = psys.fault_events[0] if has_fault else None
+    if fault is not None:
+        fault.remove()
 
     # Integration of D.A.E
     z = z0
@@ -1768,10 +1789,12 @@ def integrate_system(
         rhs_vec = z0p.duplicate()
 
         # Create integration object
-        dae = DAE_petsc(psys, theta, jacobian, ton, toff)
+        dae = DAE_petsc(psys, theta, jacobian)
 
         ts = PETSc.TS().create(comm=PETSc.COMM_WORLD)
         ts.setProblemType(ts.ProblemType.NONLINEAR)
+        opts = PETSc.Options()
+        opts.setValue("ts_adapt_type", "none")
 
         if arkimex:
             slow_indices, fast_indices, fast_indices_alg, fast_indices_dif, ndiff_fast = generate_default_partition_indices(
@@ -1788,11 +1811,6 @@ def integrate_system(
             dae.set_ts_ref(ts)
 
             # Provide stable default PETSc options for ARKIMEX unless the user overrides them.
-            opts = PETSc.Options()
-
-            if not opts.hasName("ts_adapt_type"):
-                opts.setValue("ts_adapt_type", "none")
-
             if not opts.hasName("ts_arkimex_type"):
                 opts.setValue("ts_arkimex_type", "a2")
 
@@ -1820,7 +1838,7 @@ def integrate_system(
             ts.setRHSSplitRHSFunction("fast", dae.evalRHSFunctionFast_split, None)
             ts.setRHSSplitIJacobian("fast", dae.evalIJacobianFast_split, jac_fast, jac_fast)
         else:
-            ts.setType(ts.Type.THETA)
+            ts.setType(_petsc_ts_type(PETSc, method, arkimex=False))
             ts.setIFunction(dae.evalFunction, rhs_vec)
             ts.setIJacobian(dae.evalJacobian, jac_rhs)
             ts.setIJacobianP(dae.evalJacobianP, jac_par)
@@ -1844,56 +1862,129 @@ def integrate_system(
             ts.setCostGradients(v_lambda, v_mu)
             ts.setSaveTrajectory()
 
-        historyp = []
-        tvecp = []
-        def monitor(ts, i, t, x):
-            xx = x[:].tolist()
-            historyp.append(xx)
-            tvecp.append(t)
-        ts.setMonitor(monitor)
-        ts.setTime(0.0)
-        ts.setTimeStep(dt)
-        ts.setMaxTime(ton)
-        ts.setExactFinalTime(PETSc.TS.ExactFinalTime.MATCHSTEP)
+        expected_ts_type = _petsc_ts_type(PETSc, method, arkimex)
         ts.setFromOptions()
-        ts.solve(z0p)
-        
-        if ton < tend:
-            # fault application
-            psys.fault_events[0].apply()
-            alg = ALG_petsc(psys, theta, jacobian)
-            fsp = z0p.duplicate()
-            snes = PETSc.SNES()
-            snes.create(PETSc.COMM_WORLD)
-            snes.setFunction(alg.evalFunction, fsp)
-            snes.setJacobian(alg.evalJacobian, jac_rhs)
-            snes.setOptionsPrefix("alg_")
-            snes.setFromOptions()
-            snes.solve(None, z0p)
+        if ts.getType() != expected_ts_type:
+            raise ValueError(
+                "PETSc options changed the configured integration method: "
+                f"expected {expected_ts_type}, got {ts.getType()}"
+            )
+        ts.setExactFinalTime(PETSc.TS.ExactFinalTime.MATCHSTEP)
 
-            # disturbance time
-            ts.setTime(ton)
-            ts.setMaxTime(toff)
+        transition_actions = {}
+        if schedule.fault_on_index is not None:
+            transition_actions.setdefault(schedule.fault_on_index, []).append("apply")
+        if schedule.fault_off_index is not None:
+            transition_actions.setdefault(schedule.fault_off_index, []).append("remove")
+
+        historyp = [np.array(z0, copy=True)]
+        tvecp = [float(tvec[0])]
+        event_transitions = {}
+
+        def monitor(ts, step, time, solution):
+            value = np.array(solution[:], copy=True)
+            if abs(time - tvecp[-1]) <= 1e-11:
+                tvecp[-1] = float(time)
+                historyp[-1] = value
+            else:
+                tvecp.append(float(time))
+                historyp.append(value)
+
+        ts.setMonitor(monitor)
+
+        runs = []
+        start_index = 0
+        while start_index < len(tvec) - 1:
+            step_width = tvec[start_index + 1] - tvec[start_index]
+            boundary_index = start_index + 1
+            while boundary_index < len(tvec) - 1:
+                if boundary_index in transition_actions:
+                    break
+                next_width = tvec[boundary_index + 1] - tvec[boundary_index]
+                if not np.isclose(next_width, step_width, rtol=0.0, atol=1e-12):
+                    break
+                boundary_index += 1
+            runs.append((start_index, boundary_index, step_width))
+            start_index = boundary_index
+
+        for start_index, boundary_index, step_width in runs:
+            ts.setTime(float(tvec[start_index]))
+            ts.setTimeStep(float(step_width))
+            ts.setMaxTime(float(tvec[boundary_index]))
             ts.solve(z0p)
 
-            # fault removal
-            psys.fault_events[0].remove()
-            snes.solve(None, z0p)
+            for action in transition_actions.get(boundary_index, ()):
+                if action == "apply":
+                    fault.apply()
+                else:
+                    fault.remove()
+                projected, _, _, _ = integrate(
+                    np.array(z0p[:], copy=True),
+                    theta,
+                    0.0,
+                    psys,
+                    residual,
+                    jacobian,
+                    None,
+                    verbose=verbose,
+                    fsolve=False,
+                    newton_tol=newton_tol,
+                    newton_max_iter=newton_max_iter,
+                    uold=None,
+                    vold=None,
+                    mold=None,
+                )
+                z0p.setArray(projected)
+                z0p.assemble()
+                event_transitions.setdefault(boundary_index, []).append(
+                    (action, np.array(z0p[:], copy=True))
+                )
+            if boundary_index in transition_actions:
+                ts.setSolution(z0p)
+                ts.setTime(float(tvec[boundary_index]))
+                ts.restartStep()
 
-            # post disturbance time
-            ts.setTime(toff)
-            ts.setMaxTime(tend)
-            ts.solve(z0p)
+        if (
+            len(tvecp) != len(tvec)
+            or not np.allclose(tvecp, tvec, rtol=0.0, atol=1e-11)
+        ):
+            raise RuntimeError("PETSc did not return the configured integration time grid")
+        for event_index, transitions in event_transitions.items():
+            historyp[event_index] = transitions[-1][1]
 
         # adjoint computation
         if comp_sens:
             if verbose:
                 logger.info("Solving adjoint problem...")
-            ts.adjointSolve()
+            if fault is not None and ton <= tvec[-1] < toff:
+                fault.apply()
+            elif fault is not None:
+                fault.remove()
+            for start_index, boundary_index, _ in reversed(runs):
+                ts.adjointSetSteps(boundary_index - start_index)
+                ts.adjointSolve()
+                for action, event_state in reversed(
+                        event_transitions.get(start_index, ())):
+                    lambda_values, mu_values = _algebraic_projection_adjoint(
+                        psys,
+                        event_state,
+                        theta,
+                        jacobian,
+                        np.array(v_lambda[:], copy=True),
+                        np.array(v_mu[:], copy=True),
+                    )
+                    v_lambda.setArray(lambda_values)
+                    v_lambda.assemble()
+                    v_mu.setArray(mu_values)
+                    v_mu.assemble()
+                    if action == "apply":
+                        fault.remove()
+                    else:
+                        fault.apply()
+            if fault is not None:
+                fault.remove()
 
             # extract results
-            cst = ts.getCostIntegral()
-            
             # Get the trajectory contribution
             cost_value = ts.getCostIntegral()
             mu_trajectory = np.array(v_mu[:])      # μᵢ term
@@ -1917,23 +2008,25 @@ def integrate_system(
             results["lambda_final"] = lambda_final
             results["adjoint_gradient_complete"] = complete_gradient # Total
 
-        # Cast history to numpy arrays
-        history = np.transpose(np.array(historyp))
-        tvec = np.array(tvecp)
+        if fault is not None:
+            fault.remove()
+
+        history = np.transpose(np.asarray(historyp))
 
     else:
-        tvec = np.linspace(0, nsteps*h, nsteps)
-        history = np.zeros((system_size, nsteps))
-        for i in range(nsteps):
+        history = np.zeros((system_size, len(tvec)))
+        history[:, 0] = np.copy(z)
+        for i in range(1, len(tvec)):
+            t_start = tvec[i - 1]
+            h_step = tvec[i] - t_start
             if verbose:
-                logger.info("Step: %i. Time: %g (sec)", i, i * h)
+                logger.info("Step: %i. Time: %g (sec)", i, tvec[i])
             if psys.signal_injectors:
-                t_now = i * h
                 for inj in psys.signal_injectors:
-                    inj.update(t_now, theta, psys)
+                    inj.update(t_start, theta, psys)
             z, u, v, m = integrate(z,
                                 theta,
-                                h,
+                                h_step,
                                 psys,
                                 residual,
                                 jacobian,
@@ -1945,82 +2038,31 @@ def integrate_system(
                                 uold=None,
                                 vold=None,
                                 mold=None)
-            history[:, i] = np.copy(z)
 
-            if i == step_on:
+            if i == schedule.fault_on_index:
                 if verbose:
                     logger.info("Apply fault")
-                if len(psys.fault_events) > 0:
-                    psys.fault_events[0].apply()
-                try:
-                    z, _, _, _ = integrate(z,
-                                        theta,
-                                        0.0,
-                                        psys,
-                                        residual,
-                                        jacobian,
-                                        None,
-                                        verbose=verbose,
-                                        fsolve=False,
-                                        newton_tol=newton_tol,
-                                        newton_max_iter=newton_max_iter,
-                                        uold=None,
-                                        vold=None,
-                                        mold=None)
-                except NameError:
-                    z, _, _, _ = integrate(z,
-                                        theta,
-                                        0.0,
-                                        psys,
-                                        residual,
-                                        jacobian,
-                                        None,
-                                        verbose=verbose,
-                                        fsolve=False,
-                                        newton_tol=newton_tol,
-                                        newton_max_iter=newton_max_iter,
-                                        uold=None,
-                                        vold=None,
-                                        mold=None)
-            if i == step_off:
+                fault.apply()
+                z, _, _, _ = integrate(
+                    z, theta, 0.0, psys, residual, jacobian, None,
+                    verbose=verbose, fsolve=False,
+                    newton_tol=newton_tol, newton_max_iter=newton_max_iter,
+                    uold=None, vold=None, mold=None,
+                )
+            if i == schedule.fault_off_index:
                 if verbose:
                     logger.info("Remove fault")
-                if len(psys.fault_events) > 0:
-                    psys.fault_events[0].remove()
-                try:
-                    z, _, _, _ = integrate(z,
-                                        theta,
-                                        0.0,
-                                        psys,
-                                        residual,
-                                        jacobian,
-                                        None,
-                                        verbose=verbose,
-                                        fsolve=False,
-                                        newton_tol=newton_tol,
-                                        newton_max_iter=newton_max_iter,
-                                        uold=None,
-                                        vold=None,
-                                        mold=None)
-                except NameError:
-                    z, _, _, _ = integrate(z,
-                                        theta,
-                                        0.0,
-                                        psys,
-                                        residual,
-                                        jacobian,
-                                        None,
-                                        verbose=verbose,
-                                        fsolve=False,
-                                        newton_tol=newton_tol,
-                                        newton_max_iter=newton_max_iter,
-                                        uold=None,
-                                        vold=None,
-                                        mold=None)
+                fault.remove()
+                z, _, _, _ = integrate(
+                    z, theta, 0.0, psys, residual, jacobian, None,
+                    verbose=verbose, fsolve=False,
+                    newton_tol=newton_tol, newton_max_iter=newton_max_iter,
+                    uold=None, vold=None, mold=None,
+                )
+            history[:, i] = np.copy(z)
 
-        # if tend < toff we remove fault before exiting
-        if i < step_off:
-            psys.fault_events[0].remove()
+        if fault is not None:
+            fault.remove()
 
     # pack results into dict
     results["tvec"] = tvec

--- a/uqgrid/simulation/herk.py
+++ b/uqgrid/simulation/herk.py
@@ -11,6 +11,7 @@ from scipy.sparse.linalg import spsolve
 
 from uqgrid.simulation.residual import residual_function
 from uqgrid.simulation.jacobian import residual_jacobian
+from uqgrid.simulation.timing import build_integration_schedule
 
 
 # ---------------------------------------------------------------------------
@@ -130,8 +131,6 @@ def integrate_system_herk(psys, config, ctx=None):
     no-Jacobian-check path is supported. Fault on/off events are handled
     between steps via an algebraic resolve.
     """
-    import math
-
     from uqgrid.simulation.dynamics import (
         _initialize_system_from_config,
         preallocate_jacobian,
@@ -175,53 +174,59 @@ def integrate_system_herk(psys, config, ctx=None):
     J = preallocate_jacobian(psys)
     F = np.zeros(system_size)
 
-    h = config.dt
-    if config.steps > 0:
-        nsteps = config.steps
-    else:
-        nsteps = int(math.floor(config.tend / config.dt)) + 1
-
-    step_on = int(config.ton / h)
-    step_off = int(config.toff / h)
+    has_fault = bool(psys.fault_events)
+    schedule = build_integration_schedule(
+        dt=config.dt,
+        tend=config.tend,
+        steps=config.steps,
+        ton=config.ton,
+        toff=config.toff,
+        has_fault=has_fault,
+    )
+    tvec = schedule.times
+    fault = psys.fault_events[0] if has_fault else None
+    if fault is not None:
+        fault.remove()
 
     tol = config.herk_alg_tol
     max_iter = config.herk_alg_max_iter
 
-    tvec = np.linspace(0, nsteps * h, nsteps)
-    history = np.zeros((system_size, nsteps))
+    history = np.zeros((system_size, len(tvec)))
     z = z0
+    history[:, 0] = z
 
     NDIFFEQ = psys.num_dof_dif
     alg_size = psys.num_dof_alg
 
-    for i in range(nsteps):
+    for i in range(1, len(tvec)):
+        t_start = tvec[i - 1]
+        h_step = tvec[i] - t_start
         if psys.signal_injectors:
-            t_now = i * h
             for inj in psys.signal_injectors:
-                inj.update(t_now, theta, psys)
-        z = herk_step(z, theta, h, psys, A, b, c, F, J, tol, max_iter)
+                inj.update(t_start, theta, psys)
+        z = herk_step(z, theta, h_step, psys, A, b, c, F, J, tol, max_iter)
+
+        if i == schedule.fault_on_index:
+            fault.apply()
+            x = z[:NDIFFEQ]
+            y = z[NDIFFEQ:NDIFFEQ + alg_size]
+            v = z[NDIFFEQ + alg_size:]
+            y_new, v_new, _ = solve_stage_algebraic(
+                x, y, v, theta, psys, F, J, tol, max_iter)
+            z = np.concatenate([x, y_new, v_new])
+
+        if i == schedule.fault_off_index:
+            fault.remove()
+            x = z[:NDIFFEQ]
+            y = z[NDIFFEQ:NDIFFEQ + alg_size]
+            v = z[NDIFFEQ + alg_size:]
+            y_new, v_new, _ = solve_stage_algebraic(
+                x, y, v, theta, psys, F, J, tol, max_iter)
+            z = np.concatenate([x, y_new, v_new])
         history[:, i] = z
 
-        if i == step_on and len(psys.fault_events) > 0:
-            psys.fault_events[0].apply()
-            x = z[:NDIFFEQ]
-            y = z[NDIFFEQ:NDIFFEQ + alg_size]
-            v = z[NDIFFEQ + alg_size:]
-            y_new, v_new, _ = solve_stage_algebraic(
-                x, y, v, theta, psys, F, J, tol, max_iter)
-            z = np.concatenate([x, y_new, v_new])
-
-        if i == step_off and len(psys.fault_events) > 0:
-            psys.fault_events[0].remove()
-            x = z[:NDIFFEQ]
-            y = z[NDIFFEQ:NDIFFEQ + alg_size]
-            v = z[NDIFFEQ + alg_size:]
-            y_new, v_new, _ = solve_stage_algebraic(
-                x, y, v, theta, psys, F, J, tol, max_iter)
-            z = np.concatenate([x, y_new, v_new])
-
-    if nsteps - 1 < step_off and len(psys.fault_events) > 0:
-        psys.fault_events[0].remove()
+    if fault is not None:
+        fault.remove()
 
     results = {"tvec": tvec, "history": history}
     if pf_solution.validation is not None:

--- a/uqgrid/simulation/timing.py
+++ b/uqgrid/simulation/timing.py
@@ -1,0 +1,82 @@
+"""Shared time-grid construction for dynamic integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class IntegrationSchedule:
+    """Stored times and fault-transition indices for one integration run."""
+
+    times: np.ndarray
+    fault_on_index: int | None
+    fault_off_index: int | None
+
+
+def _append_distinct(times: list[float], value: float, tolerance: float) -> None:
+    if not times or abs(value - times[-1]) > tolerance:
+        times.append(value)
+    else:
+        times[-1] = value
+
+
+def build_integration_schedule(
+    *,
+    dt: float,
+    tend: float,
+    steps: int,
+    ton: float,
+    toff: float,
+    has_fault: bool,
+) -> IntegrationSchedule:
+    """Build the common stored-time grid, including exact fault boundaries."""
+    if dt <= 0.0:
+        raise ValueError("dt must be positive")
+    if tend < 0.0:
+        raise ValueError("tend must be non-negative")
+    if steps == 0 or steps < -1:
+        raise ValueError("steps must be -1 or a positive integer")
+    if ton < 0.0:
+        raise ValueError("ton must be non-negative")
+    if toff < ton:
+        raise ValueError("toff must be greater than or equal to ton")
+    horizon = steps * dt if steps > 0 else tend
+    tolerance = 1e-12 * max(1.0, horizon, dt)
+    if has_fault and ton <= tolerance:
+        raise ValueError(
+            "ton=0 is incompatible with storing one initialized sample at t=0"
+        )
+
+    n_full_steps = int(np.floor((horizon + tolerance) / dt))
+    base_times = [index * dt for index in range(n_full_steps + 1)]
+    if base_times[-1] < horizon - tolerance:
+        base_times.append(horizon)
+    else:
+        base_times[-1] = horizon
+
+    candidates = list(base_times)
+    if has_fault:
+        for event_time in (ton, toff):
+            if -tolerance <= event_time <= horizon + tolerance:
+                candidates.append(min(max(event_time, 0.0), horizon))
+
+    times: list[float] = []
+    for value in sorted(candidates):
+        _append_distinct(times, float(value), tolerance)
+
+    values = np.asarray(times, dtype=float)
+
+    def event_index(event_time: float) -> int | None:
+        if not has_fault or event_time < -tolerance or event_time > horizon + tolerance:
+            return None
+        matches = np.flatnonzero(np.abs(values - event_time) <= tolerance)
+        return int(matches[0]) if matches.size else None
+
+    return IntegrationSchedule(
+        times=values,
+        fault_on_index=event_index(ton),
+        fault_off_index=event_index(toff),
+    )


### PR DESCRIPTION
## Summary

- normalize stored time grids across native backward Euler, PETSc backward Euler, PETSc Crank-Nicolson, PETSc ARKIMEX, HERK2, and HERK4
- include the initialized state at `t=0`, use exact off-grid horizons and fault transitions, and store one post-switch state per event timestamp
- make PETSc method selection explicit and prevent PETSc options from silently overriding the configured method or time grid
- propagate `integration.method` through scenario adapters, CLI drivers, examples, and documentation

## Integration contract

- `steps=N` means N nominal advances and N+1 base samples from `0` through `N*dt`
- `steps=-1` integrates exactly through `tend`, including a shortened final interval when needed
- the fault is active on `[ton, toff)` and topology transitions use fixed-differential algebraic projection
- `method="beuler"` selects native backward Euler or PETSc `TSBEULER`
- `method="cn"` selects PETSc `TSCN` and requires PETSc
- HERK2/HERK4 require the native backend; ARKIMEX remains a PETSc-only flag
- PETSc adjoint sensitivities require Crank-Nicolson because backward-Euler integral adjoints did not satisfy finite-difference validation (remains TODO)

## Compatibility

The default remains backward Euler. PETSc configurations that intended Crank-Nicolson must now specify `"method": "cn"`. Corrected trajectories include `t=0` and exact event timestamps, so older dense histories should not be appended to datasets generated with this contract. TSI values can change where historical event timing or method selection was ambiguous.

## Validation

- focused integrator/configuration/scenario suite: 132 passed
- full repository suite: 208 passed, 2 skipped
- PETSc adjoint finite-difference suite: 5 passed
- short IEEE-9 no-fault and faulted runs passed across BE, CN, HERK2, and HERK4
- Python compilation, JSON parsing, and `git diff --check` passed