### PR TITLE
Add directional SEXS field-voltage limits

### DIFF
--- a/bin/dynamics_driver.py
+++ b/bin/dynamics_driver.py
@@ -38,6 +38,15 @@ def parse_args():
     parser.add_argument('--toff', type=float, default=0.4, help='Fault deactivation time.')
     parser.add_argument('--petsc', action='store_true', help='Enable PETSc integration.')
     parser.add_argument('--arkimex', action='store_true', help='Use ARKIMEX integrator.')
+    parser.add_argument(
+        '--enforce-dynamic-limits',
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help='Enable hard dynamic-state limits.',
+    )
+    parser.add_argument('--dynamic-limit-tolerance', type=float, default=1e-8)
+    parser.add_argument('--dynamic-limit-release-tolerance', type=float, default=1e-10)
+    parser.add_argument('--max-dynamic-limit-iterations', type=int, default=20)
     parser.add_argument('--plot', action='store_true', help='Plot results after simulation.')
 
     # Parse only the script arguments
@@ -57,7 +66,13 @@ def parse_args():
             fsolve=args.fsolve,
             petsc=args.petsc,
             petsc_args=petsc_args,
-            arkimex=args.arkimex
+            arkimex=args.arkimex,
+            enforce_dynamic_limits=args.enforce_dynamic_limits,
+            dynamic_limit_tolerance=args.dynamic_limit_tolerance,
+            dynamic_limit_release_tolerance=(
+                args.dynamic_limit_release_tolerance
+            ),
+            max_dynamic_limit_iterations=args.max_dynamic_limit_iterations,
         )
     except ValueError as e:
         print(f"Configuration Error: {e}")

--- a/bin/dynamics_partition_driver.py
+++ b/bin/dynamics_partition_driver.py
@@ -52,6 +52,15 @@ def parse_args(argv: List[str]):
     parser.add_argument('--verbose', action='store_true', help='Enable verbose logging.')
     parser.add_argument('--petsc', action='store_true', help='Enable PETSc integrator backend.')
     parser.add_argument('--arkimex', action='store_true', help='Use ARKIMEX time integrator.')
+    parser.add_argument(
+        '--enforce-dynamic-limits',
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help='Enable hard dynamic-state limits.',
+    )
+    parser.add_argument('--dynamic-limit-tolerance', type=float, default=1e-8)
+    parser.add_argument('--dynamic-limit-release-tolerance', type=float, default=1e-10)
+    parser.add_argument('--max-dynamic-limit-iterations', type=int, default=20)
     parser.add_argument('--slow-diff', default=None, help='Comma or space separated list of slow differential indices.')
     parser.add_argument('--fast-diff', default=None, help='Comma or space separated list of fast differential indices.')
     parser.add_argument('--plot', action='store_true', help='Plot generator speed traces after simulation.')
@@ -78,6 +87,12 @@ def parse_args(argv: List[str]):
             petsc=args.petsc,
             petsc_args=petsc_args,
             arkimex=args.arkimex,
+            enforce_dynamic_limits=args.enforce_dynamic_limits,
+            dynamic_limit_tolerance=args.dynamic_limit_tolerance,
+            dynamic_limit_release_tolerance=(
+                args.dynamic_limit_release_tolerance
+            ),
+            max_dynamic_limit_iterations=args.max_dynamic_limit_iterations,
             arkimex_slow_differential=slow_list,
             arkimex_fast_differential=fast_list,
         )

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -21,6 +21,13 @@ from uqgrid.simulation.config import (
     IntegrationCtx,
     PowerFlowValidationConfig,
 )
+from uqgrid.simulation.dynamic_limits import (
+    DYNAMIC_LIMIT_EVENT_ACTIONS,
+    DYNAMIC_LIMIT_EVENT_FIELDS,
+    DynamicLimitError,
+    DynamicLimitMode,
+    LimitedStateDescriptor,
+)
 ```
 
 - `IntegrationConfig`: Validated settings for time integration.
@@ -28,6 +35,17 @@ from uqgrid.simulation.config import (
   before dynamic initialization.
 - `IntegrationCtx`: Optional container for custom initial conditions and
   parameter overrides.
+- `LimitedStateDescriptor`: JSON-safe identity and bounds for a limited state.
+- `DynamicLimitMode`: Free, lower-active, or upper-active limiter mode.
+- `DynamicLimitError`: Structured dynamic-limit failure with a `.diagnostics`
+  dictionary.
+- `DYNAMIC_LIMIT_EVENT_FIELDS`: Required keys returned by every limiter event.
+- `DYNAMIC_LIMIT_EVENT_ACTIONS`: Supported projection and mode-transition
+  action names.
+
+The dynamic-limit module also provides pure state projection, directional
+derivative projection, complementarity evaluation, and active-set update
+helpers for the supported integrators.
 
 `IntegrationConfig` also includes optional Jacobian diagnostics for non-PETSc
 runs:

--- a/docs/user-guide/dynamics-simulation.md
+++ b/docs/user-guide/dynamics-simulation.md
@@ -63,6 +63,10 @@ config = IntegrationConfig(
     enforce_q_limits=True,
     q_limit_tolerance=1e-8,
     max_q_limit_iterations=None,
+    enforce_dynamic_limits=True,
+    dynamic_limit_tolerance=1e-8,
+    dynamic_limit_release_tolerance=1e-10,
+    max_dynamic_limit_iterations=20,
     power_flow_validation={
         "enabled": False,
         "residual_tolerance": 1e-8,
@@ -99,6 +103,13 @@ Key fields:
 - **max_q_limit_iterations**: Optional cap on active-set power-flow solves.
 - **power_flow_validation**: Optional final operating-point checks performed
   after PF convergence and before dynamic device initialization.
+- **enforce_dynamic_limits**: Validate enabled hard dynamic-state limits at
+  initialization and enforce them in supported integration methods.
+- **dynamic_limit_tolerance**: State-bound tolerance used by hard limits.
+- **dynamic_limit_release_tolerance**: Complementarity tolerance reserved for
+  directional release from an active bound.
+- **max_dynamic_limit_iterations**: Maximum active-set iterations reserved for
+  implicit hard-limit solves.
 - **check_jacobian**: Run a finite-difference Jacobian check (non-PETSc only).
 - **jacobian_check_tol**: Absolute tolerance for reporting FD mismatches.
 - **jacobian_check_top_k**: Number of mismatches to report.
@@ -109,19 +120,22 @@ Key fields:
 | Configuration | Backend |
 |---|---|
 | `method="beuler", petsc=False` | Native backward Euler |
-| `method="beuler", petsc=True` | PETSc `TSBEULER` |
-| `method="cn", petsc=True` | PETSc `TSCN` |
+| `method="beuler", petsc=True` | PETSc `TSBEULER`, or ordinary SNES when hard limits are active |
+| `method="cn", petsc=True` | PETSc `TSCN`, or ordinary SNES when hard limits are active |
 | `method="herk2", petsc=False` | HERK2 |
 | `method="herk4", petsc=False` | HERK4 |
-| `arkimex=True, petsc=True` | PETSc ARKIMEX |
+| `arkimex=True, petsc=True, enforce_dynamic_limits=False` | PETSc ARKIMEX |
 
-`cn` is explicitly mapped to PETSc `TSCN`. This is not the same as selecting
-the midpoint form of `TSTHETA`; PETSc distinguishes endpoint Crank-Nicolson
-from its theta-method midpoint formulation for DAEs. See the
+Without enabled hard-limit states, `cn` is explicitly mapped to PETSc `TSCN`.
+This is not the same as selecting the midpoint form of `TSTHETA`; PETSc
+distinguishes endpoint Crank-Nicolson from its theta-method midpoint
+formulation for DAEs. See the
 [PETSc TSTHETA documentation](https://petsc.org/release/manualpages/TS/TSTHETA/).
 
 `cn` requires PETSc, HERK requires the native backend, and ARKIMEX cannot be
-combined with `cn` or HERK. The library default remains `method="beuler"`.
+combined with `cn` or HERK. Hard dynamic limits do not support ARKIMEX,
+sensitivities, or the legacy fsolve path; set `enforce_dynamic_limits=False`
+explicitly to use those paths. The library default remains `method="beuler"`.
 Configurations that previously omitted `method` therefore select backward
 Euler. PETSc command-line options may tune solver internals, but options that
 override the configured TS type, time step, horizon, exact-final-time policy,
@@ -137,8 +151,100 @@ aggregate generator Q capability, the power flow switches that bus to PQ and
 solves again. The same initialization is used for PETSc, backward Euler,
 HERK2, and HERK4.
 
-This constrains the operating point only. It does not impose generator
-reactive-power or exciter field-voltage limits during the dynamic trajectory.
+This constrains the operating point only. Exciter field-voltage limits use the
+separate dynamic-limit configuration below.
+
+### Hard dynamic-state limits
+
+Hard dynamic limits default to enabled. Valid finite SEXS limits parsed from a
+DYR file are enabled when `EMIN < EMAX`; malformed or non-increasing limits
+fail DYR loading with the bus and generator identity. Manually constructed
+SEXS models retain their explicit `enable_limits` setting. UQGrid validates
+enabled Efd states after `IntegrationCtx` state and parameter overrides. Values
+outside EMIN/EMAX beyond `dynamic_limit_tolerance` raise `DynamicLimitError`
+before Jacobian allocation, PETSc setup, fault scheduling, or time stepping.
+Initial values are never silently clamped.
+
+Every successful result contains a JSON-safe `dynamic_limit_diagnostics`
+summary, including disabled and zero-state cases. Native HERK2 and HERK4 enforce
+SEXS Efd limits at every RK stage and weighted endpoint. A tentative stage is
+projected before its algebraic solve, only outward derivatives are blocked, and
+the final weighted state is projected before its endpoint algebraic solve.
+Inward derivatives release immediately, while the upstream SEXS state keeps
+evolving when Efd is pinned.
+
+HERK limiter activation is evaluated only at RK stages and endpoints. It does
+not localize the exact crossing, backtrack, or add timestamps. Accuracy is
+locally first order around a limit transition even though HERK2/HERK4 retain
+their nominal order on smooth intervals. Diagnostics record actual clamps and
+compact `activate`/`release` transitions, not every repeatedly blocked stage.
+
+Native and PETSc backward Euler use a fixed-active-set nonlinear solve at every
+endpoint. Free states retain the ordinary BE equation. An active Efd row is
+replaced by `Efd_next - bound = 0` with an identity Jacobian row, while all
+algebraic equations remain in the coupled solve. After convergence, the
+discarded free BE residual determines whether an active state remains pinned or
+releases inward. The solve repeats until the active set is
+complementarity-consistent. Cycling, nonlinear-solver failure, or exceeding
+`max_dynamic_limit_iterations` raises a structured `DynamicLimitError`.
+
+When PETSc BE has at least one enabled limited state, UQGrid advances the shared
+time grid one interval at a time with ordinary PETSc SNES rather than TS. The
+default SNES type is `newtonls`; KSP, preconditioner, monitor, tolerance, and
+line-search options may still be supplied through `petsc_args`. PETSc
+variational-inequality types `vinewtonrsls` and `vinewtonssls` are rejected:
+UQGrid owns the active set and never calls SNESVI or configures variable bounds.
+PETSc BE with limits disabled or no enabled states continues to use TSBEULER.
+
+Backward Euler transitions are represented at the interval endpoint; they do
+not localize the crossing, backtrack, or add timestamps. Stored endpoints are
+bound-feasible and algebraically consistent, but activation or release may be
+delayed by one step and contributes an expected O(dt) switching-time error.
+PETSc CN uses the same endpoint active-set contract when enabled limited states
+exist, but assembles the trapezoidal equations explicitly and solves them with
+ordinary SNES instead of delegating to TSCN. At each accepted interval start,
+an outward raw derivative is zeroed only for an inherited active bound; inward
+derivatives pass through immediately. That effective starting derivative stays
+fixed while UQGrid repeats endpoint SNES solves until the active set is
+complementarity-consistent. Free differential rows use the average of the fixed
+starting derivative and the raw endpoint derivative. Active rows remain exact
+bound equations, and algebraic rows remain endpoint equations.
+
+This limited CN path uses neither TS limiter state nor SNESVI. It retains
+second-order accuracy on smooth intervals, but endpoint-only activation and
+release are locally first order and may shift by one step. Crossings are not
+localized and add no timestamps. PETSc CN with limits disabled or no enabled
+limited states continues to use TSCN. Set `enforce_dynamic_limits=False` for
+legacy unconstrained behavior.
+
+All supported integrators return limiter events with the same required fields:
+
+```text
+device_type, device_id, bus, state_index,
+side, action, time, stage_or_endpoint,
+raw_derivative, state_before, state_after, bound,
+active_set_iterations
+```
+
+Supported actions are `project`, `block_outward_derivative`, `activate`, and
+`release`. Runtime event times are finite. HERK events identify `stage_N` or
+`endpoint`; implicit BE/CN events identify `endpoint`. `raw_derivative` is null
+when it is not applicable to a projection or implicit complementarity event,
+and `active_set_iterations` is null for explicit methods. Existing descriptor
+bounds, enabled status, and implicit `free_residual` fields remain available.
+The schema constants are exported as `DYNAMIC_LIMIT_EVENT_FIELDS` and
+`DYNAMIC_LIMIT_EVENT_ACTIONS`.
+
+Cross-integrator validation requires stored and HERK stage Efd values to remain
+inside their configured bounds, algebraic endpoint residuals to remain below
+solver tolerance, and implicit free or active integration rows to satisfy their
+method equations and complementarity conditions. A raw differential residual
+during a disturbance is the physical state derivative and is not expected to
+be zero. No-fault initialized trajectories remain flat. Native and PETSc BE use
+the same equations and agree to nonlinear-solver tolerance. All methods
+converge toward the same trajectory as the step is reduced, while stage- or
+endpoint-only limiter transitions can differ by up to one step because UQGrid
+does not localize crossings.
 
 ### Final operating-point validation
 
@@ -176,8 +282,9 @@ results = integrate_system(psys, config)
 ```
 
 The solver returns a dictionary with time stamps (`tvec`), state trajectory
-(`history`), and optional adjoint outputs when sensitivities are enabled. The
-first column of `history` is the initialized state at `t=0`.
+(`history`), `dynamic_limit_diagnostics`, and optional adjoint outputs when
+sensitivities are enabled. The first column of `history` is the initialized
+state at `t=0`.
 
 ## Interpret the trajectory
 

--- a/scripts/run/README.md
+++ b/scripts/run/README.md
@@ -312,6 +312,10 @@ baseline config may omit those optional fields and still run.
 | | `toff` | Fault clearing time [s] |
 | | `verbose` | Enable verbose solver output |
 | | `petsc` | Use PETSc solver |
+| | `enforce_dynamic_limits` | Enable hard dynamic-state limit handling |
+| | `dynamic_limit_tolerance` | State-bound tolerance for hard dynamic limits |
+| | `dynamic_limit_release_tolerance` | Complementarity release tolerance |
+| | `max_dynamic_limit_iterations` | Maximum hard-limit active-set iterations |
 
 ### Time Grid and PETSc Method
 
@@ -322,18 +326,21 @@ application and clearing times are inserted into the stored grid. Event samples
 contain the post-switch algebraic state, and the fault is active on
 `[ton, toff)`.
 
-Set `method="cn"` explicitly for PETSc Crank-Nicolson (`TSCN`). Omitting
-`method` selects backward Euler, including when `petsc=true`. Native HERK2/HERK4
-require `petsc=false`; PETSc ARKIMEX is selected separately with
-`arkimex=true`. PETSc options cannot override the configured method or time
-grid. Histories generated before this normalized contract have different time
-axes and should not be appended to corrected dense-history datasets.
+Set `method="cn"` explicitly for PETSc Crank-Nicolson. It uses `TSCN` when hard
+limits are disabled or no enabled limited states exist, and an explicit
+per-interval ordinary-SNES trapezoidal solve otherwise. Omitting `method`
+selects backward Euler, including when `petsc=true`. Native HERK2/HERK4 require
+`petsc=false`; PETSc ARKIMEX is selected separately with
+`arkimex=true` and requires `enforce_dynamic_limits=false`. PETSc options
+cannot override the configured method or time grid. Histories generated before
+this normalized contract have different time axes and should not be appended
+to corrected dense-history datasets.
 
-Adjoint sensitivities (`comp_sens=true`) require `petsc=true` and
-`method="cn"`. Faulted adjoints use reverse topology segments and algebraic
-projection jump conditions. Forward PETSc backward Euler remains supported,
-but its integral adjoint is rejected because it does not pass finite-difference
-validation.
+Adjoint sensitivities (`comp_sens=true`) require `petsc=true`, `method="cn"`,
+and `enforce_dynamic_limits=false`. Faulted adjoints use reverse topology
+segments and algebraic projection jump conditions. Forward PETSc backward
+Euler remains supported, but its integral adjoint is rejected because it does
+not pass finite-difference validation.
 
 ### Perturbation and Operating-Point Workflow
 
@@ -500,6 +507,10 @@ configured separately under `integration`:
     "enforce_q_limits": true,
     "q_limit_tolerance": 1e-8,
     "max_q_limit_iterations": null,
+    "enforce_dynamic_limits": true,
+    "dynamic_limit_tolerance": 1e-8,
+    "dynamic_limit_release_tolerance": 1e-10,
+    "max_dynamic_limit_iterations": 20,
     "power_flow_validation": {
         "enabled": true,
         "residual_tolerance": 1e-8,
@@ -517,8 +528,50 @@ configured separately under `integration`:
 screening. `integration.enforce_q_limits` controls the final initialization PF
 used by backward Euler, PETSc, HERK2, or HERK4 and defaults to `true`. Set it to
 `false` only when an unconstrained legacy operating point is required. These
-limits apply only to the initial operating point; dynamic exciter and
-field-voltage limits are separate models. Final validation remains opt-in.
+limits apply only to the initial operating point. Hard dynamic limits are a
+separate contract. Finite, strictly ordered SEXS Efd limits parsed from DYR are
+device-enabled; malformed bounds fail loading with the device identity. Native
+HERK2/HERK4 project enabled limits at every stage and endpoint, resolve the
+algebraic equations after projection, and release immediately for inward raw
+derivatives. Native backward Euler uses repeated fixed-active-set Newton solves:
+active Efd rows are bound equations, and discarded free BE residuals control
+directional release. All algebraic equations remain in the coupled endpoint
+solve. PETSc BE uses the same equations and active-set controller through an
+ordinary per-interval SNES solve. PETSc CN explicitly assembles trapezoidal
+endpoint equations and fixes the directionally blocked starting derivative for
+all active-set retries within that interval. Neither limited PETSc path uses TS
+or SNESVI. PETSc VI SNES types are rejected, while ordinary KSP, preconditioner,
+monitor, tolerance, and line-search options remain available. Limiter crossings
+are not localized and add no timestamps, so BE has expected O(dt) switching-time
+error. CN remains second order on smooth intervals but is locally first order
+around endpoint-only activation or release. PETSc CN with limits disabled or no
+enabled states continues to use TSCN. Set `enforce_dynamic_limits=false` for
+legacy unconstrained behavior.
+
+Every limiter event uses the same required keys: `device_type`, `device_id`,
+`bus`, `state_index`, `side`, `action`, `time`, `stage_or_endpoint`,
+`raw_derivative`, `state_before`, `state_after`, `bound`, and
+`active_set_iterations`. HERK uses `stage_N` or `endpoint`; implicit BE/CN uses
+`endpoint`. Method-inapplicable values are null, while existing bounds,
+`enabled`, and implicit `free_residual` fields remain available. Supported
+actions are `project`, `block_outward_derivative`, `activate`, and `release`.
+The event records are JSON-safe and are retained in
+`dynamic_limit_diagnostics["events"]`.
+
+Validation distinguishes physical derivatives from solver mismatches: a raw
+differential residual during a fault is generally nonzero, while initial
+equilibrium, endpoint algebraic equations, and method-specific discrete rows
+must satisfy their configured tolerances. Cross-method differences close to a
+limit transition are expected no-localization error; activation and release can
+occur at different stages or endpoints within one time step and add no new
+timestamps.
+Initialization failures use
+`reject_reason="dynamic_limit_initialization_failed"` and retain the structured
+diagnostics in the scenario record. Runtime limiter failures from every
+supported backend use `reject_reason="dynamic_limit_runtime_failed"`. Implicit
+failures additionally report Newton, active-set, complementarity, transition,
+backend, and PETSc SNES details when applicable. Final validation remains
+opt-in.
 When enabled, a validation failure rejects the fault replay before dynamic
 initialization. The fault diagnostic record includes the structured
 `power_flow_validation` result.

--- a/scripts/run/generate_scenarios.py
+++ b/scripts/run/generate_scenarios.py
@@ -212,6 +212,7 @@ from joblib import Parallel, delayed
 
 from uqgrid.simulation.dynamics import integrate_system
 from uqgrid.simulation.config import IntegrationConfig
+from uqgrid.simulation.dynamic_limits import DynamicLimitError
 from uqgrid.simulation.pflow import PowerFlowValidationError, runpf
 from uqgrid.io.parse import load_psse, add_dyr
 from uqgrid.core.psydef import Bus
@@ -1574,7 +1575,21 @@ def _integration_config_from_dict(integration_config=None):
         q_limit_tolerance=int_cfg.get("q_limit_tolerance", 1e-8),
         max_q_limit_iterations=int_cfg.get("max_q_limit_iterations"),
         power_flow_validation=int_cfg.get("power_flow_validation", {}),
+        enforce_dynamic_limits=int_cfg.get("enforce_dynamic_limits", True),
+        dynamic_limit_tolerance=int_cfg.get("dynamic_limit_tolerance", 1e-8),
+        dynamic_limit_release_tolerance=int_cfg.get(
+            "dynamic_limit_release_tolerance", 1e-10
+        ),
+        max_dynamic_limit_iterations=int_cfg.get(
+            "max_dynamic_limit_iterations", 20
+        ),
     )
+
+
+def _dynamic_limit_reject_reason(error):
+    if error.diagnostics.get("phase") == "runtime":
+        return "dynamic_limit_runtime_failed"
+    return "dynamic_limit_initialization_failed"
 
 
 def _simulation_file_path(scenario_id):
@@ -1871,6 +1886,9 @@ def _run_fault_with_operating_point_worker(
             diagnostics["power_flow_validation"] = sim.get(
                 "power_flow_diagnostics"
             )
+            diagnostics["dynamic_limit_diagnostics"] = sim.get(
+                "dynamic_limit_diagnostics"
+            )
         except Exception as e:
             print(f"Simulation failed for scenario {scenario_id}: {str(e)}")
             sim = {"history": None, "tvec": None}
@@ -1879,6 +1897,9 @@ def _run_fault_with_operating_point_worker(
             if isinstance(e, PowerFlowValidationError):
                 diagnostics["reject_reason"] = "power_flow_validation_failed"
                 diagnostics["power_flow_validation"] = e.diagnostics
+            elif isinstance(e, DynamicLimitError):
+                diagnostics["reject_reason"] = _dynamic_limit_reject_reason(e)
+                diagnostics["dynamic_limit_diagnostics"] = e.diagnostics
 
         diagnostics["simulation_diverged"] = diverged
         diagnostics["file"] = None if diverged else _simulation_file_path(scenario_id)
@@ -2272,6 +2293,14 @@ def run_single_scenario_worker(
             q_limit_tolerance=int_cfg.get('q_limit_tolerance', 1e-8),
             max_q_limit_iterations=int_cfg.get('max_q_limit_iterations'),
             power_flow_validation=int_cfg.get('power_flow_validation', {}),
+            enforce_dynamic_limits=int_cfg.get('enforce_dynamic_limits', True),
+            dynamic_limit_tolerance=int_cfg.get('dynamic_limit_tolerance', 1e-8),
+            dynamic_limit_release_tolerance=int_cfg.get(
+                'dynamic_limit_release_tolerance', 1e-10
+            ),
+            max_dynamic_limit_iterations=int_cfg.get(
+                'max_dynamic_limit_iterations', 20
+            ),
         )
 
         try:
@@ -2279,6 +2308,9 @@ def run_single_scenario_worker(
             diverged = False
             diagnostics["power_flow_validation"] = sim.get(
                 "power_flow_diagnostics"
+            )
+            diagnostics["dynamic_limit_diagnostics"] = sim.get(
+                "dynamic_limit_diagnostics"
             )
         except Exception as e:
             print(f"Simulation failed for scenario {scenario_id}: {str(e)}")
@@ -2288,6 +2320,9 @@ def run_single_scenario_worker(
             if isinstance(e, PowerFlowValidationError):
                 diagnostics["reject_reason"] = "power_flow_validation_failed"
                 diagnostics["power_flow_validation"] = e.diagnostics
+            elif isinstance(e, DynamicLimitError):
+                diagnostics["reject_reason"] = _dynamic_limit_reject_reason(e)
+                diagnostics["dynamic_limit_diagnostics"] = e.diagnostics
 
         diagnostics["simulation_diverged"] = diverged
         diagnostics["file"] = None if diverged else f"simulation_data/scenario_{scenario_id}.npz"
@@ -3458,6 +3493,10 @@ def get_default_config(model_name: str) -> dict:
             "enforce_q_limits": True,
             "q_limit_tolerance": 1e-8,
             "max_q_limit_iterations": None,
+            "enforce_dynamic_limits": True,
+            "dynamic_limit_tolerance": 1e-8,
+            "dynamic_limit_release_tolerance": 1e-10,
+            "max_dynamic_limit_iterations": 20,
             "power_flow_validation": {
                 "enabled": False,
                 "residual_tolerance": 1e-8,
@@ -3881,6 +3920,18 @@ Examples:
         "enforce_q_limits": integration_cfg.get("enforce_q_limits", True),
         "q_limit_tolerance": integration_cfg.get("q_limit_tolerance", 1e-8),
         "max_q_limit_iterations": integration_cfg.get("max_q_limit_iterations"),
+        "enforce_dynamic_limits": integration_cfg.get(
+            "enforce_dynamic_limits", True
+        ),
+        "dynamic_limit_tolerance": integration_cfg.get(
+            "dynamic_limit_tolerance", 1e-8
+        ),
+        "dynamic_limit_release_tolerance": integration_cfg.get(
+            "dynamic_limit_release_tolerance", 1e-10
+        ),
+        "max_dynamic_limit_iterations": integration_cfg.get(
+            "max_dynamic_limit_iterations", 20
+        ),
         "power_flow_validation": {
             "enabled": validation_cfg.get("enabled", False),
             "residual_tolerance": validation_cfg.get(
@@ -3997,6 +4048,22 @@ Examples:
     print(
         "  - PF Q-limit max solves: "
         f"{integration_config['max_q_limit_iterations']}"
+    )
+    print(
+        "  - Enforce dynamic limits: "
+        f"{integration_config['enforce_dynamic_limits']}"
+    )
+    print(
+        "  - Dynamic state tolerance: "
+        f"{integration_config['dynamic_limit_tolerance']}"
+    )
+    print(
+        "  - Dynamic release tolerance: "
+        f"{integration_config['dynamic_limit_release_tolerance']}"
+    )
+    print(
+        "  - Dynamic limit max iterations: "
+        f"{integration_config['max_dynamic_limit_iterations']}"
     )
     validation_summary = integration_config["power_flow_validation"]
     print(f"  - Validate final PF: {validation_summary['enabled']}")

--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -62,6 +62,7 @@ def test_config():
         power_injection=False,
         verbose=False,
         comp_sens=True,
+        enforce_dynamic_limits=False,
         petsc=True,
         method="cn",
     )

--- a/tests/test_beuler_dynamic_limits.py
+++ b/tests/test_beuler_dynamic_limits.py
@@ -1,0 +1,518 @@
+import json
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from scipy.sparse import csr_matrix
+
+from uqgrid.io.parse import add_dyr, load_psse
+from uqgrid.simulation import dynamics
+from uqgrid.simulation.config import IntegrationConfig, IntegrationCtx
+from uqgrid.simulation.dynamic_limits import (
+    DynamicLimitError,
+    DynamicLimitMode,
+    LimitedStateDescriptor,
+    collect_limited_state_descriptors,
+    initialize_dynamic_limit_modes,
+)
+from uqgrid.simulation.dynamics import (
+    initialize_system,
+    integrate_system,
+    preallocate_jacobian,
+)
+from uqgrid.simulation.pflow import runpf
+from uqgrid.simulation.residual import residual_function
+
+
+@pytest.fixture
+def data_dir():
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data"
+    )
+
+
+def _descriptor(state_index=0, device_id="1"):
+    return LimitedStateDescriptor(
+        state_index=state_index,
+        lower_bound=0.0,
+        upper_bound=1.0,
+        device_type="SEXS",
+        bus=101 + state_index,
+        device_id=device_id,
+        enabled=True,
+    )
+
+
+def _build_two_bus(data_dir, *, fault=False):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "2bus_33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "2bus_SEXS.dyr"))
+    if fault:
+        psys.add_busfault(1, 1e-4)
+    psys.createYbusComplex()
+    psys.power_injection = False
+    return psys
+
+
+def _initialize_context(psys):
+    solution = runpf(psys, verbose=False)
+    z0, theta = initialize_system(psys, solution)
+    ctx = IntegrationCtx()
+    ctx.set_initial_conditions(z0.copy())
+    ctx.set_theta(theta.copy())
+    return z0, theta, ctx
+
+
+def _set_limits(theta, exciter, lower, upper, *, vref_offset=0.0):
+    ptr = exciter.par_ptr
+    theta[ptr + 4] = lower
+    theta[ptr + 5] = upper
+    theta[ptr + 6] = 1.0
+    theta[ptr + 7] += vref_offset
+
+
+def _biased_two_bus(data_dir, side, *, fault=False, width=0.01):
+    psys = _build_two_bus(data_dir, fault=fault)
+    z0, theta, ctx = _initialize_context(psys)
+    exciter = psys.exc[0]
+    state_index = exciter.dif_ptr + exciter.efd_idx
+    initial = float(z0[state_index])
+    lower = initial - width
+    upper = initial + width
+    _set_limits(
+        theta,
+        exciter,
+        lower,
+        upper,
+        vref_offset=0.05 if side == "upper" else -0.05,
+    )
+    ctx.set_theta(theta.copy())
+    return psys, ctx, state_index, lower, upper
+
+
+def _config(**overrides):
+    values = {
+        "method": "beuler",
+        "petsc": False,
+        "steps": 4,
+        "dt": 0.005,
+        "ton": 10.0,
+        "toff": 11.0,
+    }
+    values.update(overrides)
+    return IntegrationConfig(**values)
+
+
+def test_fixed_active_rows_replace_residual_and_sparse_jacobian_rows():
+    descriptors = [_descriptor(0, "upper"), _descriptor(1, "lower")]
+    modes = {
+        0: DynamicLimitMode.UPPER_ACTIVE,
+        1: DynamicLimitMode.LOWER_ACTIVE,
+    }
+    state = np.asarray([1.25, -0.25, 7.0])
+    residual = np.asarray([9.0, 8.0, 7.0])
+    jacobian = csr_matrix(np.full((3, 3), 2.0))
+
+    dynamics._apply_beuler_active_rows(
+        residual, jacobian, state, descriptors, modes
+    )
+
+    np.testing.assert_allclose(residual, [0.25, -0.25, 7.0])
+    np.testing.assert_allclose(jacobian.toarray()[0], [1.0, 0.0, 0.0])
+    np.testing.assert_allclose(jacobian.toarray()[1], [0.0, 1.0, 0.0])
+    np.testing.assert_allclose(jacobian.toarray()[2], [2.0, 2.0, 2.0])
+
+
+@pytest.mark.parametrize("side", ["upper", "lower"])
+def test_native_be_crossing_activates_bound_without_overshoot(data_dir, side):
+    psys, ctx, state_index, lower, upper = _biased_two_bus(data_dir, side)
+
+    result = integrate_system(psys, _config(), ctx)
+
+    values = result["history"][state_index]
+    assert np.min(values) >= lower - 1e-12
+    assert np.max(values) <= upper + 1e-12
+    bound = upper if side == "upper" else lower
+    assert np.any(np.isclose(values, bound, atol=1e-10))
+    events = result["dynamic_limit_diagnostics"]["events"]
+    activations = [
+        event
+        for event in events
+        if event["action"] == "activate" and event["side"] == side
+    ]
+    assert len(activations) == 1
+    assert activations[0]["state_after"] == pytest.approx(bound)
+    assert activations[0]["active_set_iterations"] == 1
+    json.dumps(events, allow_nan=False)
+
+
+@pytest.mark.parametrize("side", ["upper", "lower"])
+def test_native_be_pins_outward_and_releases_for_inward_drive(data_dir, side):
+    psys = _build_two_bus(data_dir)
+    z0, theta, _ = _initialize_context(psys)
+    exciter = psys.exc[0]
+    state_index = exciter.dif_ptr + exciter.efd_idx
+    ptr = exciter.par_ptr
+    initial = float(z0[state_index])
+    base_vref = float(theta[ptr + 7])
+    if side == "upper":
+        _set_limits(
+            theta, exciter, initial - 0.1, initial, vref_offset=0.05
+        )
+    else:
+        _set_limits(
+            theta, exciter, initial, initial + 0.1, vref_offset=-0.05
+        )
+    descriptors = collect_limited_state_descriptors(psys, theta)
+    modes = initialize_dynamic_limit_modes(descriptors)
+    residual = np.zeros_like(z0)
+    jacobian = preallocate_jacobian(psys)
+
+    pinned, modes, activation_events = (
+        dynamics._integrate_beuler_with_dynamic_limits(
+            z0,
+            theta,
+            0.005,
+            psys,
+            residual,
+            jacobian,
+            descriptors=descriptors,
+            modes=modes,
+            state_tolerance=1e-8,
+            release_tolerance=1e-10,
+            max_active_set_iterations=20,
+            endpoint_time=0.005,
+            newton_tol=1e-10,
+            newton_max_iter=50,
+        )
+    )
+    assert pinned[state_index] == pytest.approx(initial, abs=1e-10)
+    expected_mode = (
+        DynamicLimitMode.UPPER_ACTIVE
+        if side == "upper"
+        else DynamicLimitMode.LOWER_ACTIVE
+    )
+    assert modes[state_index] == expected_mode
+
+    theta[ptr + 7] = (
+        base_vref - 0.05 if side == "upper" else base_vref + 0.05
+    )
+    released, modes, release_events = (
+        dynamics._integrate_beuler_with_dynamic_limits(
+            pinned,
+            theta,
+            0.005,
+            psys,
+            residual,
+            jacobian,
+            descriptors=descriptors,
+            modes=modes,
+            state_tolerance=1e-8,
+            release_tolerance=1e-10,
+            max_active_set_iterations=20,
+            endpoint_time=0.01,
+            newton_tol=1e-10,
+            newton_max_iter=50,
+        )
+    )
+
+    if side == "upper":
+        assert released[state_index] < initial
+    else:
+        assert released[state_index] > initial
+    assert modes[state_index] == DynamicLimitMode.FREE
+    assert any(event["action"] == "activate" for event in activation_events)
+    assert any(event["action"] == "release" for event in release_events)
+
+
+def test_native_be_enforces_multiple_sexs_limits_together(data_dir):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "ieee9_v33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "ieee9bus_SEXS.dyr"))
+    psys.createYbusComplex()
+    psys.power_injection = False
+    z0, theta, ctx = _initialize_context(psys)
+    limited = []
+    expected_buses = set()
+    for index, exciter in enumerate(psys.exc):
+        state_index = exciter.dif_ptr + exciter.efd_idx
+        initial = float(z0[state_index])
+        _set_limits(
+            theta,
+            exciter,
+            initial - 0.01,
+            initial + 0.01,
+            vref_offset=0.05 if index % 2 == 0 else -0.05,
+        )
+        limited.append((state_index, initial - 0.01, initial + 0.01))
+        expected_buses.add(psys.buses[exciter.bus].id)
+    ctx.set_theta(theta.copy())
+
+    result = integrate_system(psys, _config(), ctx)
+
+    for state_index, lower, upper in limited:
+        values = result["history"][state_index]
+        assert np.min(values) >= lower - 1e-12
+        assert np.max(values) <= upper + 1e-12
+    activation_buses = {
+        event["bus"]
+        for event in result["dynamic_limit_diagnostics"]["events"]
+        if event["action"] == "activate"
+    }
+    assert activation_buses == expected_buses
+
+
+def test_native_be_endpoint_is_dae_and_complementarity_consistent(data_dir):
+    psys, ctx, state_index, _, upper = _biased_two_bus(data_dir, "upper")
+    result = integrate_system(psys, _config(steps=1), ctx)
+    zold = result["history"][:, 0]
+    endpoint = result["history"][:, 1]
+    theta = ctx.theta_user
+    free_residual = np.zeros_like(endpoint)
+    dynamics._assemble_beuler_residual(
+        free_residual, endpoint, zold, 0.005, psys, theta
+    )
+    raw_residual = np.zeros_like(endpoint)
+    residual_function(raw_residual, endpoint, theta, psys)
+
+    assert endpoint[state_index] == pytest.approx(upper, abs=1e-10)
+    assert free_residual[state_index] <= 1e-10
+    assert np.linalg.norm(
+        raw_residual[psys.num_dof_dif :], np.inf
+    ) < 1e-8
+    inactive_rows = np.ones(psys.num_dof_dif, dtype=bool)
+    inactive_rows[state_index] = False
+    assert np.linalg.norm(
+        free_residual[: psys.num_dof_dif][inactive_rows], np.inf
+    ) < 1e-8
+
+
+def test_fault_projection_holds_differential_states_fixed(data_dir, monkeypatch):
+    psys, ctx, state_index, lower, upper = _biased_two_bus(
+        data_dir, "upper", fault=True
+    )
+    original_integrate = dynamics.integrate
+    projection_pairs = []
+
+    def recording_integrate(zold, theta, h, psys, *args, **kwargs):
+        result = original_integrate(zold, theta, h, psys, *args, **kwargs)
+        if h == 0.0:
+            projection_pairs.append(
+                (zold[: psys.num_dof_dif].copy(), result[0][: psys.num_dof_dif])
+            )
+        return result
+
+    monkeypatch.setattr(dynamics, "integrate", recording_integrate)
+    result = integrate_system(
+        psys,
+        _config(steps=3, ton=0.005, toff=0.01),
+        ctx,
+    )
+
+    assert len(projection_pairs) == 2
+    for before, after in projection_pairs:
+        np.testing.assert_allclose(after, before, atol=1e-12)
+    values = result["history"][state_index]
+    assert np.min(values) >= lower - 1e-12
+    assert np.max(values) <= upper + 1e-12
+
+
+def test_native_be_failure_after_fault_application_restores_fault(
+    data_dir, monkeypatch
+):
+    psys, ctx, _, _, _ = _biased_two_bus(
+        data_dir, "upper", fault=True
+    )
+    original_step = dynamics._integrate_beuler_with_dynamic_limits
+    calls = 0
+
+    def fail_second_interval(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise DynamicLimitError(
+                {
+                    "enabled": True,
+                    "phase": "runtime",
+                    "method": "beuler",
+                    "failure_reasons": ["active_set_cycle"],
+                    "events": [],
+                }
+            )
+        return original_step(*args, **kwargs)
+
+    monkeypatch.setattr(
+        dynamics,
+        "_integrate_beuler_with_dynamic_limits",
+        fail_second_interval,
+    )
+
+    with pytest.raises(DynamicLimitError):
+        integrate_system(
+            psys,
+            _config(steps=2, ton=0.005, toff=0.02),
+            ctx,
+        )
+
+    assert calls == 2
+    assert psys.fault_events[0].active is False
+
+
+def _run_failure_fixture(monkeypatch, updates, *, max_iterations=20):
+    descriptor = _descriptor()
+    psys = SimpleNamespace(num_dof_dif=1)
+    residual = np.zeros(1)
+    jacobian = csr_matrix(np.eye(1))
+
+    monkeypatch.setattr(
+        dynamics,
+        "_solve_beuler_fixed_active_set",
+        lambda *args, **kwargs: (np.asarray([0.5]), 3, 1e-12, True),
+    )
+    monkeypatch.setattr(
+        dynamics,
+        "_assemble_beuler_residual",
+        lambda F, *args, **kwargs: F.fill(0.0),
+    )
+    calls = iter(updates)
+
+    def fake_update(*args, **kwargs):
+        mode = next(calls)
+        return (
+            {0: mode},
+            True,
+            {"consistent": False, "records": []},
+            [],
+        )
+
+    monkeypatch.setattr(dynamics, "update_dynamic_limit_active_set", fake_update)
+    return dynamics._integrate_beuler_with_dynamic_limits(
+        np.asarray([0.5]),
+        np.asarray([]),
+        0.1,
+        psys,
+        residual,
+        jacobian,
+        descriptors=[descriptor],
+        modes={0: DynamicLimitMode.FREE},
+        state_tolerance=1e-8,
+        release_tolerance=1e-10,
+        max_active_set_iterations=max_iterations,
+        endpoint_time=0.1,
+        newton_tol=1e-10,
+        newton_max_iter=10,
+    )
+
+
+def test_native_be_reports_active_set_cycle(monkeypatch):
+    with pytest.raises(DynamicLimitError) as exc_info:
+        _run_failure_fixture(
+            monkeypatch,
+            [DynamicLimitMode.UPPER_ACTIVE, DynamicLimitMode.FREE],
+        )
+
+    diagnostics = exc_info.value.diagnostics
+    assert diagnostics["phase"] == "runtime"
+    assert diagnostics["failure_reasons"] == ["active_set_cycle"]
+    assert diagnostics["active_set_iterations"] == 2
+    json.dumps(diagnostics, allow_nan=False)
+
+
+def test_native_be_reports_active_set_iteration_limit(monkeypatch):
+    with pytest.raises(DynamicLimitError) as exc_info:
+        _run_failure_fixture(
+            monkeypatch,
+            [DynamicLimitMode.UPPER_ACTIVE],
+            max_iterations=1,
+        )
+
+    diagnostics = exc_info.value.diagnostics
+    assert diagnostics["failure_reasons"] == ["active_set_iteration_limit"]
+    assert diagnostics["active_set_iterations"] == 1
+
+
+def test_native_be_reports_fixed_set_newton_failure(monkeypatch):
+    descriptor = _descriptor()
+    monkeypatch.setattr(
+        dynamics,
+        "_solve_beuler_fixed_active_set",
+        lambda *args, **kwargs: (np.asarray([0.5]), 4, np.inf, False),
+    )
+
+    with pytest.raises(DynamicLimitError) as exc_info:
+        dynamics._integrate_beuler_with_dynamic_limits(
+            np.asarray([0.5]),
+            np.asarray([]),
+            0.1,
+            SimpleNamespace(num_dof_dif=1),
+            np.zeros(1),
+            csr_matrix(np.eye(1)),
+            descriptors=[descriptor],
+            modes={0: DynamicLimitMode.FREE},
+            state_tolerance=1e-8,
+            release_tolerance=1e-10,
+            max_active_set_iterations=20,
+            endpoint_time=0.1,
+            newton_tol=1e-10,
+            newton_max_iter=4,
+        )
+
+    diagnostics = exc_info.value.diagnostics
+    assert diagnostics["failure_reasons"] == ["newton_nonconvergence"]
+    assert diagnostics["newton_iterations"] == 4
+    assert diagnostics["residual_norm"] is None
+
+
+def test_native_be_converges_toward_small_step_herk(data_dir):
+    def run(method, dt, steps):
+        psys, ctx, _, _, _ = _biased_two_bus(data_dir, "upper")
+        result = integrate_system(
+            psys,
+            IntegrationConfig(
+                method=method,
+                petsc=False,
+                dt=dt,
+                steps=steps,
+                ton=10.0,
+                toff=11.0,
+            ),
+            ctx,
+        )
+        return result["history"][:, -1]
+
+    reference = run("herk4", 0.00025, 80)
+    coarse = run("beuler", 0.004, 5)
+    fine = run("beuler", 0.002, 10)
+
+    assert np.linalg.norm(fine - reference) < np.linalg.norm(coarse - reference)
+
+
+def test_native_be_sexs_no_fault_trajectory_stays_flat(data_dir):
+    psys = _build_two_bus(data_dir)
+
+    result = integrate_system(
+        psys,
+        _config(steps=50, dt=0.001),
+    )
+
+    drift = np.max(np.abs(result["history"] - result["history"][:, [0]]))
+    assert drift < 1e-8
+    assert result["dynamic_limit_diagnostics"]["events"] == []
+
+
+def test_disabled_dynamic_limits_preserve_legacy_beuler_path(
+    data_dir, monkeypatch
+):
+    psys = _build_two_bus(data_dir)
+    monkeypatch.setattr(
+        dynamics,
+        "_integrate_beuler_with_dynamic_limits",
+        lambda *args, **kwargs: pytest.fail("limited BE path must not run"),
+    )
+
+    result = integrate_system(
+        psys,
+        _config(steps=1, enforce_dynamic_limits=False),
+    )
+
+    assert result["dynamic_limit_diagnostics"]["enabled"] is False
+    assert result["dynamic_limit_diagnostics"]["events"] == []

--- a/tests/test_dynamic_limit_cross_integrator.py
+++ b/tests/test_dynamic_limit_cross_integrator.py
@@ -1,0 +1,675 @@
+import importlib
+import json
+import os
+
+import numpy as np
+import pytest
+
+import uqgrid
+import uqgrid.simulation
+from uqgrid.io.parse import add_dyr, load_psse
+from uqgrid.simulation import dynamics
+from uqgrid.simulation.config import IntegrationConfig, IntegrationCtx
+from uqgrid.simulation.dynamic_limits import (
+    DYNAMIC_LIMIT_EVENT_ACTIONS,
+    DYNAMIC_LIMIT_EVENT_FIELDS,
+    DynamicLimitMode,
+    collect_limited_state_descriptors,
+    initialize_dynamic_limit_modes,
+)
+from uqgrid.simulation.dynamics import initialize_system, integrate_system
+from uqgrid.simulation.pflow import runpf
+from uqgrid.simulation.residual import residual_function
+
+
+METHODS = (
+    pytest.param("beuler", False, id="native-be"),
+    pytest.param("herk2", False, id="herk2"),
+    pytest.param("herk4", False, id="herk4"),
+    pytest.param("beuler", True, id="petsc-be"),
+    pytest.param("cn", True, id="petsc-cn"),
+)
+IMPLICIT_METHODS = (
+    pytest.param("beuler", False, id="native-be"),
+    pytest.param("beuler", True, id="petsc-be"),
+    pytest.param("cn", True, id="petsc-cn"),
+)
+
+
+@pytest.fixture
+def data_dir():
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data"
+    )
+
+
+def _require_backend(petsc):
+    if petsc:
+        pytest.importorskip("petsc4py")
+
+
+def _build_two_bus(data_dir, *, fault=False):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "2bus_33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "2bus_SEXS.dyr"))
+    if fault:
+        psys.add_busfault(1, 1e-4)
+    psys.createYbusComplex()
+    psys.power_injection = False
+    return psys
+
+
+def _initialize_context(psys):
+    solution = runpf(psys, verbose=False)
+    z0, theta = initialize_system(psys, solution)
+    ctx = IntegrationCtx()
+    ctx.set_initial_conditions(z0.copy())
+    ctx.set_theta(theta.copy())
+    return z0, theta, ctx
+
+
+def _set_biased_limits(psys, z0, theta, *, width=0.01, offset=0.05):
+    exciter = psys.exc[0]
+    state_index = exciter.dif_ptr + exciter.efd_idx
+    initial = float(z0[state_index])
+    ptr = exciter.par_ptr
+    theta[ptr + 4] = initial - width
+    theta[ptr + 5] = initial + width
+    theta[ptr + 6] = 1.0
+    theta[ptr + 7] += offset
+    return state_index, initial - width, initial + width
+
+
+def _run_two_bus(
+    data_dir,
+    method,
+    petsc,
+    *,
+    fault=False,
+    biased=False,
+    dt=0.005,
+    steps=4,
+    tend=10.0,
+    ton=10.0,
+    toff=11.0,
+):
+    _require_backend(petsc)
+    psys = _build_two_bus(data_dir, fault=fault)
+    z0, theta, ctx = _initialize_context(psys)
+    limits = None
+    if biased:
+        limits = _set_biased_limits(psys, z0, theta)
+        ctx.set_theta(theta.copy())
+    config = IntegrationConfig(
+        method=method,
+        petsc=petsc,
+        dt=dt,
+        steps=steps,
+        tend=tend,
+        ton=ton,
+        toff=toff,
+        newton_tol=1e-10,
+        newton_max_iter=100,
+        herk_alg_tol=1e-10,
+        herk_alg_max_iter=100,
+    )
+    result = integrate_system(psys, config, ctx)
+    return psys, ctx, config, result, limits
+
+
+def _run_limited_ieee9(data_dir, method, petsc):
+    _require_backend(petsc)
+    psys = load_psse(raw_filename=os.path.join(data_dir, "ieee9_v33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "ieee9bus_SEXS.dyr"))
+    psys.createYbusComplex()
+    psys.power_injection = False
+    z0, theta, ctx = _initialize_context(psys)
+    limits = []
+    for index, exciter in enumerate(psys.exc):
+        state_index = exciter.dif_ptr + exciter.efd_idx
+        initial = float(z0[state_index])
+        ptr = exciter.par_ptr
+        theta[ptr + 4] = initial - 0.01
+        theta[ptr + 5] = initial + 0.01
+        theta[ptr + 6] = 1.0
+        expected_side = "upper" if index % 2 == 0 else "lower"
+        theta[ptr + 7] += 0.05 if expected_side == "upper" else -0.05
+        limits.append(
+            {
+                "state_index": state_index,
+                "lower": initial - 0.01,
+                "upper": initial + 0.01,
+                "expected_side": expected_side,
+                "bus": int(psys.buses[exciter.bus].id),
+            }
+        )
+    ctx.set_theta(theta.copy())
+    config = IntegrationConfig(
+        method=method,
+        petsc=petsc,
+        dt=0.005,
+        steps=3,
+        ton=10.0,
+        toff=11.0,
+        newton_tol=1e-10,
+        newton_max_iter=100,
+        herk_alg_tol=1e-10,
+        herk_alg_max_iter=100,
+    )
+    return psys, ctx, config, integrate_system(psys, config, ctx), limits
+
+
+def _assert_event_contract(events, *, implicit):
+    required = set(DYNAMIC_LIMIT_EVENT_FIELDS)
+    assert events
+    previous_time = -np.inf
+    for event in events:
+        assert required <= set(event)
+        assert event["action"] in DYNAMIC_LIMIT_EVENT_ACTIONS
+        assert event["side"] in {"lower", "upper"}
+        assert isinstance(event["device_type"], str)
+        assert isinstance(event["device_id"], str)
+        assert isinstance(event["bus"], int)
+        assert isinstance(event["state_index"], int)
+        assert np.isfinite(event["time"])
+        assert event["time"] >= previous_time - 1e-14
+        previous_time = event["time"]
+        if implicit:
+            assert event["stage_or_endpoint"] == "endpoint"
+            assert isinstance(event["active_set_iterations"], int)
+        else:
+            context = event["stage_or_endpoint"]
+            assert context == "endpoint" or context.startswith("stage_")
+            assert event["active_set_iterations"] is None
+    json.dumps(events, allow_nan=False)
+
+
+def test_event_schema_constants_are_exported():
+    assert uqgrid.DYNAMIC_LIMIT_EVENT_FIELDS == DYNAMIC_LIMIT_EVENT_FIELDS
+    assert uqgrid.DYNAMIC_LIMIT_EVENT_ACTIONS == DYNAMIC_LIMIT_EVENT_ACTIONS
+    assert (
+        uqgrid.simulation.DYNAMIC_LIMIT_EVENT_FIELDS
+        == DYNAMIC_LIMIT_EVENT_FIELDS
+    )
+
+
+def test_standard_ieee9_is_an_explicit_zero_limit_negative_control(data_dir):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "ieee9_v33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "ieee9bus.dyr"))
+    psys.createYbusComplex()
+    _, theta, ctx = _initialize_context(psys)
+
+    assert collect_limited_state_descriptors(psys, theta) == []
+
+    result = integrate_system(
+        psys,
+        IntegrationConfig(
+            method="beuler",
+            petsc=False,
+            steps=1,
+            dt=0.005,
+            ton=10.0,
+            toff=11.0,
+        ),
+        ctx,
+    )
+    diagnostics = result["dynamic_limit_diagnostics"]
+    assert diagnostics["discovered_state_count"] == 0
+    assert diagnostics["enabled_state_count"] == 0
+    assert diagnostics["events"] == []
+    assert (
+        uqgrid.simulation.DYNAMIC_LIMIT_EVENT_ACTIONS
+        == DYNAMIC_LIMIT_EVENT_ACTIONS
+    )
+
+
+@pytest.mark.parametrize("method,petsc", METHODS)
+def test_all_integrators_return_the_common_event_schema(
+    data_dir, method, petsc
+):
+    psys, ctx, config, result, limits = _run_two_bus(
+        data_dir, method, petsc, biased=True
+    )
+    events = result["dynamic_limit_diagnostics"]["events"]
+
+    _assert_event_contract(
+        events, implicit=method in {"beuler", "cn"}
+    )
+    state_index, lower, upper = limits
+    values = result["history"][state_index]
+    assert np.min(values) >= lower - config.dynamic_limit_tolerance
+    assert np.max(values) <= upper + config.dynamic_limit_tolerance
+    assert "stage_history" not in result
+    assert "limit_stage_history" not in result
+
+
+@pytest.mark.parametrize("method,petsc", METHODS)
+def test_all_integrators_share_the_schema_for_multiple_ieee9_exciters(
+    data_dir, method, petsc
+):
+    psys, ctx, config, result, limits = _run_limited_ieee9(
+        data_dir, method, petsc
+    )
+    events = result["dynamic_limit_diagnostics"]["events"]
+
+    descriptors = collect_limited_state_descriptors(psys, ctx.theta_user)
+    assert len(psys.exc) == 3
+    assert len(descriptors) == 3
+    assert all(descriptor.device_type == "SEXS" for descriptor in descriptors)
+    assert all(descriptor.enabled for descriptor in descriptors)
+    _assert_event_contract(events, implicit=method in {"beuler", "cn"})
+    event_buses = {event["bus"] for event in events}
+    assert event_buses == {psys.buses[exciter.bus].id for exciter in psys.exc}
+    for limit in limits:
+        state_index = limit["state_index"]
+        lower = limit["lower"]
+        upper = limit["upper"]
+        side = limit["expected_side"]
+        bound = upper if side == "upper" else lower
+        descriptor = next(
+            item for item in descriptors if item.state_index == state_index
+        )
+        assert descriptor.lower_bound == pytest.approx(lower)
+        assert descriptor.upper_bound == pytest.approx(upper)
+        activations = [
+            event
+            for event in events
+            if event["state_index"] == state_index
+            and event["action"] == "activate"
+        ]
+        assert activations
+        assert {event["side"] for event in activations} == {side}
+        assert all(event["bus"] == limit["bus"] for event in activations)
+        values = result["history"][state_index]
+        assert np.min(values) >= lower - config.dynamic_limit_tolerance
+        assert np.max(values) <= upper + config.dynamic_limit_tolerance
+        np.testing.assert_allclose(values[1:], bound, atol=1e-8, rtol=0.0)
+        if method in {"herk2", "herk4"}:
+            projections = [
+                event
+                for event in events
+                if event["state_index"] == state_index
+                and event["action"] == "project"
+                and event["side"] == side
+            ]
+            assert projections
+            assert all(
+                event["state_after"] == pytest.approx(bound)
+                for event in projections
+            )
+
+
+@pytest.mark.parametrize("method,petsc", METHODS)
+def test_no_fault_limited_trajectories_remain_flat(data_dir, method, petsc):
+    psys, ctx, config, result, _ = _run_two_bus(
+        data_dir,
+        method,
+        petsc,
+        dt=1.0 / 120.0,
+        steps=5,
+    )
+    history = result["history"]
+    drift = np.abs(history - history[:, [0]])
+    ndiff = psys.num_dof_dif
+    nalg = psys.num_dof_alg
+    slices = (
+        drift[:ndiff],
+        drift[ndiff : ndiff + nalg],
+        drift[ndiff + nalg :],
+        drift,
+    )
+    for values in slices:
+        assert np.max(values, initial=0.0) < 1e-8
+
+    residual = np.zeros(history.shape[0])
+    for state in history.T:
+        residual_function(residual, state, ctx.theta_user, psys)
+        assert np.linalg.norm(residual, np.inf) < 1e-8
+    assert result["dynamic_limit_diagnostics"]["events"] == []
+
+
+@pytest.mark.parametrize("method", ["herk2", "herk4"])
+def test_herk_stages_are_bound_feasible_and_algebraically_consistent(
+    data_dir, method, monkeypatch
+):
+    herk = importlib.import_module("uqgrid.simulation.herk")
+    projected_states = []
+    algebraic_norms = []
+    original_project = herk.project_limited_states
+    original_solve = herk.solve_stage_algebraic
+
+    def recording_project(state, descriptors, **kwargs):
+        projected, events = original_project(state, descriptors, **kwargs)
+        projected_states.append((projected.copy(), list(descriptors)))
+        return projected, events
+
+    def recording_solve(X_i, y0, v0, theta, psys, F, J, *args, **kwargs):
+        y, v, iterations = original_solve(
+            X_i, y0, v0, theta, psys, F, J, *args, **kwargs
+        )
+        state = np.concatenate([X_i, y, v])
+        check = np.zeros_like(state)
+        residual_function(check, state, theta, psys)
+        algebraic_norms.append(
+            np.linalg.norm(check[psys.num_dof_dif :], np.inf)
+        )
+        return y, v, iterations
+
+    monkeypatch.setattr(herk, "project_limited_states", recording_project)
+    monkeypatch.setattr(herk, "solve_stage_algebraic", recording_solve)
+    psys, ctx, config, result, _ = _run_two_bus(
+        data_dir, method, False, biased=True
+    )
+
+    assert projected_states
+    for state, descriptors in projected_states:
+        for descriptor in descriptors:
+            value = state[descriptor.state_index]
+            assert value >= descriptor.lower_bound - config.dynamic_limit_tolerance
+            assert value <= descriptor.upper_bound + config.dynamic_limit_tolerance
+    assert algebraic_norms
+    assert max(algebraic_norms) < 1e-8
+    assert "stage_history" not in result
+
+
+def _apply_endpoint_events(modes, descriptors, events, endpoint_time):
+    updated = dict(modes)
+    for event in events:
+        if not np.isclose(event["time"], endpoint_time, atol=1e-14, rtol=0.0):
+            continue
+        state_index = event["state_index"]
+        if event["action"] == "activate":
+            updated[state_index] = (
+                DynamicLimitMode.UPPER_ACTIVE
+                if event["side"] == "upper"
+                else DynamicLimitMode.LOWER_ACTIVE
+            )
+        elif event["action"] == "release":
+            updated[state_index] = DynamicLimitMode.FREE
+    return updated
+
+
+@pytest.mark.parametrize("method,petsc", IMPLICIT_METHODS)
+def test_implicit_endpoint_equations_and_complementarity(
+    data_dir, method, petsc
+):
+    psys, ctx, config, result, _ = _run_two_bus(
+        data_dir, method, petsc, biased=True
+    )
+    history = result["history"]
+    times = result["tvec"]
+    theta = ctx.theta_user
+    descriptors = collect_limited_state_descriptors(psys, theta)
+    modes = initialize_dynamic_limit_modes(descriptors)
+    events = result["dynamic_limit_diagnostics"]["events"]
+
+    for index in range(1, len(times)):
+        zold = history[:, index - 1]
+        endpoint = history[:, index]
+        h = times[index] - times[index - 1]
+        start_modes = dict(modes)
+        if method == "cn":
+            start_derivative = dynamics._effective_cn_start_derivative(
+                zold,
+                theta,
+                psys,
+                descriptors,
+                start_modes,
+                tolerance=config.dynamic_limit_tolerance,
+            )
+            free_residual = np.zeros_like(endpoint)
+            dynamics._assemble_cn_residual(
+                free_residual,
+                endpoint,
+                zold,
+                h,
+                start_derivative,
+                psys,
+                theta,
+            )
+        else:
+            free_residual = np.zeros_like(endpoint)
+            dynamics._assemble_beuler_residual(
+                free_residual, endpoint, zold, h, psys, theta
+            )
+
+        modes = _apply_endpoint_events(modes, descriptors, events, times[index])
+        free_rows = np.ones(psys.num_dof_dif, dtype=bool)
+        for descriptor in descriptors:
+            state_index = descriptor.state_index
+            mode = modes[state_index]
+            if mode == DynamicLimitMode.FREE:
+                continue
+            free_rows[state_index] = False
+            if mode == DynamicLimitMode.UPPER_ACTIVE:
+                assert endpoint[state_index] == pytest.approx(
+                    descriptor.upper_bound, abs=1e-8
+                )
+                assert free_residual[state_index] <= (
+                    config.dynamic_limit_release_tolerance + 1e-8
+                )
+            else:
+                assert endpoint[state_index] == pytest.approx(
+                    descriptor.lower_bound, abs=1e-8
+                )
+                assert free_residual[state_index] >= -(
+                    config.dynamic_limit_release_tolerance + 1e-8
+                )
+        assert np.linalg.norm(
+            free_residual[: psys.num_dof_dif][free_rows], np.inf
+        ) < 1e-8
+        assert np.linalg.norm(
+            free_residual[psys.num_dof_dif :], np.inf
+        ) < 1e-8
+
+
+def test_native_and_petsc_be_match_on_the_common_fault_case(data_dir):
+    native = _run_two_bus(
+        data_dir,
+        "beuler",
+        False,
+        fault=True,
+        biased=True,
+        dt=0.005,
+        steps=4,
+        ton=0.0075,
+        toff=0.0135,
+    )
+    petsc = _run_two_bus(
+        data_dir,
+        "beuler",
+        True,
+        fault=True,
+        biased=True,
+        dt=0.005,
+        steps=4,
+        ton=0.0075,
+        toff=0.0135,
+    )
+
+    np.testing.assert_allclose(petsc[3]["tvec"], native[3]["tvec"])
+    np.testing.assert_allclose(
+        petsc[3]["history"],
+        native[3]["history"],
+        atol=1e-8,
+        rtol=1e-8,
+    )
+    native_events = native[3]["dynamic_limit_diagnostics"]["events"]
+    petsc_events = petsc[3]["dynamic_limit_diagnostics"]["events"]
+    identities = lambda records: [
+        (
+            item["device_type"],
+            item["device_id"],
+            item["bus"],
+            item["state_index"],
+            item["side"],
+            item["action"],
+            item["time"],
+            item["stage_or_endpoint"],
+        )
+        for item in records
+    ]
+    assert identities(petsc_events) == identities(native_events)
+
+
+@pytest.mark.parametrize("method,petsc", METHODS)
+def test_all_integrators_preserve_the_normalized_fault_schedule(
+    data_dir, method, petsc
+):
+    psys, ctx, config, result, limits = _run_two_bus(
+        data_dir,
+        method,
+        petsc,
+        fault=True,
+        biased=True,
+        dt=0.005,
+        steps=4,
+        ton=0.0075,
+        toff=0.0135,
+    )
+    expected = [0.0, 0.005, 0.0075, 0.01, 0.0135, 0.015, 0.02]
+    np.testing.assert_allclose(result["tvec"], expected)
+    assert result["history"].shape[1] == len(expected)
+    state_index, lower, upper = limits
+    values = result["history"][state_index]
+    assert np.min(values) >= lower - config.dynamic_limit_tolerance
+    assert np.max(values) <= upper + config.dynamic_limit_tolerance
+    activations = [
+        event
+        for event in result["dynamic_limit_diagnostics"]["events"]
+        if event["action"] == "activate" and event["state_index"] == state_index
+    ]
+    assert activations
+    assert any(
+        np.isclose(values, event["bound"], atol=1e-8, rtol=0.0).any()
+        for event in activations
+    )
+
+    residual = np.zeros(result["history"].shape[0])
+    fault = psys.fault_events[0]
+    for time, state in zip(result["tvec"], result["history"].T):
+        if config.ton <= time < config.toff:
+            fault.apply()
+        else:
+            fault.remove()
+        residual_function(residual, state, ctx.theta_user, psys)
+        assert np.linalg.norm(residual[psys.num_dof_dif :], np.inf) < 1e-8
+    fault.remove()
+    assert fault.active is False
+
+
+def _sample_reference(reference_times, reference_history, sample_times):
+    indices = []
+    for time in sample_times:
+        matches = np.flatnonzero(
+            np.isclose(reference_times, time, atol=1e-13, rtol=0.0)
+        )
+        assert len(matches) == 1
+        indices.append(matches[0])
+    return reference_history[:, indices]
+
+
+def _normalized_error(candidate, reference):
+    scale = max(1.0, float(np.linalg.norm(reference, np.inf)))
+    return float(np.linalg.norm(candidate - reference, np.inf) / scale)
+
+
+def test_all_integrators_converge_toward_one_faulted_limited_trajectory(data_dir):
+    dts = (1.0 / 120.0, 1.0 / 240.0, 1.0 / 480.0)
+    reference_run = _run_two_bus(
+        data_dir,
+        "herk4",
+        False,
+        fault=True,
+        biased=True,
+        dt=1.0 / 1920.0,
+        steps=-1,
+        tend=0.1,
+        ton=0.025,
+        toff=0.05,
+    )
+    reference = reference_run[3]
+    ndiff = reference_run[0].num_dof_dif
+    errors = {f"{method}:{petsc}": [] for method, petsc in [
+        ("beuler", False),
+        ("herk2", False),
+        ("herk4", False),
+        ("beuler", True),
+        ("cn", True),
+    ]}
+    endpoint_states = {dt: [] for dt in dts}
+    activation_times = []
+    reference_events = reference["dynamic_limit_diagnostics"]["events"]
+    reference_activation = next(
+        event["time"]
+        for event in reference_events
+        if event["action"] == "activate"
+    )
+
+    for method, petsc in [
+        ("beuler", False),
+        ("herk2", False),
+        ("herk4", False),
+        ("beuler", True),
+        ("cn", True),
+    ]:
+        _require_backend(petsc)
+        key = f"{method}:{petsc}"
+        for dt in dts:
+            run = _run_two_bus(
+                data_dir,
+                method,
+                petsc,
+                fault=True,
+                biased=True,
+                dt=dt,
+                steps=-1,
+                tend=0.1,
+                ton=0.025,
+                toff=0.05,
+            )
+            result = run[3]
+            reference_sample = _sample_reference(
+                reference["tvec"],
+                reference["history"][:ndiff],
+                result["tvec"],
+            )
+            errors[key].append(
+                _normalized_error(result["history"][:ndiff], reference_sample)
+            )
+            endpoint_states[dt].append(result["history"][:ndiff, -1])
+            activation = next(
+                event["time"]
+                for event in result["dynamic_limit_diagnostics"]["events"]
+                if event["action"] == "activate"
+            )
+            activation_times.append((activation, reference_activation, dt))
+
+    for method_errors in errors.values():
+        assert method_errors[-1] < 0.75 * method_errors[0]
+
+    spreads = []
+    for dt in dts:
+        states = endpoint_states[dt]
+        spreads.append(
+            max(
+                _normalized_error(left, right)
+                for left in states
+                for right in states
+            )
+        )
+    assert spreads[-1] < 0.75 * spreads[0]
+    for activation, fine_activation, dt in activation_times:
+        assert abs(activation - fine_activation) <= dt + 1e-12
+
+
+def test_arkimex_requires_legacy_unconstrained_dynamic_limits():
+    with pytest.raises(ValueError, match="enforce_dynamic_limits=False"):
+        IntegrationConfig(petsc=True, arkimex=True)
+
+    config = IntegrationConfig(
+        petsc=True,
+        arkimex=True,
+        enforce_dynamic_limits=False,
+    )
+    assert config.arkimex is True
+    assert config.enforce_dynamic_limits is False

--- a/tests/test_dynamic_limits.py
+++ b/tests/test_dynamic_limits.py
@@ -1,0 +1,501 @@
+import json
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from uqgrid.io.parse import add_dyr, load_psse
+from uqgrid.models.sexs_imp import ExcSEXS
+from uqgrid.simulation.config import IntegrationConfig, IntegrationCtx
+from uqgrid.simulation.dynamic_limits import (
+    DynamicLimitError,
+    DynamicLimitMode,
+    LimitedStateDescriptor,
+    collect_limited_state_descriptors,
+    evaluate_dynamic_limit_complementarity,
+    initialize_dynamic_limit_modes,
+    project_limited_derivatives,
+    project_limited_states,
+    update_dynamic_limit_active_set,
+    validate_initial_dynamic_limits,
+)
+from uqgrid.simulation.dynamics import initialize_system, integrate_system
+from uqgrid.simulation.pflow import runpf
+
+
+@pytest.fixture
+def data_dir():
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data"
+    )
+
+
+def _descriptor(**overrides):
+    values = {
+        "state_index": 0,
+        "lower_bound": 0.0,
+        "upper_bound": 1.0,
+        "device_type": "SEXS",
+        "bus": 101,
+        "device_id": "1",
+        "enabled": True,
+    }
+    values.update(overrides)
+    return LimitedStateDescriptor(**values)
+
+
+def _validate(z0, descriptors, **overrides):
+    values = {
+        "enforce_dynamic_limits": True,
+        "dynamic_limit_tolerance": 1e-8,
+        "dynamic_limit_release_tolerance": 1e-10,
+        "max_dynamic_limit_iterations": 20,
+    }
+    values.update(overrides)
+    return validate_initial_dynamic_limits(z0, descriptors, **values)
+
+
+def test_collect_sexs_descriptors_uses_effective_theta_and_external_bus():
+    first = ExcSEXS("A", 0.1, 1.0, 10.0, 0.1, -1.0, 1.0)
+    first.set_pointers(2, 0, 0, 0)
+    first.set_bus(0)
+    second = ExcSEXS("B", 0.1, 1.0, 10.0, 0.1, -2.0, 2.0)
+    second.set_pointers(8, 0, 8, 1)
+    second.set_bus(1)
+    theta = np.zeros(16)
+    theta[4:7] = [-0.5, 0.75, 1.0]
+    theta[12:15] = [-1.5, 1.25, 0.0]
+    psys = SimpleNamespace(
+        devices=[first, second],
+        buses=[SimpleNamespace(id=101), SimpleNamespace(id=205)],
+    )
+
+    descriptors = collect_limited_state_descriptors(psys, theta)
+
+    assert descriptors == [
+        LimitedStateDescriptor(3, -0.5, 0.75, "SEXS", 101, "A", True),
+        LimitedStateDescriptor(9, -1.5, 1.25, "SEXS", 205, "B", False),
+    ]
+    json.dumps([item.to_dict() for item in descriptors], allow_nan=False)
+
+
+def test_sexs_exposes_efd_bounded_state_metadata():
+    metadata = ExcSEXS.bounded_state_metadata
+
+    assert len(metadata) == 1
+    assert metadata[0].state_name == "Efd"
+    assert metadata[0].state_offset == 1
+    assert metadata[0].lower_parameter_offset == 4
+    assert metadata[0].upper_parameter_offset == 5
+    assert metadata[0].enabled_parameter_offset == 6
+    assert metadata[0].device_type == "SEXS"
+
+
+@pytest.mark.parametrize("value", [0.0, 1.0, -5e-9, 1.0 + 5e-9, 0.5])
+def test_initial_dynamic_limit_validation_accepts_bounds_and_tolerance(value):
+    z0 = np.asarray([value])
+    original = z0.copy()
+
+    diagnostics = _validate(z0, [_descriptor()])
+
+    assert diagnostics["initialization"]["valid"] is True
+    assert diagnostics["initialization"]["checked_state_count"] == 1
+    assert diagnostics["initialization"]["violations"] == []
+    np.testing.assert_array_equal(z0, original)
+
+
+@pytest.mark.parametrize(
+    "value, side, reason",
+    [
+        (-2e-8, "lower", "initial_state_below_lower_bound"),
+        (1.0 + 2e-8, "upper", "initial_state_above_upper_bound"),
+    ],
+)
+def test_initial_dynamic_limit_validation_rejects_bound_violations(
+    value, side, reason
+):
+    z0 = np.asarray([value])
+    original = z0.copy()
+
+    with pytest.raises(DynamicLimitError) as exc_info:
+        _validate(z0, [_descriptor()])
+
+    diagnostics = exc_info.value.diagnostics
+    assert diagnostics["initialization"]["failure_reasons"] == [reason]
+    assert diagnostics["initialization"]["violations"][0]["side"] == side
+    assert diagnostics["initialization"]["violations"][0]["state_index"] == 0
+    json.dumps(diagnostics, allow_nan=False)
+    np.testing.assert_array_equal(z0, original)
+
+
+@pytest.mark.parametrize(
+    "descriptor, value, reason",
+    [
+        (_descriptor(lower_bound=-np.inf), 0.5, "non_finite_bounds"),
+        (_descriptor(lower_bound=1.0, upper_bound=1.0), 1.0, "degenerate_bounds"),
+        (_descriptor(lower_bound=2.0, upper_bound=1.0), 1.5, "inverted_bounds"),
+        (_descriptor(), np.nan, "non_finite_initial_state"),
+    ],
+)
+def test_initial_dynamic_limit_validation_rejects_invalid_data(
+    descriptor, value, reason
+):
+    with pytest.raises(DynamicLimitError) as exc_info:
+        _validate(np.asarray([value]), [descriptor])
+
+    diagnostics = exc_info.value.diagnostics
+    assert diagnostics["initialization"]["failure_reasons"] == [reason]
+    json.dumps(diagnostics, allow_nan=False)
+
+
+def test_disabled_global_or_device_limit_skips_initial_check():
+    globally_disabled = _validate(
+        np.asarray([2.0]),
+        [_descriptor()],
+        enforce_dynamic_limits=False,
+    )
+    device_disabled = _validate(
+        np.asarray([2.0]),
+        [_descriptor(enabled=False)],
+    )
+
+    assert globally_disabled["enabled"] is False
+    assert globally_disabled["initialization"]["checked_state_count"] == 0
+    assert device_disabled["enabled_state_count"] == 0
+    assert device_disabled["initialization"]["valid"] is True
+
+    no_states = _validate(np.asarray([]), [])
+    assert no_states["discovered_state_count"] == 0
+    assert no_states["initialization"]["valid"] is True
+
+
+def test_state_projection_clamps_both_sides_without_mutating_inputs():
+    descriptors = [
+        _descriptor(state_index=0, device_id="lower"),
+        _descriptor(state_index=1, device_id="upper"),
+        _descriptor(state_index=2, device_id="disabled", enabled=False),
+    ]
+    state = np.asarray([-0.25, 1.25, 4.0])
+    original = state.copy()
+
+    projected, events = project_limited_states(
+        state,
+        descriptors,
+        time=0.2,
+        stage_or_endpoint="endpoint",
+        active_set_iterations=2,
+    )
+
+    np.testing.assert_array_equal(state, original)
+    np.testing.assert_array_equal(projected, [0.0, 1.0, 4.0])
+    assert [event["side"] for event in events] == ["lower", "upper"]
+    assert all(event["action"] == "project" for event in events)
+    assert events[0]["time"] == pytest.approx(0.2)
+    assert events[0]["stage_or_endpoint"] == "endpoint"
+    assert events[0]["active_set_iterations"] == 2
+    json.dumps(events, allow_nan=False)
+
+
+@pytest.mark.parametrize(
+    "state, raw_derivative, expected, blocked_sides",
+    [
+        ([1.0, 0.0], [2.0, -3.0], [0.0, 0.0], ["upper", "lower"]),
+        ([1.0, 0.0], [-2.0, 3.0], [-2.0, 3.0], []),
+        ([1.0 - 5e-9, 5e-9], [2.0, -3.0], [0.0, 0.0], ["upper", "lower"]),
+    ],
+)
+def test_directional_projection_blocks_outward_and_releases_inward(
+    state, raw_derivative, expected, blocked_sides
+):
+    descriptors = [_descriptor(state_index=0), _descriptor(state_index=1)]
+    raw_derivative = np.asarray(raw_derivative, dtype=float)
+    original = raw_derivative.copy()
+
+    projected, events = project_limited_derivatives(
+        np.asarray(state, dtype=float),
+        raw_derivative,
+        descriptors,
+        tolerance=1e-8,
+    )
+
+    np.testing.assert_array_equal(raw_derivative, original)
+    np.testing.assert_array_equal(projected, expected)
+    assert [event["side"] for event in events] == blocked_sides
+    assert all(
+        event["action"] == "block_outward_derivative" for event in events
+    )
+
+
+def test_disabled_limit_helpers_leave_state_and_derivative_unchanged():
+    descriptor = _descriptor(enabled=False)
+    state = np.asarray([2.0])
+    derivative = np.asarray([3.0])
+
+    projected_state, state_events = project_limited_states(state, [descriptor])
+    projected_derivative, derivative_events = project_limited_derivatives(
+        state,
+        derivative,
+        [descriptor],
+        tolerance=1e-8,
+    )
+
+    np.testing.assert_array_equal(projected_state, state)
+    np.testing.assert_array_equal(projected_derivative, derivative)
+    assert state_events == []
+    assert derivative_events == []
+
+
+@pytest.mark.parametrize(
+    "descriptor, reason",
+    [
+        (_descriptor(upper_bound=np.inf), "non_finite_bounds"),
+        (_descriptor(lower_bound=1.0, upper_bound=1.0), "degenerate_bounds"),
+        (_descriptor(lower_bound=2.0, upper_bound=1.0), "inverted_bounds"),
+    ],
+)
+def test_projection_helpers_reject_invalid_effective_bounds(descriptor, reason):
+    with pytest.raises(DynamicLimitError) as exc_info:
+        project_limited_states(np.asarray([0.5]), [descriptor])
+
+    assert exc_info.value.diagnostics["failure_reasons"] == [reason]
+
+
+def test_active_set_activates_retains_and_releases_multiple_limits():
+    descriptors = [
+        _descriptor(state_index=0, device_id="upper"),
+        _descriptor(state_index=1, device_id="lower"),
+    ]
+    modes = initialize_dynamic_limit_modes(descriptors)
+
+    modes, changed, complementarity, events = update_dynamic_limit_active_set(
+        np.asarray([1.1, -0.1]),
+        np.asarray([0.0, 0.0]),
+        descriptors,
+        modes,
+        state_tolerance=1e-8,
+        release_tolerance=1e-10,
+        time=0.1,
+        stage_or_endpoint="endpoint",
+        active_set_iterations=1,
+    )
+
+    assert changed is True
+    assert complementarity["consistent"] is False
+    assert modes == {
+        0: DynamicLimitMode.UPPER_ACTIVE,
+        1: DynamicLimitMode.LOWER_ACTIVE,
+    }
+    assert [(event["side"], event["action"]) for event in events] == [
+        ("upper", "activate"),
+        ("lower", "activate"),
+    ]
+
+    modes, changed, complementarity, events = update_dynamic_limit_active_set(
+        np.asarray([1.0, 0.0]),
+        np.asarray([-1e-3, 1e-3]),
+        descriptors,
+        modes,
+        state_tolerance=1e-8,
+        release_tolerance=1e-10,
+    )
+
+    assert changed is False
+    assert complementarity["consistent"] is True
+    assert events == []
+
+    modes, changed, complementarity, events = update_dynamic_limit_active_set(
+        np.asarray([1.0, 0.0]),
+        np.asarray([1e-3, -1e-3]),
+        descriptors,
+        modes,
+        state_tolerance=1e-8,
+        release_tolerance=1e-10,
+    )
+
+    assert changed is True
+    assert complementarity["consistent"] is False
+    assert modes == {0: DynamicLimitMode.FREE, 1: DynamicLimitMode.FREE}
+    assert [(event["side"], event["action"]) for event in events] == [
+        ("upper", "release"),
+        ("lower", "release"),
+    ]
+    json.dumps(events, allow_nan=False)
+
+
+def test_active_set_tolerances_do_not_activate_or_release_at_threshold():
+    descriptor = _descriptor()
+    modes = initialize_dynamic_limit_modes([descriptor])
+
+    modes, changed, complementarity, _ = update_dynamic_limit_active_set(
+        np.asarray([1.0 + 1e-8]),
+        np.asarray([0.0]),
+        [descriptor],
+        modes,
+        state_tolerance=1e-8,
+        release_tolerance=1e-10,
+    )
+
+    assert changed is False
+    assert complementarity["consistent"] is True
+
+    modes[0] = DynamicLimitMode.UPPER_ACTIVE
+    modes, changed, complementarity, _ = update_dynamic_limit_active_set(
+        np.asarray([1.0]),
+        np.asarray([1e-10]),
+        [descriptor],
+        modes,
+        state_tolerance=1e-8,
+        release_tolerance=1e-10,
+    )
+
+    assert changed is False
+    assert complementarity["consistent"] is True
+    assert modes[0] == DynamicLimitMode.UPPER_ACTIVE
+
+
+def test_complementarity_rejects_non_finite_free_residual():
+    descriptor = _descriptor()
+    modes = initialize_dynamic_limit_modes([descriptor])
+
+    with pytest.raises(DynamicLimitError) as exc_info:
+        evaluate_dynamic_limit_complementarity(
+            np.asarray([0.5]),
+            np.asarray([np.nan]),
+            [descriptor],
+            modes,
+            state_tolerance=1e-8,
+            release_tolerance=1e-10,
+        )
+
+    assert exc_info.value.diagnostics["failure_reasons"] == [
+        "non_finite_free_residual"
+    ]
+
+
+def _load_enabled_sexs_system(data_dir):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "2bus_33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "2bus_SEXS.dyr"))
+    assert psys.exc[0].enable_limits is True
+    psys.createYbusComplex()
+    return psys
+
+
+def test_native_be_and_herk_return_identical_initial_limit_diagnostics(data_dir):
+    results = []
+    for method in ("beuler", "herk2"):
+        psys = _load_enabled_sexs_system(data_dir)
+        results.append(
+            integrate_system(
+                psys,
+                IntegrationConfig(
+                    method=method,
+                    petsc=False,
+                    steps=1,
+                    dt=0.01,
+                    ton=10.0,
+                    toff=11.0,
+                ),
+            )["dynamic_limit_diagnostics"]
+        )
+
+    assert results[0] == results[1]
+    assert results[0]["enabled_state_count"] == 1
+    assert results[0]["initialization"]["valid"] is True
+    assert results[0]["events"] == []
+
+
+def _invalid_initial_context(psys):
+    pf_solution = runpf(psys, verbose=False)
+    z0, theta = initialize_system(psys, pf_solution)
+    exciter = psys.exc[0]
+    state_index = exciter.dif_ptr + exciter.efd_idx
+    par_ptr = exciter.par_ptr
+    theta[par_ptr + 4] = z0[state_index] - 1.0
+    theta[par_ptr + 5] = z0[state_index] - 0.1
+    theta[par_ptr + 6] = 1.0
+    ctx = IntegrationCtx()
+    ctx.set_initial_conditions(z0.copy())
+    ctx.set_theta(theta)
+    return ctx, state_index, z0[state_index]
+
+
+def test_invalid_context_fails_before_petsc_setup_or_schedule(data_dir, monkeypatch):
+    from uqgrid.simulation import dynamics
+
+    psys = _load_enabled_sexs_system(data_dir)
+    ctx, state_index, initial_value = _invalid_initial_context(psys)
+    monkeypatch.setattr(
+        dynamics,
+        "_get_petsc_for_config",
+        lambda config: pytest.fail("PETSc setup must not run"),
+    )
+    monkeypatch.setattr(
+        dynamics,
+        "build_integration_schedule",
+        lambda **kwargs: pytest.fail("schedule must not be built"),
+    )
+
+    with pytest.raises(DynamicLimitError) as exc_info:
+        integrate_system(
+            psys,
+            IntegrationConfig(petsc=True, method="cn", steps=1),
+            ctx,
+        )
+
+    violation = exc_info.value.diagnostics["initialization"]["violations"][0]
+    assert violation["state_index"] == state_index
+    assert violation["initial_value"] == pytest.approx(initial_value)
+    assert ctx.z0_user[state_index] == pytest.approx(initial_value)
+
+
+def test_invalid_context_fails_before_native_allocation_or_schedule(
+    data_dir, monkeypatch
+):
+    from uqgrid.simulation import dynamics
+
+    psys = _load_enabled_sexs_system(data_dir)
+    ctx, _, _ = _invalid_initial_context(psys)
+    monkeypatch.setattr(
+        dynamics,
+        "preallocate_jacobian",
+        lambda psys: pytest.fail("Jacobian allocation must not run"),
+    )
+    monkeypatch.setattr(
+        dynamics,
+        "build_integration_schedule",
+        lambda **kwargs: pytest.fail("schedule must not be built"),
+    )
+
+    with pytest.raises(DynamicLimitError):
+        integrate_system(
+            psys,
+            IntegrationConfig(petsc=False, method="beuler", steps=1),
+            ctx,
+        )
+
+
+def test_invalid_context_fails_before_herk_allocation_or_schedule(
+    data_dir, monkeypatch
+):
+    from uqgrid.simulation import dynamics, herk
+
+    psys = _load_enabled_sexs_system(data_dir)
+    ctx, _, _ = _invalid_initial_context(psys)
+    monkeypatch.setattr(
+        dynamics,
+        "preallocate_jacobian",
+        lambda psys: pytest.fail("Jacobian allocation must not run"),
+    )
+    monkeypatch.setattr(
+        herk,
+        "build_integration_schedule",
+        lambda **kwargs: pytest.fail("schedule must not be built"),
+    )
+
+    with pytest.raises(DynamicLimitError):
+        integrate_system(
+            psys,
+            IntegrationConfig(petsc=False, method="herk2", steps=1),
+            ctx,
+        )

--- a/tests/test_generate_scenarios_operating_point.py
+++ b/tests/test_generate_scenarios_operating_point.py
@@ -56,6 +56,10 @@ def test_integration_config_adapter_preserves_q_limit_controls(gs):
         "enforce_q_limits": True,
         "q_limit_tolerance": 2e-7,
         "max_q_limit_iterations": 11,
+        "enforce_dynamic_limits": True,
+        "dynamic_limit_tolerance": 3e-7,
+        "dynamic_limit_release_tolerance": 4e-9,
+        "max_dynamic_limit_iterations": 17,
         "power_flow_validation": {
             "enabled": True,
             "voltage_min": 0.9,
@@ -69,6 +73,10 @@ def test_integration_config_adapter_preserves_q_limit_controls(gs):
     assert cfg.enforce_q_limits is True
     assert cfg.q_limit_tolerance == pytest.approx(2e-7)
     assert cfg.max_q_limit_iterations == 11
+    assert cfg.enforce_dynamic_limits is True
+    assert cfg.dynamic_limit_tolerance == pytest.approx(3e-7)
+    assert cfg.dynamic_limit_release_tolerance == pytest.approx(4e-9)
+    assert cfg.max_dynamic_limit_iterations == 17
     assert cfg.power_flow_validation.enabled is True
     assert cfg.power_flow_validation.voltage_min == pytest.approx(0.9)
     assert cfg.power_flow_validation.voltage_max == pytest.approx(1.1)
@@ -82,6 +90,10 @@ def test_default_scenario_config_includes_q_limit_controls(gs):
     assert integration["enforce_q_limits"] is True
     assert integration["q_limit_tolerance"] == pytest.approx(1e-8)
     assert integration["max_q_limit_iterations"] is None
+    assert integration["enforce_dynamic_limits"] is True
+    assert integration["dynamic_limit_tolerance"] == pytest.approx(1e-8)
+    assert integration["dynamic_limit_release_tolerance"] == pytest.approx(1e-10)
+    assert integration["max_dynamic_limit_iterations"] == 20
     validation = integration["power_flow_validation"]
     assert validation["enabled"] is False
     assert validation["residual_tolerance"] == pytest.approx(1e-8)
@@ -93,6 +105,7 @@ def test_default_scenario_config_includes_q_limit_controls(gs):
     adapted = gs._integration_config_from_dict({})
     assert adapted.method == "beuler"
     assert adapted.enforce_q_limits is True
+    assert adapted.enforce_dynamic_limits is True
     assert adapted.power_flow_validation.enabled is False
 
     legacy = gs._integration_config_from_dict({"enforce_q_limits": False})
@@ -144,6 +157,7 @@ def test_fault_worker_preserves_successful_pf_validation(
         gs, tmp_path, monkeypatch):
     scenario, operating_point = _fault_worker_inputs()
     validation = {"valid": True, "failure_reasons": []}
+    dynamic_limits = {"enabled": True, "initialization": {"valid": True}}
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(gs, "_load_power_system", lambda *args: _fake_fault_psys())
     monkeypatch.setattr(
@@ -153,6 +167,7 @@ def test_fault_worker_preserves_successful_pf_validation(
             "history": np.zeros((2, 2)),
             "tvec": np.array([0.0, 0.1]),
             "power_flow_diagnostics": validation,
+            "dynamic_limit_diagnostics": dynamic_limits,
         },
     )
 
@@ -167,6 +182,7 @@ def test_fault_worker_preserves_successful_pf_validation(
 
     assert result["diverged"] is False
     assert result["diagnostics"]["power_flow_validation"] == validation
+    assert result["diagnostics"]["dynamic_limit_diagnostics"] == dynamic_limits
 
 
 def test_fault_worker_preserves_failed_pf_validation(
@@ -193,6 +209,75 @@ def test_fault_worker_preserves_failed_pf_validation(
     assert result["diverged"] is True
     assert result["diagnostics"]["reject_reason"] == "power_flow_validation_failed"
     assert result["diagnostics"]["power_flow_validation"] == validation
+
+
+def test_fault_worker_preserves_failed_dynamic_limit_validation(
+        gs, tmp_path, monkeypatch):
+    scenario, operating_point = _fault_worker_inputs()
+    diagnostics = {
+        "enabled": True,
+        "initialization": {
+            "valid": False,
+            "failure_reasons": ["initial_state_above_upper_bound"],
+        },
+    }
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(gs, "_load_power_system", lambda *args: _fake_fault_psys())
+
+    def fail_validation(*args):
+        raise gs.DynamicLimitError(diagnostics)
+
+    monkeypatch.setattr(gs, "integrate_system", fail_validation)
+
+    result = gs._run_fault_with_operating_point_worker(
+        "case.raw",
+        "case.dyr",
+        scenario,
+        "scenario-0",
+        operating_point,
+        {"enforce_dynamic_limits": True},
+    )
+
+    assert result["diverged"] is True
+    assert (
+        result["diagnostics"]["reject_reason"]
+        == "dynamic_limit_initialization_failed"
+    )
+    assert result["diagnostics"]["dynamic_limit_diagnostics"] == diagnostics
+
+
+def test_fault_worker_classifies_dynamic_limit_runtime_failure(
+        gs, tmp_path, monkeypatch):
+    scenario, operating_point = _fault_worker_inputs()
+    diagnostics = {
+        "enabled": True,
+        "phase": "runtime",
+        "method": "beuler",
+        "failure_reasons": ["active_set_cycle"],
+        "events": [],
+    }
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(gs, "_load_power_system", lambda *args: _fake_fault_psys())
+
+    def fail_runtime(*args):
+        raise gs.DynamicLimitError(diagnostics)
+
+    monkeypatch.setattr(gs, "integrate_system", fail_runtime)
+
+    result = gs._run_fault_with_operating_point_worker(
+        "case.raw",
+        "case.dyr",
+        scenario,
+        "scenario-0",
+        operating_point,
+        {"enforce_dynamic_limits": True},
+    )
+
+    assert result["diverged"] is True
+    assert result["diagnostics"]["reject_reason"] == (
+        "dynamic_limit_runtime_failed"
+    )
+    assert result["diagnostics"]["dynamic_limit_diagnostics"] == diagnostics
 
 
 def test_stress_load_preserves_load_power_factor_with_no_noise(gs):

--- a/tests/test_herk_dynamic_limits.py
+++ b/tests/test_herk_dynamic_limits.py
@@ -1,0 +1,585 @@
+import json
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from uqgrid.io.parse import add_dyr, load_psse
+from uqgrid.simulation import herk
+from uqgrid.simulation.config import IntegrationConfig, IntegrationCtx
+from uqgrid.simulation.dynamic_limits import (
+    DynamicLimitError,
+    DynamicLimitMode,
+    LimitedStateDescriptor,
+    collect_limited_state_descriptors,
+    initialize_dynamic_limit_modes,
+)
+from uqgrid.simulation.dynamics import (
+    initialize_system,
+    integrate_system,
+    preallocate_jacobian,
+)
+from uqgrid.simulation.pflow import runpf
+from uqgrid.simulation.residual import residual_function
+
+
+@pytest.fixture
+def data_dir():
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data"
+    )
+
+
+def _build_two_bus_sexs(data_dir, *, fault=False):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "2bus_33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "2bus_SEXS.dyr"))
+    psys.createYbusComplex()
+    psys.power_injection = False
+    if fault:
+        psys.add_busfault(1, 1e-4)
+    return psys
+
+
+def _initialize_context(psys):
+    pf_solution = runpf(psys, verbose=False)
+    z0, theta = initialize_system(psys, pf_solution)
+    ctx = IntegrationCtx()
+    ctx.set_initial_conditions(z0.copy())
+    ctx.set_theta(theta.copy())
+    return z0, theta, ctx
+
+
+def _set_sexs_limits(theta, exciter, lower, upper, *, vref_offset=0.0):
+    par_ptr = exciter.par_ptr
+    theta[par_ptr + 4] = lower
+    theta[par_ptr + 5] = upper
+    theta[par_ptr + 6] = 1.0
+    theta[par_ptr + 7] += vref_offset
+
+
+def _biased_two_bus_context(data_dir, side, *, width=0.01):
+    psys = _build_two_bus_sexs(data_dir)
+    z0, theta, ctx = _initialize_context(psys)
+    exciter = psys.exc[0]
+    state_index = exciter.dif_ptr + exciter.efd_idx
+    initial_efd = float(z0[state_index])
+    _set_sexs_limits(
+        theta,
+        exciter,
+        initial_efd - width,
+        initial_efd + width,
+        vref_offset=0.05 if side == "upper" else -0.05,
+    )
+    ctx.set_theta(theta.copy())
+    return psys, ctx, state_index, initial_efd - width, initial_efd + width
+
+
+@pytest.mark.parametrize("method", ["herk2", "herk4"])
+@pytest.mark.parametrize("side", ["upper", "lower"])
+def test_herk_crossings_project_and_block_without_stored_overshoot(
+    data_dir, method, side
+):
+    psys, ctx, state_index, lower, upper = _biased_two_bus_context(
+        data_dir, side
+    )
+    config = IntegrationConfig(
+        method=method,
+        petsc=False,
+        steps=4,
+        dt=0.005,
+        ton=10.0,
+        toff=11.0,
+    )
+
+    result = integrate_system(psys, config, ctx)
+
+    efd = result["history"][state_index]
+    assert np.min(efd) >= lower - 1e-12
+    assert np.max(efd) <= upper + 1e-12
+    expected_bound = upper if side == "upper" else lower
+    assert np.any(np.isclose(efd, expected_bound, atol=1e-12))
+    events = result["dynamic_limit_diagnostics"]["events"]
+    assert any(
+        event["action"] == "project" and event["side"] == side
+        for event in events
+    )
+    assert any(
+        event["action"] == "activate" and event["side"] == side
+        for event in events
+    )
+    assert not any(
+        event["action"] == "block_outward_derivative" for event in events
+    )
+    assert all(event["time"] is not None for event in events)
+    assert all(event["stage_or_endpoint"] is not None for event in events)
+    json.dumps(events, allow_nan=False)
+
+
+@pytest.mark.parametrize("method", ["herk2", "herk4"])
+@pytest.mark.parametrize("side", ["upper", "lower"])
+def test_herk_releases_immediately_for_inward_derivative(
+    data_dir, method, side
+):
+    psys = _build_two_bus_sexs(data_dir)
+    z0, theta, _ = _initialize_context(psys)
+    exciter = psys.exc[0]
+    state_index = exciter.dif_ptr + exciter.efd_idx
+    par_ptr = exciter.par_ptr
+    initial_efd = float(z0[state_index])
+    base_vref = float(theta[par_ptr + 7])
+    if side == "upper":
+        _set_sexs_limits(
+            theta,
+            exciter,
+            initial_efd - 0.1,
+            initial_efd,
+            vref_offset=0.05,
+        )
+    else:
+        _set_sexs_limits(
+            theta,
+            exciter,
+            initial_efd,
+            initial_efd + 0.1,
+            vref_offset=-0.05,
+        )
+
+    descriptors = collect_limited_state_descriptors(psys, theta)
+    modes = initialize_dynamic_limit_modes(descriptors)
+    F = np.zeros_like(z0)
+    J = preallocate_jacobian(psys)
+    A, b, c = herk.TABLEAUS[method]
+
+    z_bound, modes, activation_events = herk._herk_step_with_limits(
+        z0,
+        theta,
+        0.005,
+        psys,
+        A,
+        b,
+        c,
+        F,
+        J,
+        1e-10,
+        50,
+        limit_descriptors=descriptors,
+        limit_tolerance=1e-8,
+        limit_modes=modes,
+        t_start=0.0,
+    )
+    theta[par_ptr + 7] = (
+        base_vref - 0.05 if side == "upper" else base_vref + 0.05
+    )
+    z_released, modes, release_events = herk._herk_step_with_limits(
+        z_bound,
+        theta,
+        0.005,
+        psys,
+        A,
+        b,
+        c,
+        F,
+        J,
+        1e-10,
+        50,
+        limit_descriptors=descriptors,
+        limit_tolerance=1e-8,
+        limit_modes=modes,
+        t_start=0.005,
+    )
+
+    assert z_bound[state_index] == pytest.approx(initial_efd)
+    if side == "upper":
+        assert z_released[state_index] < initial_efd
+    else:
+        assert z_released[state_index] > initial_efd
+    assert any(
+        event["action"] == "activate" and event["side"] == side
+        for event in activation_events
+    )
+    assert any(
+        event["action"] == "release" and event["side"] == side
+        for event in release_events
+    )
+    assert modes[state_index] == DynamicLimitMode.FREE
+
+
+@pytest.mark.parametrize(
+    "method, raw_derivatives, expected_endpoint",
+    [
+        ("herk2", [2.0, -1.0, 0.0], 0.5),
+        ("herk4", [4.0, -2.0, 0.0, 0.0, 0.0], 0.0),
+    ],
+)
+def test_projected_predictor_does_not_pin_weighted_endpoint(
+    monkeypatch, method, raw_derivatives, expected_endpoint
+):
+    calls = iter(raw_derivatives)
+
+    def fake_residual(F, z, theta, psys):
+        F.fill(0.0)
+        F[0] = next(calls)
+
+    def fake_algebraic(X_i, y0, v0, *args, **kwargs):
+        return np.asarray([]), np.asarray([]), 0
+
+    monkeypatch.setattr(herk, "residual_function", fake_residual)
+    monkeypatch.setattr(herk, "solve_stage_algebraic", fake_algebraic)
+    descriptor = LimitedStateDescriptor(
+        state_index=0,
+        lower_bound=-10.0,
+        upper_bound=1.0,
+        device_type="SEXS",
+        bus=1,
+        device_id="1",
+        enabled=True,
+    )
+    modes = initialize_dynamic_limit_modes([descriptor])
+    psys = SimpleNamespace(num_dof_dif=1, num_dof_alg=0)
+    A, b, c = herk.TABLEAUS[method]
+
+    endpoint, modes, events = herk._herk_step_with_limits(
+        np.asarray([0.0]),
+        np.asarray([]),
+        1.0,
+        psys,
+        A,
+        b,
+        c,
+        np.zeros(1),
+        None,
+        1e-10,
+        5,
+        limit_descriptors=[descriptor],
+        limit_tolerance=1e-8,
+        limit_modes=modes,
+        t_start=0.0,
+    )
+
+    assert endpoint[0] == pytest.approx(expected_endpoint)
+    assert endpoint[0] < descriptor.upper_bound
+    assert modes[0] == DynamicLimitMode.FREE
+    assert any(
+        event["action"] == "project"
+        and event["stage_or_endpoint"].startswith("stage_")
+        for event in events
+    )
+    assert not any(
+        event["action"] == "project"
+        and event["stage_or_endpoint"] == "endpoint"
+        for event in events
+    )
+
+
+@pytest.mark.parametrize("method", ["herk2", "herk4"])
+def test_multiple_sexs_limits_are_enforced_together(data_dir, method):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "ieee9_v33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "ieee9bus_SEXS.dyr"))
+    psys.createYbusComplex()
+    psys.power_injection = False
+    z0, theta, ctx = _initialize_context(psys)
+    state_indices = []
+    bounds = []
+    expected_buses = set()
+    for index, exciter in enumerate(psys.exc):
+        state_index = exciter.dif_ptr + exciter.efd_idx
+        initial_efd = float(z0[state_index])
+        _set_sexs_limits(
+            theta,
+            exciter,
+            initial_efd - 0.01,
+            initial_efd + 0.01,
+            vref_offset=0.05 if index % 2 == 0 else -0.05,
+        )
+        state_indices.append(state_index)
+        bounds.append((initial_efd - 0.01, initial_efd + 0.01))
+        expected_buses.add(psys.buses[exciter.bus].id)
+    ctx.set_theta(theta.copy())
+
+    result = integrate_system(
+        psys,
+        IntegrationConfig(
+            method=method,
+            petsc=False,
+            steps=4,
+            dt=0.005,
+            ton=10.0,
+            toff=11.0,
+        ),
+        ctx,
+    )
+
+    for state_index, (lower, upper) in zip(state_indices, bounds):
+        values = result["history"][state_index]
+        assert np.min(values) >= lower - 1e-12
+        assert np.max(values) <= upper + 1e-12
+    activation_buses = {
+        event["bus"]
+        for event in result["dynamic_limit_diagnostics"]["events"]
+        if event["action"] == "activate"
+    }
+    assert activation_buses == expected_buses
+
+
+@pytest.mark.parametrize("method", ["herk2", "herk4"])
+def test_projected_stages_and_endpoint_remain_algebraically_consistent(
+    data_dir, method, monkeypatch
+):
+    psys, ctx, state_index, lower, upper = _biased_two_bus_context(
+        data_dir, "upper"
+    )
+    original_solve = herk.solve_stage_algebraic
+    algebraic_norms = []
+    stage_values = []
+
+    def recording_solve(X_i, y0, v0, theta, psys, F, J, tol, max_iter):
+        y, v, iterations = original_solve(
+            X_i, y0, v0, theta, psys, F, J, tol, max_iter
+        )
+        check = np.concatenate([X_i, y, v])
+        residual = np.zeros_like(check)
+        residual_function(residual, check, theta, psys)
+        algebraic_norms.append(
+            np.linalg.norm(residual[psys.num_dof_dif:], np.inf)
+        )
+        stage_values.append(float(X_i[state_index]))
+        return y, v, iterations
+
+    monkeypatch.setattr(herk, "solve_stage_algebraic", recording_solve)
+    result = integrate_system(
+        psys,
+        IntegrationConfig(
+            method=method,
+            petsc=False,
+            steps=1,
+            dt=0.005,
+            ton=10.0,
+            toff=11.0,
+        ),
+        ctx,
+    )
+
+    assert len(algebraic_norms) == len(herk.TABLEAUS[method][1]) + 1
+    assert max(algebraic_norms) < 1e-8
+    assert min(stage_values) >= lower - 1e-12
+    assert max(stage_values) <= upper + 1e-12
+    assert lower - 1e-12 <= result["history"][state_index, -1] <= upper + 1e-12
+
+
+@pytest.mark.parametrize("method", ["herk2", "herk4"])
+def test_sexs_no_fault_trajectory_stays_flat_without_limit_events(
+    data_dir, method
+):
+    psys = _build_two_bus_sexs(data_dir)
+    result = integrate_system(
+        psys,
+        IntegrationConfig(
+            method=method,
+            petsc=False,
+            steps=50,
+            dt=0.001,
+            ton=10.0,
+            toff=11.0,
+        ),
+    )
+
+    differential = result["history"][:psys.num_dof_dif]
+    assert np.max(np.abs(differential - differential[:, [0]])) < 1e-8
+    assert result["dynamic_limit_diagnostics"]["events"] == []
+
+
+@pytest.mark.parametrize("method", ["herk2", "herk4"])
+def test_faulted_sexs_trajectory_is_limited_and_post_switch_consistent(
+    data_dir, method
+):
+    psys = _build_two_bus_sexs(data_dir, fault=True)
+    z0, theta, ctx = _initialize_context(psys)
+    exciter = psys.exc[0]
+    state_index = exciter.dif_ptr + exciter.efd_idx
+    initial_efd = float(z0[state_index])
+    lower = initial_efd - 0.001
+    upper = initial_efd + 0.001
+    _set_sexs_limits(theta, exciter, lower, upper)
+    ctx.set_theta(theta.copy())
+    result = integrate_system(
+        psys,
+        IntegrationConfig(
+            method=method,
+            petsc=False,
+            steps=8,
+            dt=0.005,
+            ton=0.01,
+            toff=0.02,
+        ),
+        ctx,
+    )
+
+    efd = result["history"][state_index]
+    assert np.min(efd) >= lower - 1e-12
+    assert np.max(efd) <= upper + 1e-12
+    assert any(
+        event["action"] == "activate"
+        for event in result["dynamic_limit_diagnostics"]["events"]
+    )
+    fault = psys.fault_events[0]
+    residual = np.zeros(result["history"].shape[0])
+    fault.apply()
+    on_index = int(np.flatnonzero(np.isclose(result["tvec"], 0.01))[0])
+    residual_function(residual, result["history"][:, on_index], theta, psys)
+    assert np.linalg.norm(residual[psys.num_dof_dif:], np.inf) < 1e-8
+    fault.remove()
+    off_index = int(np.flatnonzero(np.isclose(result["tvec"], 0.02))[0])
+    residual_function(residual, result["history"][:, off_index], theta, psys)
+    assert np.linalg.norm(residual[psys.num_dof_dif:], np.inf) < 1e-8
+    assert fault.active is False
+
+
+def _limited_final_differential(data_dir, method, dt):
+    psys, ctx, _, _, _ = _biased_two_bus_context(data_dir, "upper")
+    result = integrate_system(
+        psys,
+        IntegrationConfig(
+            method=method,
+            petsc=False,
+            tend=0.05,
+            steps=-1,
+            dt=dt,
+            ton=10.0,
+            toff=11.0,
+        ),
+        ctx,
+    )
+    return result["history"][:psys.num_dof_dif, -1]
+
+
+@pytest.mark.parametrize("method", ["herk2", "herk4"])
+def test_limited_herk_trajectory_converges_as_dt_decreases(data_dir, method):
+    reference = _limited_final_differential(data_dir, method, 0.0003125)
+    coarse = _limited_final_differential(data_dir, method, 0.01)
+    fine = _limited_final_differential(data_dir, method, 0.005)
+
+    coarse_error = np.linalg.norm(coarse - reference, np.inf)
+    fine_error = np.linalg.norm(fine - reference, np.inf)
+    assert coarse_error > 0.0
+    assert fine_error < coarse_error
+
+
+def test_herk_helper_failure_has_runtime_stage_context(data_dir, monkeypatch):
+    psys = _build_two_bus_sexs(data_dir)
+    _, _, ctx = _initialize_context(psys)
+    state_index = psys.exc[0].dif_ptr + psys.exc[0].efd_idx
+    original_residual = herk.residual_function
+
+    def non_finite_efd_derivative(F, z, theta, psys):
+        original_residual(F, z, theta, psys)
+        F[state_index] = np.nan
+
+    monkeypatch.setattr(herk, "residual_function", non_finite_efd_derivative)
+
+    with pytest.raises(DynamicLimitError) as exc_info:
+        integrate_system(
+            psys,
+            IntegrationConfig(
+                method="herk2",
+                petsc=False,
+                steps=1,
+                dt=0.005,
+                ton=10.0,
+                toff=11.0,
+            ),
+            ctx,
+        )
+
+    diagnostics = exc_info.value.diagnostics
+    assert diagnostics["phase"] == "runtime"
+    assert diagnostics["method"] == "herk2"
+    assert diagnostics["backend"] == "native"
+    assert diagnostics["operation"] == "derivative_projection"
+    assert diagnostics["failure_reasons"] == ["non_finite_derivative"]
+    assert diagnostics["time"] == pytest.approx(0.0)
+    assert diagnostics["stage_or_endpoint"] == "stage_1"
+    json.dumps(diagnostics, allow_nan=False)
+
+
+def test_herk_failure_after_fault_application_restores_fault(
+    data_dir, monkeypatch
+):
+    psys = _build_two_bus_sexs(data_dir, fault=True)
+    z0, theta, ctx = _initialize_context(psys)
+    exciter = psys.exc[0]
+    state_index = exciter.dif_ptr + exciter.efd_idx
+    initial_efd = float(z0[state_index])
+    _set_sexs_limits(
+        theta,
+        exciter,
+        initial_efd - 0.01,
+        initial_efd + 0.01,
+        vref_offset=0.05,
+    )
+    ctx.set_theta(theta.copy())
+    original_step = herk._herk_step_with_limits
+    calls = 0
+
+    def fail_second_interval(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise DynamicLimitError(
+                {
+                    "message": "forced HERK limiter failure",
+                    "operation": "derivative_projection",
+                    "failure_reasons": ["non_finite_derivative"],
+                    "events": [],
+                }
+            )
+        return original_step(*args, **kwargs)
+
+    monkeypatch.setattr(herk, "_herk_step_with_limits", fail_second_interval)
+
+    with pytest.raises(DynamicLimitError) as exc_info:
+        integrate_system(
+            psys,
+            IntegrationConfig(
+                method="herk2",
+                petsc=False,
+                steps=2,
+                dt=0.005,
+                ton=0.005,
+                toff=0.02,
+            ),
+            ctx,
+        )
+
+    assert calls == 2
+    assert exc_info.value.diagnostics["phase"] == "runtime"
+    assert exc_info.value.diagnostics["events"]
+    assert psys.fault_events[0].active is False
+
+
+@pytest.mark.parametrize("method", ["herk2", "herk4"])
+def test_disabled_dynamic_limits_skip_herk_projection(
+    data_dir, method, monkeypatch
+):
+    psys = _build_two_bus_sexs(data_dir)
+    monkeypatch.setattr(
+        herk,
+        "project_limited_states",
+        lambda *args, **kwargs: pytest.fail("projection must remain disabled"),
+    )
+
+    result = integrate_system(
+        psys,
+        IntegrationConfig(
+            method=method,
+            petsc=False,
+            steps=1,
+            dt=0.001,
+            ton=10.0,
+            toff=11.0,
+            enforce_dynamic_limits=False,
+        ),
+    )
+
+    assert result["dynamic_limit_diagnostics"]["enabled"] is False
+    assert result["dynamic_limit_diagnostics"]["events"] == []

--- a/tests/test_integration_config.py
+++ b/tests/test_integration_config.py
@@ -9,6 +9,7 @@ def test_integration_config_accepts_slow_partition():
     cfg = IntegrationConfig(
         petsc=True,
         arkimex=True,
+        enforce_dynamic_limits=False,
         arkimex_slow_differential=[0, 2, 4],
     )
     assert cfg.arkimex_slow_differential == [0, 2, 4]
@@ -19,6 +20,7 @@ def test_integration_config_accepts_fast_partition():
     cfg = IntegrationConfig(
         petsc=True,
         arkimex=True,
+        enforce_dynamic_limits=False,
         arkimex_fast_differential=[1, 3],
     )
     assert cfg.arkimex_fast_differential == [1, 3]
@@ -30,6 +32,7 @@ def test_integration_config_rejects_both_fast_and_slow_lists():
         IntegrationConfig(
             petsc=True,
             arkimex=True,
+            enforce_dynamic_limits=False,
             arkimex_fast_differential=[1, 3],
             arkimex_slow_differential=[0, 2],
         )
@@ -57,11 +60,25 @@ def test_integration_config_q_limit_defaults():
         ({"method": "bogus"}, "method"),
         ({"method": "cn"}, "requires `petsc=True`"),
         ({"method": "herk2", "petsc": True}, "requires `petsc=False`"),
-        ({"comp_sens": True, "petsc": True}, "method='cn'"),
-        ({"comp_sens": True, "petsc": False}, "petsc=True"),
-        ({"arkimex": True}, "requires `petsc=True`"),
         (
-            {"arkimex": True, "petsc": True, "method": "cn"},
+            {"comp_sens": True, "petsc": True, "enforce_dynamic_limits": False},
+            "method='cn'",
+        ),
+        (
+            {"comp_sens": True, "petsc": False, "enforce_dynamic_limits": False},
+            "petsc=True",
+        ),
+        (
+            {"arkimex": True, "enforce_dynamic_limits": False},
+            "requires `petsc=True`",
+        ),
+        (
+            {
+                "arkimex": True,
+                "petsc": True,
+                "method": "cn",
+                "enforce_dynamic_limits": False,
+            },
             "cannot be combined",
         ),
         (
@@ -83,8 +100,47 @@ def test_integration_config_accepts_explicit_petsc_methods():
     assert IntegrationConfig(petsc=True, method="beuler").method == "beuler"
     assert IntegrationConfig(petsc=True, method="cn").method == "cn"
     assert IntegrationConfig(
-        petsc=True, method="cn", comp_sens=True
+        petsc=True,
+        method="cn",
+        comp_sens=True,
+        enforce_dynamic_limits=False,
     ).comp_sens is True
+
+
+def test_integration_config_dynamic_limit_defaults_and_opt_out():
+    cfg = IntegrationConfig()
+
+    assert cfg.enforce_dynamic_limits is True
+    assert cfg.dynamic_limit_tolerance == pytest.approx(1e-8)
+    assert cfg.dynamic_limit_release_tolerance == pytest.approx(1e-10)
+    assert cfg.max_dynamic_limit_iterations == 20
+    assert IntegrationConfig(
+        enforce_dynamic_limits=False,
+        fsolve=True,
+    ).fsolve is True
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"dynamic_limit_tolerance": -1e-8},
+        {"dynamic_limit_release_tolerance": -1e-10},
+        {"max_dynamic_limit_iterations": 0},
+        {"max_dynamic_limit_iterations": -1},
+    ],
+)
+def test_integration_config_rejects_invalid_dynamic_limit_controls(kwargs):
+    with pytest.raises(ValueError):
+        IntegrationConfig(**kwargs)
+
+
+@pytest.mark.parametrize("option", ["arkimex", "comp_sens", "fsolve"])
+def test_dynamic_limits_reject_unsupported_legacy_paths(option):
+    with pytest.raises(
+        ValueError,
+        match=rf"`{option}=True`.*`enforce_dynamic_limits=False`",
+    ):
+        IntegrationConfig(**{option: True})
 
 
 def test_petsc_method_mapping_is_explicit():

--- a/tests/test_petsc_beuler_dynamic_limits.py
+++ b/tests/test_petsc_beuler_dynamic_limits.py
@@ -1,0 +1,542 @@
+import json
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from scipy.sparse import csr_matrix
+
+from uqgrid.io.parse import add_dyr, load_psse
+from uqgrid.simulation import dynamics
+from uqgrid.simulation.config import IntegrationConfig, IntegrationCtx
+from uqgrid.simulation.dynamic_limits import (
+    DynamicLimitError,
+    DynamicLimitMode,
+    collect_limited_state_descriptors,
+    initialize_dynamic_limit_modes,
+)
+from uqgrid.simulation.dynamics import (
+    initialize_system,
+    integrate_system,
+    preallocate_jacobian,
+)
+from uqgrid.simulation.jacobian import residual_jacobian
+from uqgrid.simulation.pflow import runpf
+from uqgrid.simulation.residual import residual_function
+
+
+@pytest.fixture
+def data_dir():
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data"
+    )
+
+
+class _FakeVector:
+    def __init__(self, values):
+        self.values = np.asarray(values, dtype=float).copy()
+
+    def __getitem__(self, key):
+        return self.values[key]
+
+    def setArray(self, values):
+        self.values = np.asarray(values, dtype=float).copy()
+
+    def assemble(self):
+        return None
+
+
+class _FakeMatrix:
+    def __init__(self):
+        self.value = None
+
+    def setValuesCSR(self, indptr, indices, data):
+        self.value = csr_matrix(
+            (np.array(data, copy=True), np.array(indices, copy=True),
+             np.array(indptr, copy=True))
+        )
+
+    def assemble(self):
+        return None
+
+
+def _build_two_bus(data_dir, *, fault=False):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "2bus_33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "2bus_SEXS.dyr"))
+    if fault:
+        psys.add_busfault(1, 1e-4)
+    psys.createYbusComplex()
+    psys.power_injection = False
+    return psys
+
+
+def _initialize_context(psys):
+    solution = runpf(psys, verbose=False)
+    z0, theta = initialize_system(psys, solution)
+    ctx = IntegrationCtx()
+    ctx.set_initial_conditions(z0.copy())
+    ctx.set_theta(theta.copy())
+    return z0, theta, ctx
+
+
+def _set_limits(theta, exciter, lower, upper, *, vref_offset=0.0):
+    ptr = exciter.par_ptr
+    theta[ptr + 4] = lower
+    theta[ptr + 5] = upper
+    theta[ptr + 6] = 1.0
+    theta[ptr + 7] += vref_offset
+
+
+def _biased_two_bus(data_dir, side, *, petsc, fault=False, width=0.01):
+    psys = _build_two_bus(data_dir, fault=fault)
+    z0, theta, ctx = _initialize_context(psys)
+    exciter = psys.exc[0]
+    state_index = exciter.dif_ptr + exciter.efd_idx
+    initial = float(z0[state_index])
+    lower = initial - width
+    upper = initial + width
+    _set_limits(
+        theta,
+        exciter,
+        lower,
+        upper,
+        vref_offset=0.05 if side == "upper" else -0.05,
+    )
+    ctx.set_theta(theta.copy())
+    config = IntegrationConfig(
+        method="beuler",
+        petsc=petsc,
+        steps=4,
+        dt=0.005,
+        ton=10.0,
+        toff=11.0,
+        newton_tol=1e-10,
+        newton_max_iter=100,
+    )
+    return psys, ctx, config, state_index, lower, upper
+
+
+def _event_identity(event):
+    return (
+        event["state_index"],
+        event["bus"],
+        event["device_id"],
+        event["side"],
+        event["action"],
+        event["time"],
+        event["stage_or_endpoint"],
+        event["active_set_iterations"],
+    )
+
+
+def test_petsc_callbacks_match_native_be_rows_for_multiple_active_limits(
+    data_dir,
+):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "ieee9_v33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "ieee9bus_SEXS.dyr"))
+    psys.createYbusComplex()
+    psys.power_injection = False
+    z0, theta, _ = _initialize_context(psys)
+    descriptors = collect_limited_state_descriptors(psys, theta)
+    assert len(descriptors) >= 2
+    modes = initialize_dynamic_limit_modes(descriptors)
+    modes[descriptors[0].state_index] = DynamicLimitMode.UPPER_ACTIVE
+    modes[descriptors[1].state_index] = DynamicLimitMode.LOWER_ACTIVE
+    endpoint = z0.copy()
+    endpoint[descriptors[0].state_index] = descriptors[0].upper_bound
+    endpoint[descriptors[1].state_index] = descriptors[1].lower_bound
+    h = 0.005
+
+    ordinary_residual = np.zeros_like(endpoint)
+    dynamics._assemble_beuler_residual(
+        ordinary_residual, endpoint, z0, h, psys, theta
+    )
+    ordinary_jacobian = preallocate_jacobian(psys)
+    residual_jacobian(ordinary_jacobian, endpoint, theta, psys)
+    dynamics.jacobian_beuler(ordinary_jacobian, psys.num_dof_dif, h)
+
+    callback_residual = np.zeros_like(endpoint)
+    callback_jacobian = preallocate_jacobian(psys)
+    problem = dynamics._PETScBEActiveSetProblem(
+        psys, theta, callback_residual, callback_jacobian
+    )
+    problem.set_interval(z0, h, descriptors, modes)
+    x = _FakeVector(endpoint)
+    f = _FakeVector(np.zeros_like(endpoint))
+    matrix = _FakeMatrix()
+
+    problem.function(None, x, f)
+    problem.jacobian_function(None, x, matrix, matrix)
+
+    active_indices = {
+        descriptors[0].state_index,
+        descriptors[1].state_index,
+    }
+    for state_index in active_indices:
+        expected = np.zeros(endpoint.size)
+        expected[state_index] = 1.0
+        np.testing.assert_allclose(matrix.value.toarray()[state_index], expected)
+    inactive = [
+        index for index in range(endpoint.size) if index not in active_indices
+    ]
+    np.testing.assert_allclose(
+        matrix.value.toarray()[inactive], ordinary_jacobian.toarray()[inactive]
+    )
+    np.testing.assert_allclose(
+        f.values[inactive], ordinary_residual[inactive]
+    )
+
+
+@pytest.mark.parametrize("snes_type", ["vinewtonrsls", "vinewtonssls"])
+def test_petsc_vi_snes_types_are_rejected(snes_type):
+    with pytest.raises(ValueError, match="variational-inequality"):
+        dynamics._validate_petsc_snes_type(snes_type)
+
+
+@pytest.mark.parametrize("side", ["upper", "lower"])
+def test_native_and_petsc_be_match_limit_crossings(data_dir, side):
+    pytest.importorskip("petsc4py")
+    native = _biased_two_bus(data_dir, side, petsc=False)
+    petsc = _biased_two_bus(data_dir, side, petsc=True)
+
+    native_result = integrate_system(native[0], native[2], native[1])
+    petsc_result = integrate_system(petsc[0], petsc[2], petsc[1])
+
+    np.testing.assert_allclose(petsc_result["tvec"], native_result["tvec"])
+    np.testing.assert_allclose(
+        petsc_result["history"], native_result["history"], atol=1e-8, rtol=1e-8
+    )
+    lower, upper = petsc[4], petsc[5]
+    values = petsc_result["history"][petsc[3]]
+    assert np.min(values) >= lower - 1e-12
+    assert np.max(values) <= upper + 1e-12
+    native_events = native_result["dynamic_limit_diagnostics"]["events"]
+    petsc_events = petsc_result["dynamic_limit_diagnostics"]["events"]
+    assert [_event_identity(event) for event in petsc_events] == [
+        _event_identity(event) for event in native_events
+    ]
+    free_residual = np.zeros(petsc_result["history"].shape[0])
+    dynamics._assemble_beuler_residual(
+        free_residual,
+        petsc_result["history"][:, -1],
+        petsc_result["history"][:, -2],
+        petsc_result["tvec"][-1] - petsc_result["tvec"][-2],
+        petsc[0],
+        petsc[1].theta_user,
+    )
+    if side == "upper":
+        assert free_residual[petsc[3]] <= 1e-10
+    else:
+        assert free_residual[petsc[3]] >= -1e-10
+
+
+def _run_release_pair(data_dir, *, petsc, side):
+    psys = _build_two_bus(data_dir)
+    z0, theta, _ = _initialize_context(psys)
+    exciter = psys.exc[0]
+    state_index = exciter.dif_ptr + exciter.efd_idx
+    ptr = exciter.par_ptr
+    initial = float(z0[state_index])
+    base_vref = float(theta[ptr + 7])
+    if side == "upper":
+        _set_limits(
+            theta, exciter, initial - 0.1, initial, vref_offset=0.05
+        )
+    else:
+        _set_limits(
+            theta, exciter, initial, initial + 0.1, vref_offset=-0.05
+        )
+    descriptors = collect_limited_state_descriptors(psys, theta)
+    modes = initialize_dynamic_limit_modes(descriptors)
+    residual = np.zeros_like(z0)
+    jacobian = preallocate_jacobian(psys)
+    workspace = None
+    try:
+        if petsc:
+            config = IntegrationConfig(petsc=True, method="beuler")
+            PETSc = dynamics._get_petsc_for_config(config)
+            workspace = dynamics._PETScBEActiveSetWorkspace(
+                PETSc,
+                psys,
+                theta,
+                residual,
+                jacobian,
+                newton_tol=1e-10,
+                newton_max_iter=100,
+            )
+            stepper = dynamics._integrate_petsc_beuler_with_dynamic_limits
+            extra = {"workspace": workspace}
+        else:
+            stepper = dynamics._integrate_beuler_with_dynamic_limits
+            extra = {}
+
+        pinned, modes, first_events = stepper(
+            z0,
+            theta,
+            0.005,
+            psys,
+            residual,
+            jacobian,
+            descriptors=descriptors,
+            modes=modes,
+            state_tolerance=1e-8,
+            release_tolerance=1e-10,
+            max_active_set_iterations=20,
+            endpoint_time=0.005,
+            newton_tol=1e-10,
+            newton_max_iter=100,
+            **extra,
+        )
+        theta[ptr + 7] = (
+            base_vref - 0.05 if side == "upper" else base_vref + 0.05
+        )
+        released, modes, second_events = stepper(
+            pinned,
+            theta,
+            0.005,
+            psys,
+            residual,
+            jacobian,
+            descriptors=descriptors,
+            modes=modes,
+            state_tolerance=1e-8,
+            release_tolerance=1e-10,
+            max_active_set_iterations=20,
+            endpoint_time=0.01,
+            newton_tol=1e-10,
+            newton_max_iter=100,
+            **extra,
+        )
+        return pinned, released, modes, first_events + second_events, state_index
+    finally:
+        if workspace is not None:
+            workspace.destroy()
+
+
+@pytest.mark.parametrize("side", ["upper", "lower"])
+def test_native_and_petsc_be_match_activation_and_release(data_dir, side):
+    pytest.importorskip("petsc4py")
+    native = _run_release_pair(data_dir, petsc=False, side=side)
+    petsc = _run_release_pair(data_dir, petsc=True, side=side)
+
+    np.testing.assert_allclose(petsc[0], native[0], atol=1e-8, rtol=1e-8)
+    np.testing.assert_allclose(petsc[1], native[1], atol=1e-8, rtol=1e-8)
+    assert petsc[2][petsc[4]] == native[2][native[4]] == DynamicLimitMode.FREE
+    assert [_event_identity(event) for event in petsc[3]] == [
+        _event_identity(event) for event in native[3]
+    ]
+
+
+def _build_limited_ieee9(data_dir, *, petsc):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "ieee9_v33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "ieee9bus_SEXS.dyr"))
+    psys.createYbusComplex()
+    psys.power_injection = False
+    z0, theta, ctx = _initialize_context(psys)
+    limited = []
+    for index, exciter in enumerate(psys.exc):
+        state_index = exciter.dif_ptr + exciter.efd_idx
+        initial = float(z0[state_index])
+        _set_limits(
+            theta,
+            exciter,
+            initial - 0.01,
+            initial + 0.01,
+            vref_offset=0.05 if index % 2 == 0 else -0.05,
+        )
+        limited.append((state_index, initial - 0.01, initial + 0.01))
+    ctx.set_theta(theta.copy())
+    config = IntegrationConfig(
+        method="beuler",
+        petsc=petsc,
+        steps=3,
+        dt=0.005,
+        ton=10.0,
+        toff=11.0,
+    )
+    return psys, ctx, config, limited
+
+
+def test_native_and_petsc_be_match_multiple_sexs_limits(data_dir):
+    pytest.importorskip("petsc4py")
+    native = _build_limited_ieee9(data_dir, petsc=False)
+    petsc = _build_limited_ieee9(data_dir, petsc=True)
+
+    native_result = integrate_system(native[0], native[2], native[1])
+    petsc_result = integrate_system(petsc[0], petsc[2], petsc[1])
+
+    np.testing.assert_allclose(
+        petsc_result["history"], native_result["history"], atol=1e-8, rtol=1e-8
+    )
+    for state_index, lower, upper in petsc[3]:
+        values = petsc_result["history"][state_index]
+        assert np.min(values) >= lower - 1e-12
+        assert np.max(values) <= upper + 1e-12
+
+
+def test_native_and_petsc_be_match_off_grid_fault_boundaries(data_dir):
+    pytest.importorskip("petsc4py")
+    native = _biased_two_bus(data_dir, "upper", petsc=False, fault=True)
+    petsc = _biased_two_bus(data_dir, "upper", petsc=True, fault=True)
+    for config in (native[2], petsc[2]):
+        config.steps = 4
+        config.ton = 0.0075
+        config.toff = 0.0135
+
+    native_result = integrate_system(native[0], native[2], native[1])
+    petsc_result = integrate_system(petsc[0], petsc[2], petsc[1])
+
+    expected = [0.0, 0.005, 0.0075, 0.01, 0.0135, 0.015, 0.02]
+    np.testing.assert_allclose(petsc_result["tvec"], expected)
+    np.testing.assert_allclose(petsc_result["tvec"], native_result["tvec"])
+    np.testing.assert_allclose(
+        petsc_result["history"], native_result["history"], atol=1e-8, rtol=1e-8
+    )
+    fault = petsc[0].fault_events[0]
+    residual = np.zeros(petsc_result["history"].shape[0])
+    fault.apply()
+    residual_function(
+        residual, petsc_result["history"][:, 2], petsc[1].theta_user, petsc[0]
+    )
+    assert np.linalg.norm(residual[petsc[0].num_dof_dif :], np.inf) < 1e-8
+    fault.remove()
+    residual_function(
+        residual, petsc_result["history"][:, 4], petsc[1].theta_user, petsc[0]
+    )
+    assert np.linalg.norm(residual[petsc[0].num_dof_dif :], np.inf) < 1e-8
+    assert fault.active is False
+
+
+def test_limited_petsc_be_bypasses_ts(data_dir, monkeypatch):
+    pytest.importorskip("petsc4py")
+    psys, ctx, config, _, _, _ = _biased_two_bus(
+        data_dir, "upper", petsc=True
+    )
+    config.steps = 1
+    monkeypatch.setattr(
+        dynamics,
+        "_petsc_ts_type",
+        lambda *args: pytest.fail("limited PETSc BE must not configure TS"),
+    )
+
+    result = integrate_system(psys, config, ctx)
+
+    assert result["history"].shape[1] == 2
+
+
+def test_disabled_limits_keep_existing_petsc_ts_path(data_dir, monkeypatch):
+    pytest.importorskip("petsc4py")
+    psys = _build_two_bus(data_dir)
+    monkeypatch.setattr(
+        dynamics,
+        "_integrate_system_petsc_beuler_limits",
+        lambda *args: pytest.fail("disabled limits must keep the TS path"),
+    )
+
+    result = integrate_system(
+        psys,
+        IntegrationConfig(
+            petsc=True,
+            method="beuler",
+            enforce_dynamic_limits=False,
+            steps=1,
+            dt=0.005,
+            ton=10.0,
+            toff=11.0,
+        ),
+    )
+
+    assert result["history"].shape[1] == 2
+
+
+def test_zero_limited_states_keep_existing_petsc_ts_path(data_dir, monkeypatch):
+    pytest.importorskip("petsc4py")
+    psys = load_psse(raw_filename=os.path.join(data_dir, "ieee9_v33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "ieee9bus.dyr"))
+    psys.createYbusComplex()
+    monkeypatch.setattr(
+        dynamics,
+        "_integrate_system_petsc_beuler_limits",
+        lambda *args: pytest.fail("zero limited states must keep the TS path"),
+    )
+
+    result = integrate_system(
+        psys,
+        IntegrationConfig(
+            petsc=True,
+            method="beuler",
+            steps=1,
+            dt=0.005,
+            ton=10.0,
+            toff=11.0,
+        ),
+    )
+
+    assert result["dynamic_limit_diagnostics"]["enabled_state_count"] == 0
+    assert result["history"].shape[1] == 2
+
+
+def test_petsc_snes_nonconvergence_has_structured_runtime_diagnostics():
+    descriptor = SimpleNamespace(
+        state_index=0,
+        lower_bound=0.0,
+        upper_bound=1.0,
+        enabled=True,
+        to_dict=lambda: {
+            "state_index": 0,
+            "lower_bound": 0.0,
+            "upper_bound": 1.0,
+            "device_type": "SEXS",
+            "bus": 1,
+            "device_id": "1",
+            "enabled": True,
+        },
+    )
+    prior_event = {"action": "activate", "state_index": 0}
+
+    class FailedWorkspace:
+        def solve_fixed_active_set(self, *args):
+            return (
+                np.asarray([0.5]),
+                4,
+                np.inf,
+                False,
+                {
+                    "failure_reason": "snes_nonconvergence",
+                    "snes_type": "newtonls",
+                    "snes_converged_reason": -5,
+                    "snes_converged_reason_name": "diverged_max_it",
+                    "snes_iterations": 4,
+                    "snes_function_norm": None,
+                },
+            )
+
+    with pytest.raises(DynamicLimitError) as exc_info:
+        dynamics._integrate_petsc_beuler_with_dynamic_limits(
+            np.asarray([0.5]),
+            np.asarray([]),
+            0.1,
+            SimpleNamespace(num_dof_dif=1),
+            np.zeros(1),
+            csr_matrix(np.eye(1)),
+            workspace=FailedWorkspace(),
+            descriptors=[descriptor],
+            modes={0: DynamicLimitMode.FREE},
+            state_tolerance=1e-8,
+            release_tolerance=1e-10,
+            max_active_set_iterations=20,
+            endpoint_time=0.1,
+            newton_tol=1e-10,
+            newton_max_iter=4,
+            prior_events=[prior_event],
+        )
+
+    diagnostics = exc_info.value.diagnostics
+    assert diagnostics["phase"] == "runtime"
+    assert diagnostics["backend"] == "petsc"
+    assert diagnostics["nonlinear_solver"] == "petsc_snes"
+    assert diagnostics["failure_reasons"] == ["snes_nonconvergence"]
+    assert diagnostics["snes_converged_reason"] == -5
+    assert diagnostics["snes_converged_reason_name"] == "diverged_max_it"
+    assert diagnostics["events"] == [prior_event]
+    json.dumps(diagnostics, allow_nan=False)

--- a/tests/test_petsc_cn_dynamic_limits.py
+++ b/tests/test_petsc_cn_dynamic_limits.py
@@ -1,0 +1,807 @@
+import json
+import math
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from scipy.sparse import csr_matrix
+
+from uqgrid.io.parse import add_dyr, load_psse
+from uqgrid.simulation import dynamics
+from uqgrid.simulation.config import IntegrationConfig, IntegrationCtx
+from uqgrid.simulation.dynamic_limits import (
+    DynamicLimitError,
+    DynamicLimitMode,
+    LimitedStateDescriptor,
+    collect_limited_state_descriptors,
+    initialize_dynamic_limit_modes,
+)
+from uqgrid.simulation.dynamics import (
+    initialize_system,
+    integrate_system,
+    preallocate_jacobian,
+)
+from uqgrid.simulation.jacobian import residual_jacobian
+from uqgrid.simulation.pflow import runpf
+from uqgrid.simulation.residual import residual_function
+
+
+@pytest.fixture
+def data_dir():
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data"
+    )
+
+
+class _FakeVector:
+    def __init__(self, values):
+        self.values = np.asarray(values, dtype=float).copy()
+
+    def __getitem__(self, key):
+        return self.values[key]
+
+    def setArray(self, values):
+        self.values = np.asarray(values, dtype=float).copy()
+
+    def assemble(self):
+        return None
+
+
+class _FakeMatrix:
+    def __init__(self):
+        self.value = None
+
+    def setValuesCSR(self, indptr, indices, data):
+        self.value = csr_matrix(
+            (
+                np.array(data, copy=True),
+                np.array(indices, copy=True),
+                np.array(indptr, copy=True),
+            )
+        )
+
+    def assemble(self):
+        return None
+
+
+def _build_two_bus(data_dir, *, fault=False):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "2bus_33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "2bus_SEXS.dyr"))
+    if fault:
+        psys.add_busfault(1, 1e-4)
+    psys.createYbusComplex()
+    psys.power_injection = False
+    return psys
+
+
+def _initialize_context(psys):
+    solution = runpf(psys, verbose=False)
+    z0, theta = initialize_system(psys, solution)
+    ctx = IntegrationCtx()
+    ctx.set_initial_conditions(z0.copy())
+    ctx.set_theta(theta.copy())
+    return z0, theta, ctx
+
+
+def _set_limits(theta, exciter, lower, upper, *, vref_offset=0.0):
+    ptr = exciter.par_ptr
+    theta[ptr + 4] = lower
+    theta[ptr + 5] = upper
+    theta[ptr + 6] = 1.0
+    theta[ptr + 7] += vref_offset
+
+
+def _biased_two_bus(data_dir, side, *, fault=False, width=0.01):
+    psys = _build_two_bus(data_dir, fault=fault)
+    z0, theta, ctx = _initialize_context(psys)
+    exciter = psys.exc[0]
+    state_index = exciter.dif_ptr + exciter.efd_idx
+    initial = float(z0[state_index])
+    lower = initial - width
+    upper = initial + width
+    _set_limits(
+        theta,
+        exciter,
+        lower,
+        upper,
+        vref_offset=0.05 if side == "upper" else -0.05,
+    )
+    ctx.set_theta(theta.copy())
+    config = IntegrationConfig(
+        method="cn",
+        petsc=True,
+        steps=4,
+        dt=0.005,
+        ton=10.0,
+        toff=11.0,
+        newton_tol=1e-10,
+        newton_max_iter=100,
+    )
+    return psys, ctx, config, state_index, lower, upper
+
+
+def _descriptor(index, lower=0.0, upper=1.0):
+    return LimitedStateDescriptor(
+        state_index=index,
+        lower_bound=lower,
+        upper_bound=upper,
+        device_type="SEXS",
+        bus=index + 1,
+        device_id=str(index + 1),
+        enabled=True,
+    )
+
+
+def test_petsc_cn_callbacks_match_trapezoidal_rows_for_active_limits(data_dir):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "ieee9_v33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "ieee9bus_SEXS.dyr"))
+    psys.createYbusComplex()
+    psys.power_injection = False
+    z0, theta, _ = _initialize_context(psys)
+    descriptors = collect_limited_state_descriptors(psys, theta)
+    modes = initialize_dynamic_limit_modes(descriptors)
+    modes[descriptors[0].state_index] = DynamicLimitMode.UPPER_ACTIVE
+    modes[descriptors[1].state_index] = DynamicLimitMode.LOWER_ACTIVE
+    endpoint = z0.copy()
+    endpoint[descriptors[0].state_index] = descriptors[0].upper_bound
+    endpoint[descriptors[1].state_index] = descriptors[1].lower_bound
+    h = 0.005
+    start_derivative = dynamics._effective_cn_start_derivative(
+        z0,
+        theta,
+        psys,
+        descriptors,
+        modes,
+        tolerance=1e-8,
+    )
+
+    ordinary_residual = np.zeros_like(endpoint)
+    dynamics._assemble_cn_residual(
+        ordinary_residual,
+        endpoint,
+        z0,
+        h,
+        start_derivative,
+        psys,
+        theta,
+    )
+    ordinary_jacobian = preallocate_jacobian(psys)
+    residual_jacobian(ordinary_jacobian, endpoint, theta, psys)
+    dynamics.jacobian_beuler(
+        ordinary_jacobian, psys.num_dof_dif, 0.5 * h
+    )
+
+    callback_residual = np.zeros_like(endpoint)
+    callback_jacobian = preallocate_jacobian(psys)
+    problem = dynamics._PETScCNActiveSetProblem(
+        psys, theta, callback_residual, callback_jacobian
+    )
+    problem.set_interval(
+        z0,
+        h,
+        descriptors,
+        modes,
+        start_derivative=start_derivative,
+    )
+    x = _FakeVector(endpoint)
+    f = _FakeVector(np.zeros_like(endpoint))
+    matrix = _FakeMatrix()
+    problem.function(None, x, f)
+    problem.jacobian_function(None, x, matrix, matrix)
+
+    active_indices = {
+        descriptors[0].state_index,
+        descriptors[1].state_index,
+    }
+    for state_index in active_indices:
+        expected = np.zeros(endpoint.size)
+        expected[state_index] = 1.0
+        np.testing.assert_allclose(matrix.value.toarray()[state_index], expected)
+    inactive = [
+        index for index in range(endpoint.size) if index not in active_indices
+    ]
+    np.testing.assert_allclose(
+        matrix.value.toarray()[inactive], ordinary_jacobian.toarray()[inactive]
+    )
+    np.testing.assert_allclose(f.values[inactive], ordinary_residual[inactive])
+
+
+def test_cn_start_derivative_blocks_only_inherited_outward_modes(monkeypatch):
+    raw = np.asarray([2.0, -3.0, 4.0])
+
+    def fake_residual(output, state, theta, psys):
+        output[:] = raw
+
+    monkeypatch.setattr(dynamics, "residual_function", fake_residual)
+    descriptors = [_descriptor(0), _descriptor(1), _descriptor(2)]
+    modes = {
+        0: DynamicLimitMode.UPPER_ACTIVE,
+        1: DynamicLimitMode.LOWER_ACTIVE,
+        2: DynamicLimitMode.FREE,
+    }
+    state = np.asarray([1.0, 0.0, 1.0])
+
+    effective = dynamics._effective_cn_start_derivative(
+        state,
+        np.asarray([]),
+        SimpleNamespace(num_dof_dif=3),
+        descriptors,
+        modes,
+        tolerance=1e-8,
+    )
+    np.testing.assert_allclose(effective, [0.0, 0.0, 4.0])
+
+    raw[:] = [-2.0, 3.0, 4.0]
+    effective = dynamics._effective_cn_start_derivative(
+        state,
+        np.asarray([]),
+        SimpleNamespace(num_dof_dif=3),
+        descriptors,
+        modes,
+        tolerance=1e-8,
+    )
+    np.testing.assert_allclose(effective, raw)
+
+
+def test_cn_start_derivative_is_fixed_across_active_set_retries(monkeypatch):
+    descriptor = _descriptor(0)
+    captured = []
+
+    class RetryWorkspace:
+        def solve_fixed_active_set(
+            self, zold, h, descriptors, modes, *, start_derivative
+        ):
+            captured.append(start_derivative)
+            if len(captured) == 1:
+                return np.asarray([1.2]), 1, 0.0, True, {}
+            return np.asarray([1.0]), 1, 0.0, True, {}
+
+    fixed_start = np.asarray([0.25])
+    monkeypatch.setattr(
+        dynamics,
+        "_effective_cn_start_derivative",
+        lambda *args, **kwargs: fixed_start.copy(),
+    )
+
+    def fake_assemble(output, endpoint, *args, **kwargs):
+        output[:] = -0.1
+
+    monkeypatch.setattr(dynamics, "_assemble_cn_residual", fake_assemble)
+    endpoint, modes, events = dynamics._integrate_petsc_cn_with_dynamic_limits(
+        np.asarray([0.5]),
+        np.asarray([]),
+        0.1,
+        SimpleNamespace(num_dof_dif=1),
+        np.zeros(1),
+        csr_matrix(np.eye(1)),
+        workspace=RetryWorkspace(),
+        descriptors=[descriptor],
+        modes={0: DynamicLimitMode.FREE},
+        state_tolerance=1e-8,
+        release_tolerance=1e-10,
+        max_active_set_iterations=20,
+        endpoint_time=0.1,
+        newton_tol=1e-10,
+        newton_max_iter=10,
+    )
+
+    assert len(captured) == 2
+    assert captured[0] is captured[1]
+    assert captured[0].flags.writeable is False
+    assert endpoint[0] == pytest.approx(1.0)
+    assert modes[0] == DynamicLimitMode.UPPER_ACTIVE
+    assert [event["action"] for event in events] == ["activate"]
+
+
+def test_cn_nonfinite_start_derivative_has_runtime_context(
+    data_dir, monkeypatch
+):
+    psys = _build_two_bus(data_dir)
+    z0, theta, _ = _initialize_context(psys)
+    state_index = psys.exc[0].dif_ptr + psys.exc[0].efd_idx
+    descriptors = collect_limited_state_descriptors(psys, theta)
+    modes = initialize_dynamic_limit_modes(descriptors)
+    modes[state_index] = DynamicLimitMode.UPPER_ACTIVE
+    original_residual = dynamics.residual_function
+
+    def non_finite_efd_derivative(F, z, theta, psys):
+        original_residual(F, z, theta, psys)
+        F[state_index] = np.nan
+
+    monkeypatch.setattr(
+        dynamics, "residual_function", non_finite_efd_derivative
+    )
+
+    with pytest.raises(DynamicLimitError) as exc_info:
+        dynamics._integrate_petsc_cn_with_dynamic_limits(
+            z0,
+            theta,
+            0.005,
+            psys,
+            np.zeros_like(z0),
+            preallocate_jacobian(psys),
+            workspace=SimpleNamespace(),
+            descriptors=descriptors,
+            modes=modes,
+            state_tolerance=1e-8,
+            release_tolerance=1e-10,
+            max_active_set_iterations=20,
+            endpoint_time=0.005,
+            newton_tol=1e-10,
+            newton_max_iter=100,
+        )
+
+    diagnostics = exc_info.value.diagnostics
+    assert diagnostics["phase"] == "runtime"
+    assert diagnostics["method"] == "cn"
+    assert diagnostics["backend"] == "petsc"
+    assert diagnostics["operation"] == "derivative_projection"
+    assert diagnostics["failure_reasons"] == ["non_finite_derivative"]
+    assert diagnostics["time"] == pytest.approx(0.0)
+    assert diagnostics["stage_or_endpoint"] == "start"
+    json.dumps(diagnostics, allow_nan=False)
+
+
+@pytest.mark.parametrize("side", ["upper", "lower"])
+def test_limited_petsc_cn_activates_without_bound_overshoot(data_dir, side):
+    pytest.importorskip("petsc4py")
+    psys, ctx, config, state_index, lower, upper = _biased_two_bus(
+        data_dir, side
+    )
+
+    result = integrate_system(psys, config, ctx)
+
+    values = result["history"][state_index]
+    assert np.min(values) >= lower - config.dynamic_limit_tolerance
+    assert np.max(values) <= upper + config.dynamic_limit_tolerance
+    events = result["dynamic_limit_diagnostics"]["events"]
+    assert any(
+        event["action"] == "activate" and event["side"] == side
+        for event in events
+    )
+
+
+@pytest.mark.parametrize("side", ["upper", "lower"])
+def test_limited_petsc_cn_releases_immediately_under_inward_drive(data_dir, side):
+    pytest.importorskip("petsc4py")
+    psys = _build_two_bus(data_dir)
+    z0, theta, _ = _initialize_context(psys)
+    exciter = psys.exc[0]
+    state_index = exciter.dif_ptr + exciter.efd_idx
+    ptr = exciter.par_ptr
+    initial = float(z0[state_index])
+    base_vref = float(theta[ptr + 7])
+    if side == "upper":
+        _set_limits(theta, exciter, initial - 0.1, initial, vref_offset=0.05)
+    else:
+        _set_limits(theta, exciter, initial, initial + 0.1, vref_offset=-0.05)
+    descriptors = collect_limited_state_descriptors(psys, theta)
+    modes = initialize_dynamic_limit_modes(descriptors)
+    initial_modes = dict(modes)
+    residual = np.zeros_like(z0)
+    jacobian = preallocate_jacobian(psys)
+    PETSc = dynamics._get_petsc_for_config(
+        IntegrationConfig(petsc=True, method="cn")
+    )
+    workspace = dynamics._PETScCNActiveSetWorkspace(
+        PETSc,
+        psys,
+        theta,
+        residual,
+        jacobian,
+        newton_tol=1e-10,
+        newton_max_iter=100,
+    )
+    assert workspace.snes_type == "newtonls"
+    try:
+        pinned, modes, first_events = (
+            dynamics._integrate_petsc_cn_with_dynamic_limits(
+                z0,
+                theta,
+                0.005,
+                psys,
+                residual,
+                jacobian,
+                workspace=workspace,
+                descriptors=descriptors,
+                modes=modes,
+                state_tolerance=1e-8,
+                release_tolerance=1e-10,
+                max_active_set_iterations=20,
+                endpoint_time=0.005,
+                newton_tol=1e-10,
+                newton_max_iter=100,
+            )
+        )
+        first_start = dynamics._effective_cn_start_derivative(
+            z0,
+            theta,
+            psys,
+            descriptors,
+            initial_modes,
+            tolerance=1e-8,
+        )
+        first_free_residual = np.zeros_like(z0)
+        dynamics._assemble_cn_residual(
+            first_free_residual,
+            pinned,
+            z0,
+            0.005,
+            first_start,
+            psys,
+            theta,
+        )
+        pinned_modes = dict(modes)
+        theta[ptr + 7] = (
+            base_vref - 0.05 if side == "upper" else base_vref + 0.05
+        )
+        released, modes, second_events = (
+            dynamics._integrate_petsc_cn_with_dynamic_limits(
+                pinned,
+                theta,
+                0.005,
+                psys,
+                residual,
+                jacobian,
+                workspace=workspace,
+                descriptors=descriptors,
+                modes=modes,
+                state_tolerance=1e-8,
+                release_tolerance=1e-10,
+                max_active_set_iterations=20,
+                endpoint_time=0.01,
+                newton_tol=1e-10,
+                newton_max_iter=100,
+            )
+        )
+        second_start = dynamics._effective_cn_start_derivative(
+            pinned,
+            theta,
+            psys,
+            descriptors,
+            pinned_modes,
+            tolerance=1e-8,
+        )
+        second_free_residual = np.zeros_like(z0)
+        dynamics._assemble_cn_residual(
+            second_free_residual,
+            released,
+            pinned,
+            0.005,
+            second_start,
+            psys,
+            theta,
+        )
+    finally:
+        workspace.destroy()
+
+    assert pinned[state_index] == pytest.approx(initial)
+    assert modes[state_index] == DynamicLimitMode.FREE
+    if side == "upper":
+        assert released[state_index] < pinned[state_index]
+        assert first_free_residual[state_index] <= 1e-10
+    else:
+        assert released[state_index] > pinned[state_index]
+        assert first_free_residual[state_index] >= -1e-10
+    assert (
+        np.linalg.norm(first_free_residual[psys.num_dof_dif :], np.inf)
+        < 1e-8
+    )
+    assert np.linalg.norm(second_free_residual, np.inf) < 1e-8
+    assert [event["action"] for event in first_events + second_events] == [
+        "activate",
+        "release",
+    ]
+
+
+def test_limited_petsc_cn_handles_multiple_sexs_limits(data_dir):
+    pytest.importorskip("petsc4py")
+    psys = load_psse(raw_filename=os.path.join(data_dir, "ieee9_v33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "ieee9bus_SEXS.dyr"))
+    psys.createYbusComplex()
+    psys.power_injection = False
+    z0, theta, ctx = _initialize_context(psys)
+    limited = []
+    for index, exciter in enumerate(psys.exc):
+        state_index = exciter.dif_ptr + exciter.efd_idx
+        initial = float(z0[state_index])
+        _set_limits(
+            theta,
+            exciter,
+            initial - 0.01,
+            initial + 0.01,
+            vref_offset=0.05 if index % 2 == 0 else -0.05,
+        )
+        limited.append((state_index, initial - 0.01, initial + 0.01))
+    ctx.set_theta(theta.copy())
+
+    result = integrate_system(
+        psys,
+        IntegrationConfig(
+            method="cn",
+            petsc=True,
+            steps=3,
+            dt=0.005,
+            ton=10.0,
+            toff=11.0,
+        ),
+        ctx,
+    )
+
+    for state_index, lower, upper in limited:
+        values = result["history"][state_index]
+        assert np.min(values) >= lower - 1e-8
+        assert np.max(values) <= upper + 1e-8
+
+
+def test_limited_petsc_cn_fault_projection_uses_shared_grid(data_dir, monkeypatch):
+    pytest.importorskip("petsc4py")
+    psys, ctx, config, _, _, _ = _biased_two_bus(
+        data_dir, "upper", fault=True
+    )
+    config.ton = 0.0075
+    config.toff = 0.0135
+    projections = []
+    original_integrate = dynamics.integrate
+
+    def recording_integrate(zold, theta, h, psys, *args, **kwargs):
+        result = original_integrate(zold, theta, h, psys, *args, **kwargs)
+        if h == 0.0:
+            projections.append((np.array(zold, copy=True), result[0].copy()))
+        return result
+
+    monkeypatch.setattr(dynamics, "integrate", recording_integrate)
+    result = integrate_system(psys, config, ctx)
+
+    np.testing.assert_allclose(
+        result["tvec"],
+        [0.0, 0.005, 0.0075, 0.01, 0.0135, 0.015, 0.02],
+    )
+    assert len(projections) == 2
+    for before, after in projections:
+        np.testing.assert_allclose(
+            after[: psys.num_dof_dif], before[: psys.num_dof_dif]
+        )
+    fault = psys.fault_events[0]
+    residual = np.zeros(result["history"].shape[0])
+    fault.apply()
+    residual_function(residual, result["history"][:, 2], ctx.theta_user, psys)
+    assert np.linalg.norm(residual[psys.num_dof_dif :], np.inf) < 1e-8
+    fault.remove()
+    residual_function(residual, result["history"][:, 4], ctx.theta_user, psys)
+    assert np.linalg.norm(residual[psys.num_dof_dif :], np.inf) < 1e-8
+    assert fault.active is False
+
+
+def test_limited_petsc_cn_bypasses_ts(data_dir, monkeypatch):
+    pytest.importorskip("petsc4py")
+    psys, ctx, config, _, _, _ = _biased_two_bus(data_dir, "upper")
+    config.steps = 1
+    monkeypatch.setattr(
+        dynamics,
+        "_petsc_ts_type",
+        lambda *args: pytest.fail("limited PETSc CN must not configure TS"),
+    )
+
+    result = integrate_system(psys, config, ctx)
+
+    assert result["history"].shape[1] == 2
+
+
+def test_disabled_limits_keep_existing_petsc_cn_ts_path(data_dir, monkeypatch):
+    pytest.importorskip("petsc4py")
+    psys = _build_two_bus(data_dir)
+    monkeypatch.setattr(
+        dynamics,
+        "_integrate_system_petsc_cn_limits",
+        lambda *args: pytest.fail("disabled limits must keep TSCN"),
+    )
+
+    result = integrate_system(
+        psys,
+        IntegrationConfig(
+            petsc=True,
+            method="cn",
+            enforce_dynamic_limits=False,
+            steps=1,
+            dt=0.005,
+            ton=10.0,
+            toff=11.0,
+        ),
+    )
+
+    assert result["history"].shape[1] == 2
+
+
+def test_zero_limited_states_keep_existing_petsc_cn_ts_path(
+    data_dir, monkeypatch
+):
+    pytest.importorskip("petsc4py")
+    psys = load_psse(raw_filename=os.path.join(data_dir, "ieee9_v33.raw"))
+    add_dyr(psys, os.path.join(data_dir, "ieee9bus.dyr"))
+    psys.createYbusComplex()
+    monkeypatch.setattr(
+        dynamics,
+        "_integrate_system_petsc_cn_limits",
+        lambda *args: pytest.fail("zero limited states must keep TSCN"),
+    )
+
+    result = integrate_system(
+        psys,
+        IntegrationConfig(
+            petsc=True,
+            method="cn",
+            steps=1,
+            dt=0.005,
+            ton=10.0,
+            toff=11.0,
+        ),
+    )
+
+    assert result["dynamic_limit_diagnostics"]["enabled_state_count"] == 0
+    assert result["history"].shape[1] == 2
+
+
+def test_petsc_cn_snes_nonconvergence_has_method_diagnostics(monkeypatch):
+    descriptor = _descriptor(0)
+    monkeypatch.setattr(
+        dynamics,
+        "_effective_cn_start_derivative",
+        lambda *args, **kwargs: np.asarray([0.0]),
+    )
+
+    class FailedWorkspace:
+        def solve_fixed_active_set(self, *args, **kwargs):
+            return (
+                np.asarray([0.5]),
+                4,
+                np.inf,
+                False,
+                {
+                    "failure_reason": "snes_nonconvergence",
+                    "snes_type": "newtonls",
+                    "snes_converged_reason": -5,
+                    "snes_converged_reason_name": "diverged_max_it",
+                    "snes_iterations": 4,
+                    "snes_function_norm": None,
+                },
+            )
+
+    with pytest.raises(DynamicLimitError) as exc_info:
+        dynamics._integrate_petsc_cn_with_dynamic_limits(
+            np.asarray([0.5]),
+            np.asarray([]),
+            0.1,
+            SimpleNamespace(num_dof_dif=1),
+            np.zeros(1),
+            csr_matrix(np.eye(1)),
+            workspace=FailedWorkspace(),
+            descriptors=[descriptor],
+            modes={0: DynamicLimitMode.FREE},
+            state_tolerance=1e-8,
+            release_tolerance=1e-10,
+            max_active_set_iterations=20,
+            endpoint_time=0.1,
+            newton_tol=1e-10,
+            newton_max_iter=4,
+        )
+
+    diagnostics = exc_info.value.diagnostics
+    assert diagnostics["method"] == "cn"
+    assert diagnostics["operation"] == "cn_active_set"
+    assert diagnostics["failure_reasons"] == ["snes_nonconvergence"]
+    assert diagnostics["snes_converged_reason"] == -5
+    json.dumps(diagnostics, allow_nan=False)
+
+
+def _run_scalar_cn(monkeypatch, *, rate, lower, upper, z0, step_sizes):
+    pytest.importorskip("petsc4py")
+
+    def scalar_residual(output, state, theta, psys):
+        output[0] = rate(state[0])
+
+    def scalar_jacobian(jacobian, state, theta, psys):
+        epsilon = 1e-7
+        derivative = (
+            rate(state[0] + epsilon) - rate(state[0] - epsilon)
+        ) / (2.0 * epsilon)
+        jacobian.data[:] = derivative
+
+    monkeypatch.setattr(dynamics, "residual_function", scalar_residual)
+    monkeypatch.setattr(dynamics, "residual_jacobian", scalar_jacobian)
+    psys = SimpleNamespace(num_dof_dif=1)
+    descriptor = _descriptor(0, lower=lower, upper=upper)
+    residual = np.zeros(1)
+    jacobian = csr_matrix(np.asarray([[1.0]]))
+    PETSc = dynamics._get_petsc_for_config(
+        IntegrationConfig(petsc=True, method="cn")
+    )
+    workspace = dynamics._PETScCNActiveSetWorkspace(
+        PETSc,
+        psys,
+        np.asarray([]),
+        residual,
+        jacobian,
+        newton_tol=1e-12,
+        newton_max_iter=50,
+    )
+    state = np.asarray([z0], dtype=float)
+    modes = {0: DynamicLimitMode.FREE}
+    events = []
+    time = 0.0
+    try:
+        for h in step_sizes:
+            time += h
+            state, modes, interval_events = (
+                dynamics._integrate_petsc_cn_with_dynamic_limits(
+                    state,
+                    np.asarray([]),
+                    h,
+                    psys,
+                    residual,
+                    jacobian,
+                    workspace=workspace,
+                    descriptors=[descriptor],
+                    modes=modes,
+                    state_tolerance=1e-12,
+                    release_tolerance=1e-12,
+                    max_active_set_iterations=20,
+                    endpoint_time=time,
+                    newton_tol=1e-12,
+                    newton_max_iter=50,
+                    prior_events=events,
+                )
+            )
+            events.extend(interval_events)
+    finally:
+        workspace.destroy()
+    return state[0], events
+
+
+def test_limited_petsc_cn_is_second_order_away_from_switching(monkeypatch):
+    errors = []
+    for h in (0.2, 0.1, 0.05):
+        endpoint, events = _run_scalar_cn(
+            monkeypatch,
+            rate=lambda value: -value,
+            lower=-10.0,
+            upper=10.0,
+            z0=1.0,
+            step_sizes=[h] * round(1.0 / h),
+        )
+        assert events == []
+        errors.append(abs(endpoint - math.exp(-1.0)))
+
+    assert errors[0] / errors[1] > 3.5
+    assert errors[1] / errors[2] > 3.5
+
+
+def test_limited_petsc_cn_switch_time_error_is_first_order(monkeypatch):
+    crossing_time = 0.1
+    errors = []
+    step_sizes = []
+    for intervals_before_half_step in (4, 8, 16):
+        h = crossing_time / (intervals_before_half_step + 0.5)
+        endpoint, events = _run_scalar_cn(
+            monkeypatch,
+            rate=lambda value: 1.0,
+            lower=-1.0,
+            upper=crossing_time,
+            z0=0.0,
+            step_sizes=[h] * (intervals_before_half_step + 1),
+        )
+        assert endpoint == pytest.approx(crossing_time)
+        activation_time = next(
+            event["time"]
+            for event in events
+            if event["action"] == "activate"
+        )
+        step_sizes.append(h)
+        errors.append(activation_time - crossing_time)
+
+    np.testing.assert_allclose(
+        np.asarray(errors) / np.asarray(step_sizes),
+        0.5,
+        atol=1e-10,
+    )

--- a/tests/test_petsc_lazy_init.py
+++ b/tests/test_petsc_lazy_init.py
@@ -123,6 +123,7 @@ def test_partition_driver_preserves_sys_argv_and_stores_petsc_args(monkeypatch):
         "case.dyr",
         "--petsc",
         "--arkimex",
+        "--no-enforce-dynamic-limits",
         "--",
         "-log_view",
         ":petsc.log",
@@ -136,4 +137,5 @@ def test_partition_driver_preserves_sys_argv_and_stores_petsc_args(monkeypatch):
     assert args.raw == "case.raw"
     assert args.dyr == "case.dyr"
     assert config.petsc is True
+    assert config.enforce_dynamic_limits is False
     assert config.petsc_args == ["-log_view", ":petsc.log"]

--- a/tests/test_pssedyn.py
+++ b/tests/test_pssedyn.py
@@ -302,6 +302,7 @@ def test_petsc_uses_q_limited_initial_power_flow(data_dir, monkeypatch, method):
     assert captured[0].q_limit_events[0]["side"] == "upper"
     assert captured[0].gen_qsch[1] == pytest.approx(psys.gens[1].qgub)
     assert result["power_flow_diagnostics"] == captured[0].validation
+    assert result["dynamic_limit_diagnostics"]["initialization"]["valid"] is True
     assert result["history"].shape[1] == 3
     np.testing.assert_allclose(result["tvec"], [0.0, config.dt, 2 * config.dt])
 
@@ -401,6 +402,7 @@ def test_petsc_arkimex_uses_common_grid_without_fault(data_dir):
     config = IntegrationConfig(
         petsc=True,
         arkimex=True,
+        enforce_dynamic_limits=False,
         steps=2,
         dt=0.01,
         ton=10.0,
@@ -429,6 +431,7 @@ def test_petsc_arkimex_uses_exact_off_grid_fault_transitions(data_dir):
     config = IntegrationConfig(
         petsc=True,
         arkimex=True,
+        enforce_dynamic_limits=False,
         steps=4,
         dt=0.01,
         ton=0.015,
@@ -513,9 +516,37 @@ def test_valid_tgov1_and_sexs_records_attach_without_warning(data_dir, tmp_path,
     captured = capsys.readouterr()
     assert len(psys.gov) == 1
     assert len(psys.exc) == 1
+    assert psys.exc[0].enable_limits is True
     assert "Cannot pair TGOV1" not in caplog.text
     assert "Cannot pair SEXS" not in caplog.text
     assert captured.out == ""
+
+
+@pytest.mark.parametrize(
+    "emin, emax, message",
+    [
+        ("nan", "1.0", "EMIN and EMAX must be finite"),
+        ("0.5", "0.5", "EMIN (0.5) must be less than EMAX (0.5)"),
+        ("1.0", "0.5", "EMIN (1.0) must be less than EMAX (0.5)"),
+    ],
+)
+def test_invalid_parsed_sexs_limits_fail_with_device_identity(
+    data_dir, tmp_path, emin, emax, message
+):
+    psys = load_psse(raw_filename=os.path.join(data_dir, "2bus_33.raw"))
+    dyr_path = tmp_path / "invalid_sexs_limits.dyr"
+    dyr_path.write_text(
+        f"""
+1 'GENROU' 1 6.1 0.05 1.0 0.15 3.38 0.0 1.575 1.512 0.291 0.39 0.1733 0.0787 0.0 0.0 /
+1 'SEXS' 1 0.1 0.2 100.0 0.05 {emin} {emax} /
+""".lstrip()
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        add_dyr(psys, str(dyr_path))
+
+    assert "bus 1, generator 1" in str(exc_info.value)
+    assert message in str(exc_info.value)
 
 
 def test_add_dyr_verbose_uses_info_logging_not_stdout(data_dir, tmp_path, caplog, capsys):

--- a/uqgrid/__init__.py
+++ b/uqgrid/__init__.py
@@ -22,6 +22,12 @@ from .simulation.config import (
     IntegrationCtx,
     PowerFlowValidationConfig,
 )
+from .simulation.dynamic_limits import (
+    DYNAMIC_LIMIT_EVENT_ACTIONS,
+    DYNAMIC_LIMIT_EVENT_FIELDS,
+    DynamicLimitError,
+    LimitedStateDescriptor,
+)
 
 # Check if PETSc is available
 try:

--- a/uqgrid/core/base_models.py
+++ b/uqgrid/core/base_models.py
@@ -1,9 +1,23 @@
 import numpy as np
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from uqgrid.utils.tools import csr_add_row, csr_set_row
 
 # constants
 ws = 2*np.pi*60
+
+
+@dataclass(frozen=True)
+class BoundedStateMetadata:
+    """Model-relative locations for one bounded differential state."""
+
+    state_name: str
+    state_offset: int
+    lower_parameter_offset: int
+    upper_parameter_offset: int
+    enabled_parameter_offset: int
+    device_type: str
+
 
 class DeviceModel(ABC):
     """ Base class for device model object.
@@ -21,6 +35,8 @@ class DeviceModel(ABC):
             ndev (int): device number (local to bus)
 
     """
+
+    bounded_state_metadata = ()
 
     def __init__(self, ddim, adim, pdim, id_tag, model_type):
         self.dif_dim = ddim

--- a/uqgrid/io/parse.py
+++ b/uqgrid/io/parse.py
@@ -6,6 +6,7 @@ import numpy as np
 import warnings
 import re
 import logging
+import math
 
 logger = logging.getLogger(__name__)
 
@@ -650,10 +651,35 @@ def add_dyr(psys, dyr_filename, verbose=False):
             EMIN = float(device[7])
             EMAX = float(device[8])
 
+            if not math.isfinite(EMIN) or not math.isfinite(EMAX):
+                raise ValueError(
+                    "Invalid SEXS limits at bus "
+                    f"{int(device[0])}, generator {gen_id}: "
+                    "EMIN and EMAX must be finite."
+                )
+            if EMIN >= EMAX:
+                raise ValueError(
+                    "Invalid SEXS limits at bus "
+                    f"{int(device[0])}, generator {gen_id}: "
+                    f"EMIN ({EMIN}) must be less than EMAX ({EMAX})."
+                )
+
             found_match = False
             for gen in psys.gendyn:
                 if gen.bus == bus and gen.id_tag.strip() == gen_id.strip():
-                    psys.add_exc(gen, ExcSEXS(gen_id, TA_TB, TB, K, TE, EMIN, EMAX))
+                    psys.add_exc(
+                        gen,
+                        ExcSEXS(
+                            gen_id,
+                            TA_TB,
+                            TB,
+                            K,
+                            TE,
+                            EMIN,
+                            EMAX,
+                            enable_limits=True,
+                        ),
+                    )
                     found_match = True
                     break
 

--- a/uqgrid/models/sexs_imp.py
+++ b/uqgrid/models/sexs_imp.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numba import jit
-from uqgrid.core.base_models import Exciter
+from uqgrid.core.base_models import BoundedStateMetadata, Exciter
 from uqgrid.utils.tools import csr_set_row
 
 
@@ -72,8 +72,20 @@ class ExcSEXS(Exciter):
     Simplified Excitation System (SEXS).
 
     Parameters are:
-    TA_TB, TB, K, TE, Emin, Emax. Limits are parsed but ignored.
+    TA_TB, TB, K, TE, Emin, Emax. The raw model equations remain
+    unconstrained; the integration layer applies enabled Efd limits.
     """
+
+    bounded_state_metadata = (
+        BoundedStateMetadata(
+            state_name="Efd",
+            state_offset=1,
+            lower_parameter_offset=4,
+            upper_parameter_offset=5,
+            enabled_parameter_offset=6,
+            device_type="SEXS",
+        ),
+    )
 
     def __init__(self, id_tag, TA_TB, TB, K, TE, Emin, Emax, enable_limits=False):
         self.TA_TB = TA_TB

--- a/uqgrid/simulation/__init__.py
+++ b/uqgrid/simulation/__init__.py
@@ -3,3 +3,9 @@
 from .dynamics import integrate_system, initialize_system, initialize_sensitivities, preallocate_jacobian, coord_to_sparse, preallocate_hessian, compute_equilibrium, compute_rhs_jacobian
 from .jacobian_check import finite_difference_jacobian, compare_jacobians, build_index_map
 from .pflow import PowerFlowValidationError, runpf, validate_power_flow_solution
+from .dynamic_limits import (
+    DYNAMIC_LIMIT_EVENT_ACTIONS,
+    DYNAMIC_LIMIT_EVENT_FIELDS,
+    DynamicLimitError,
+    LimitedStateDescriptor,
+)

--- a/uqgrid/simulation/config.py
+++ b/uqgrid/simulation/config.py
@@ -66,6 +66,25 @@ class IntegrationConfig(BaseModel):
         default_factory=PowerFlowValidationConfig,
         description="Optional final operating-point checks before dynamic initialization.",
     )
+    enforce_dynamic_limits: bool = Field(
+        True,
+        description="Enable hard dynamic-state limits for models that expose them.",
+    )
+    dynamic_limit_tolerance: float = Field(
+        1e-8,
+        ge=0.0,
+        description="State-bound tolerance for hard dynamic limits.",
+    )
+    dynamic_limit_release_tolerance: float = Field(
+        1e-10,
+        ge=0.0,
+        description="Complementarity tolerance for releasing hard dynamic limits.",
+    )
+    max_dynamic_limit_iterations: int = Field(
+        20,
+        gt=0,
+        description="Maximum active-set iterations for hard dynamic limits.",
+    )
     solve_powerflow_dynamics: bool = Field(True, description="Solve power flow before dynamics.")
     arkimex: bool = Field(False, description="Use ARKIMEX integrator.")
     check_jacobian: bool = Field(False, description="Run FD Jacobian check (non-PETSc only).")
@@ -111,6 +130,23 @@ class IntegrationConfig(BaseModel):
     def validate_integration_contract(self):
         slow = self.arkimex_slow_differential
         fast = self.arkimex_fast_differential
+        if self.enforce_dynamic_limits:
+            conflicts = [
+                name
+                for name, enabled in (
+                    ("arkimex", self.arkimex),
+                    ("comp_sens", self.comp_sens),
+                    ("fsolve", self.fsolve),
+                )
+                if enabled
+            ]
+            if conflicts:
+                formatted = ", ".join(f"`{name}=True`" for name in conflicts)
+                raise ValueError(
+                    "Hard dynamic limits are incompatible with "
+                    f"{formatted}. Set `enforce_dynamic_limits=False` to use "
+                    "these legacy integration paths."
+                )
         if slow is not None and fast is not None:
             raise ValueError(
                 "Specify only one of `arkimex_slow_differential` or `arkimex_fast_differential`."

--- a/uqgrid/simulation/dynamic_limits.py
+++ b/uqgrid/simulation/dynamic_limits.py
@@ -1,0 +1,854 @@
+"""Shared metadata, validation, and pure helpers for hard dynamic limits."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import Enum
+import math
+from typing import Any, Iterable, Mapping
+
+import numpy as np
+
+
+DYNAMIC_LIMIT_EVENT_FIELDS = (
+    "device_type",
+    "device_id",
+    "bus",
+    "state_index",
+    "side",
+    "action",
+    "time",
+    "stage_or_endpoint",
+    "raw_derivative",
+    "state_before",
+    "state_after",
+    "bound",
+    "active_set_iterations",
+)
+
+DYNAMIC_LIMIT_EVENT_ACTIONS = (
+    "project",
+    "block_outward_derivative",
+    "activate",
+    "release",
+)
+
+
+@dataclass(frozen=True)
+class LimitedStateDescriptor:
+    """JSON-safe identity and bounds for one limited differential state."""
+
+    state_index: int
+    lower_bound: float
+    upper_bound: float
+    device_type: str
+    bus: int
+    device_id: str
+    enabled: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        values = asdict(self)
+        for key in ("lower_bound", "upper_bound"):
+            value = float(values[key])
+            values[key] = value if math.isfinite(value) else None
+        return values
+
+
+class DynamicLimitError(RuntimeError):
+    """Raised when dynamic-limit validation or helper evaluation fails."""
+
+    def __init__(self, diagnostics: dict[str, Any]):
+        self.diagnostics = diagnostics
+        reasons = diagnostics.get("failure_reasons")
+        if reasons is None:
+            reasons = diagnostics.get("initialization", {}).get(
+                "failure_reasons", []
+            )
+        reasons = ", ".join(reasons)
+        super().__init__(
+            diagnostics.get("message", "Dynamic-limit validation failed")
+            + (f": {reasons}" if reasons else "")
+        )
+
+
+class DynamicLimitMode(str, Enum):
+    """Active-set mode for one limited differential state."""
+
+    FREE = "free"
+    LOWER_ACTIVE = "lower_active"
+    UPPER_ACTIVE = "upper_active"
+
+
+def collect_limited_state_descriptors(psys, theta) -> list[LimitedStateDescriptor]:
+    """Resolve model-level bounded-state metadata against effective parameters."""
+    theta = np.asarray(theta, dtype=float)
+    descriptors = []
+    for device in psys.devices:
+        for metadata in getattr(device, "bounded_state_metadata", ()):
+            par_ptr = int(device.par_ptr)
+            descriptors.append(
+                LimitedStateDescriptor(
+                    state_index=int(device.dif_ptr + metadata.state_offset),
+                    lower_bound=float(
+                        theta[par_ptr + metadata.lower_parameter_offset]
+                    ),
+                    upper_bound=float(
+                        theta[par_ptr + metadata.upper_parameter_offset]
+                    ),
+                    device_type=metadata.device_type,
+                    bus=int(psys.buses[device.bus].id),
+                    device_id=str(device.id_tag).strip(),
+                    enabled=bool(
+                        theta[par_ptr + metadata.enabled_parameter_offset]
+                    ),
+                )
+            )
+    return descriptors
+
+
+def _json_number(value: float) -> float | None:
+    value = float(value)
+    return value if math.isfinite(value) else None
+
+
+def _violation_record(
+    descriptor: LimitedStateDescriptor,
+    *,
+    value: float,
+    side: str,
+    bound: float | None,
+    violation: float | None,
+) -> dict[str, Any]:
+    return {
+        **descriptor.to_dict(),
+        "initial_value": _json_number(value),
+        "side": side,
+        "bound": None if bound is None else _json_number(bound),
+        "violation": None if violation is None else _json_number(violation),
+    }
+
+
+def _validate_enabled_descriptor(
+    descriptor: LimitedStateDescriptor,
+    *,
+    operation: str,
+    time: float | None = None,
+    stage_or_endpoint: str | None = None,
+) -> None:
+    lower = float(descriptor.lower_bound)
+    upper = float(descriptor.upper_bound)
+    reason = None
+    if not math.isfinite(lower) or not math.isfinite(upper):
+        reason = "non_finite_bounds"
+    elif lower == upper:
+        reason = "degenerate_bounds"
+    elif lower > upper:
+        reason = "inverted_bounds"
+    if reason is not None:
+        raise DynamicLimitError(
+            {
+                "message": f"Dynamic-limit {operation} failed",
+                "operation": operation,
+                "time": None if time is None else _json_number(time),
+                "stage_or_endpoint": stage_or_endpoint,
+                "failure_reasons": [reason],
+                "violations": [
+                    {
+                        **descriptor.to_dict(),
+                        "side": "invalid",
+                        "bound": None,
+                    }
+                ],
+                "events": [],
+            }
+        )
+
+
+def _event_record(
+    descriptor: LimitedStateDescriptor,
+    *,
+    side: str,
+    action: str,
+    bound: float,
+    state_before: float,
+    state_after: float,
+    raw_derivative: float | None = None,
+    free_residual: float | None = None,
+    time: float | None = None,
+    stage_or_endpoint: str | None = None,
+    active_set_iterations: int | None = None,
+) -> dict[str, Any]:
+    return {
+        **descriptor.to_dict(),
+        "side": side,
+        "action": action,
+        "time": None if time is None else _json_number(time),
+        "stage_or_endpoint": stage_or_endpoint,
+        "raw_derivative": (
+            None if raw_derivative is None else _json_number(raw_derivative)
+        ),
+        "free_residual": (
+            None if free_residual is None else _json_number(free_residual)
+        ),
+        "state_before": _json_number(state_before),
+        "state_after": _json_number(state_after),
+        "bound": _json_number(bound),
+        "active_set_iterations": active_set_iterations,
+    }
+
+
+def _helper_failure(
+    operation: str,
+    reason: str,
+    descriptor: LimitedStateDescriptor,
+    *,
+    value: float | None = None,
+    time: float | None = None,
+    stage_or_endpoint: str | None = None,
+) -> DynamicLimitError:
+    return DynamicLimitError(
+        {
+            "message": f"Dynamic-limit {operation} failed",
+            "operation": operation,
+            "time": None if time is None else _json_number(time),
+            "stage_or_endpoint": stage_or_endpoint,
+            "failure_reasons": [reason],
+            "violations": [
+                {
+                    **descriptor.to_dict(),
+                    "value": None if value is None else _json_number(value),
+                }
+            ],
+            "events": [],
+        }
+    )
+
+
+def _contextualize_dynamic_limit_runtime_error(
+    error: DynamicLimitError,
+    *,
+    method: str,
+    backend: str,
+    time: float,
+    stage_or_endpoint: str,
+    prior_events: Iterable[Mapping[str, Any]] = (),
+) -> DynamicLimitError:
+    """Return a helper failure decorated with integration runtime context."""
+    diagnostics = dict(error.diagnostics)
+    diagnostics["phase"] = "runtime"
+    diagnostics["method"] = method
+    diagnostics["backend"] = backend
+    if diagnostics.get("time") is None:
+        diagnostics["time"] = _json_number(time)
+    if diagnostics.get("stage_or_endpoint") is None:
+        diagnostics["stage_or_endpoint"] = stage_or_endpoint
+    diagnostics["events"] = [
+        *[dict(event) for event in prior_events],
+        *[dict(event) for event in diagnostics.get("events", ())],
+    ]
+    return DynamicLimitError(diagnostics)
+
+
+def project_limited_states(
+    state,
+    descriptors: Iterable[LimitedStateDescriptor],
+    *,
+    time: float | None = None,
+    stage_or_endpoint: str | None = None,
+    active_set_iterations: int | None = None,
+) -> tuple[np.ndarray, list[dict[str, Any]]]:
+    """Clamp enabled limited states exactly, without mutating the input."""
+    projected = np.array(state, dtype=float, copy=True)
+    events = []
+    for descriptor in descriptors:
+        if not descriptor.enabled:
+            continue
+        _validate_enabled_descriptor(
+            descriptor,
+            operation="state_projection",
+            time=time,
+            stage_or_endpoint=stage_or_endpoint,
+        )
+        value = float(projected[descriptor.state_index])
+        if not math.isfinite(value):
+            raise _helper_failure(
+                "state_projection",
+                "non_finite_state",
+                descriptor,
+                value=value,
+                time=time,
+                stage_or_endpoint=stage_or_endpoint,
+            )
+        lower = float(descriptor.lower_bound)
+        upper = float(descriptor.upper_bound)
+        if value < lower:
+            projected[descriptor.state_index] = lower
+            events.append(
+                _event_record(
+                    descriptor,
+                    side="lower",
+                    action="project",
+                    bound=lower,
+                    state_before=value,
+                    state_after=lower,
+                    time=time,
+                    stage_or_endpoint=stage_or_endpoint,
+                    active_set_iterations=active_set_iterations,
+                )
+            )
+        elif value > upper:
+            projected[descriptor.state_index] = upper
+            events.append(
+                _event_record(
+                    descriptor,
+                    side="upper",
+                    action="project",
+                    bound=upper,
+                    state_before=value,
+                    state_after=upper,
+                    time=time,
+                    stage_or_endpoint=stage_or_endpoint,
+                    active_set_iterations=active_set_iterations,
+                )
+            )
+    return projected, events
+
+
+def project_limited_derivatives(
+    state,
+    raw_derivative,
+    descriptors: Iterable[LimitedStateDescriptor],
+    *,
+    tolerance: float,
+    time: float | None = None,
+    stage_or_endpoint: str | None = None,
+    active_set_iterations: int | None = None,
+) -> tuple[np.ndarray, list[dict[str, Any]]]:
+    """Zero only derivatives that point outward at an enabled bound."""
+    tolerance = float(tolerance)
+    if tolerance < 0.0:
+        raise ValueError("Dynamic-limit state tolerance must be non-negative.")
+    state = np.asarray(state, dtype=float)
+    projected = np.array(raw_derivative, dtype=float, copy=True)
+    events = []
+    for descriptor in descriptors:
+        if not descriptor.enabled:
+            continue
+        _validate_enabled_descriptor(
+            descriptor,
+            operation="derivative_projection",
+            time=time,
+            stage_or_endpoint=stage_or_endpoint,
+        )
+        value = float(state[descriptor.state_index])
+        derivative = float(projected[descriptor.state_index])
+        if not math.isfinite(value):
+            raise _helper_failure(
+                "derivative_projection",
+                "non_finite_state",
+                descriptor,
+                value=value,
+                time=time,
+                stage_or_endpoint=stage_or_endpoint,
+            )
+        if not math.isfinite(derivative):
+            raise _helper_failure(
+                "derivative_projection",
+                "non_finite_derivative",
+                descriptor,
+                value=derivative,
+                time=time,
+                stage_or_endpoint=stage_or_endpoint,
+            )
+        lower = float(descriptor.lower_bound)
+        upper = float(descriptor.upper_bound)
+        side = None
+        bound = None
+        if value >= upper - tolerance and derivative > 0.0:
+            side = "upper"
+            bound = upper
+        elif value <= lower + tolerance and derivative < 0.0:
+            side = "lower"
+            bound = lower
+        if side is not None:
+            projected[descriptor.state_index] = 0.0
+            events.append(
+                _event_record(
+                    descriptor,
+                    side=side,
+                    action="block_outward_derivative",
+                    bound=bound,
+                    state_before=value,
+                    state_after=value,
+                    raw_derivative=derivative,
+                    time=time,
+                    stage_or_endpoint=stage_or_endpoint,
+                    active_set_iterations=active_set_iterations,
+                )
+            )
+    return projected, events
+
+
+def update_explicit_dynamic_limit_modes(
+    state,
+    raw_derivative,
+    descriptors: Iterable[LimitedStateDescriptor],
+    modes: Mapping[int, DynamicLimitMode | str],
+    *,
+    tolerance: float,
+    time: float | None = None,
+    stage_or_endpoint: str | None = None,
+) -> tuple[dict[int, DynamicLimitMode], bool, list[dict[str, Any]]]:
+    """Track explicit limiter activation and release without changing values."""
+    tolerance = float(tolerance)
+    if tolerance < 0.0:
+        raise ValueError("Dynamic-limit state tolerance must be non-negative.")
+    state = np.asarray(state, dtype=float)
+    raw_derivative = np.asarray(raw_derivative, dtype=float)
+    descriptors = list(descriptors)
+    updated = {
+        descriptor.state_index: _mode_for(modes, descriptor)
+        for descriptor in descriptors
+    }
+    events = []
+
+    for descriptor in descriptors:
+        state_index = descriptor.state_index
+        previous_mode = updated[state_index]
+        if not descriptor.enabled:
+            updated[state_index] = DynamicLimitMode.FREE
+            continue
+        _validate_enabled_descriptor(
+            descriptor,
+            operation="explicit_mode_update",
+            time=time,
+            stage_or_endpoint=stage_or_endpoint,
+        )
+        value = float(state[state_index])
+        derivative = float(raw_derivative[state_index])
+        if not math.isfinite(value):
+            raise _helper_failure(
+                "explicit_mode_update",
+                "non_finite_state",
+                descriptor,
+                value=value,
+                time=time,
+                stage_or_endpoint=stage_or_endpoint,
+            )
+        if not math.isfinite(derivative):
+            raise _helper_failure(
+                "explicit_mode_update",
+                "non_finite_derivative",
+                descriptor,
+                value=derivative,
+                time=time,
+                stage_or_endpoint=stage_or_endpoint,
+            )
+
+        lower = float(descriptor.lower_bound)
+        upper = float(descriptor.upper_bound)
+        if value >= upper - tolerance and derivative > 0.0:
+            next_mode = DynamicLimitMode.UPPER_ACTIVE
+        elif value <= lower + tolerance and derivative < 0.0:
+            next_mode = DynamicLimitMode.LOWER_ACTIVE
+        elif derivative == 0.0 and (
+            (
+                previous_mode == DynamicLimitMode.UPPER_ACTIVE
+                and value >= upper - tolerance
+            )
+            or (
+                previous_mode == DynamicLimitMode.LOWER_ACTIVE
+                and value <= lower + tolerance
+            )
+        ):
+            next_mode = previous_mode
+        else:
+            next_mode = DynamicLimitMode.FREE
+
+        if next_mode == previous_mode:
+            continue
+        if previous_mode != DynamicLimitMode.FREE:
+            previous_side = (
+                "upper"
+                if previous_mode == DynamicLimitMode.UPPER_ACTIVE
+                else "lower"
+            )
+            previous_bound = upper if previous_side == "upper" else lower
+            events.append(
+                _event_record(
+                    descriptor,
+                    side=previous_side,
+                    action="release",
+                    bound=previous_bound,
+                    state_before=value,
+                    state_after=value,
+                    raw_derivative=derivative,
+                    time=time,
+                    stage_or_endpoint=stage_or_endpoint,
+                )
+            )
+        if next_mode != DynamicLimitMode.FREE:
+            next_side = (
+                "upper"
+                if next_mode == DynamicLimitMode.UPPER_ACTIVE
+                else "lower"
+            )
+            next_bound = upper if next_side == "upper" else lower
+            events.append(
+                _event_record(
+                    descriptor,
+                    side=next_side,
+                    action="activate",
+                    bound=next_bound,
+                    state_before=value,
+                    state_after=value,
+                    raw_derivative=derivative,
+                    time=time,
+                    stage_or_endpoint=stage_or_endpoint,
+                )
+            )
+        updated[state_index] = next_mode
+
+    changed = any(
+        updated[descriptor.state_index] != _mode_for(modes, descriptor)
+        for descriptor in descriptors
+    )
+    return updated, changed, events
+
+
+def initialize_dynamic_limit_modes(
+    descriptors: Iterable[LimitedStateDescriptor],
+) -> dict[int, DynamicLimitMode]:
+    """Create a free active-set mode for every discovered limited state."""
+    modes = {}
+    for descriptor in descriptors:
+        if descriptor.state_index in modes:
+            raise ValueError(
+                f"Duplicate limited state index {descriptor.state_index}."
+            )
+        modes[descriptor.state_index] = DynamicLimitMode.FREE
+    return modes
+
+
+def _mode_for(
+    modes: Mapping[int, DynamicLimitMode | str],
+    descriptor: LimitedStateDescriptor,
+) -> DynamicLimitMode:
+    try:
+        return DynamicLimitMode(modes[descriptor.state_index])
+    except KeyError as exc:
+        raise ValueError(
+            f"Missing active-set mode for state {descriptor.state_index}."
+        ) from exc
+    except ValueError as exc:
+        raise ValueError(
+            f"Invalid active-set mode for state {descriptor.state_index}."
+        ) from exc
+
+
+def evaluate_dynamic_limit_complementarity(
+    endpoint_state,
+    free_residual,
+    descriptors: Iterable[LimitedStateDescriptor],
+    modes: Mapping[int, DynamicLimitMode | str],
+    *,
+    state_tolerance: float,
+    release_tolerance: float,
+) -> dict[str, Any]:
+    """Evaluate bound feasibility and discarded-residual complementarity."""
+    state_tolerance = float(state_tolerance)
+    release_tolerance = float(release_tolerance)
+    if state_tolerance < 0.0 or release_tolerance < 0.0:
+        raise ValueError("Dynamic-limit tolerances must be non-negative.")
+    endpoint_state = np.asarray(endpoint_state, dtype=float)
+    free_residual = np.asarray(free_residual, dtype=float)
+    records = []
+    for descriptor in descriptors:
+        mode = _mode_for(modes, descriptor)
+        if not descriptor.enabled:
+            records.append(
+                {
+                    **descriptor.to_dict(),
+                    "mode": DynamicLimitMode.FREE.value,
+                    "state_value": _json_number(
+                        endpoint_state[descriptor.state_index]
+                    ),
+                    "free_residual": None,
+                    "side": None,
+                    "bound": None,
+                    "consistent": mode == DynamicLimitMode.FREE,
+                }
+            )
+            continue
+        _validate_enabled_descriptor(
+            descriptor, operation="complementarity_evaluation"
+        )
+        value = float(endpoint_state[descriptor.state_index])
+        residual = float(free_residual[descriptor.state_index])
+        if not math.isfinite(value):
+            raise _helper_failure(
+                "complementarity_evaluation",
+                "non_finite_state",
+                descriptor,
+                value=value,
+            )
+        if not math.isfinite(residual):
+            raise _helper_failure(
+                "complementarity_evaluation",
+                "non_finite_free_residual",
+                descriptor,
+                value=residual,
+            )
+        lower = float(descriptor.lower_bound)
+        upper = float(descriptor.upper_bound)
+        side = None
+        bound = None
+        if mode == DynamicLimitMode.UPPER_ACTIVE:
+            side = "upper"
+            bound = upper
+            consistent = (
+                abs(value - upper) <= state_tolerance
+                and residual <= release_tolerance
+            )
+        elif mode == DynamicLimitMode.LOWER_ACTIVE:
+            side = "lower"
+            bound = lower
+            consistent = (
+                abs(value - lower) <= state_tolerance
+                and residual >= -release_tolerance
+            )
+        else:
+            consistent = (
+                lower - state_tolerance <= value <= upper + state_tolerance
+            )
+        records.append(
+            {
+                **descriptor.to_dict(),
+                "mode": mode.value,
+                "state_value": _json_number(value),
+                "free_residual": _json_number(residual),
+                "side": side,
+                "bound": None if bound is None else _json_number(bound),
+                "consistent": bool(consistent),
+            }
+        )
+    return {
+        "consistent": all(record["consistent"] for record in records),
+        "records": records,
+    }
+
+
+def update_dynamic_limit_active_set(
+    endpoint_state,
+    free_residual,
+    descriptors: Iterable[LimitedStateDescriptor],
+    modes: Mapping[int, DynamicLimitMode | str],
+    *,
+    state_tolerance: float,
+    release_tolerance: float,
+    time: float | None = None,
+    stage_or_endpoint: str | None = None,
+    active_set_iterations: int | None = None,
+) -> tuple[
+    dict[int, DynamicLimitMode], bool, dict[str, Any], list[dict[str, Any]]
+]:
+    """Update implicit limiter modes from endpoint and free-row residuals."""
+    descriptors = list(descriptors)
+    endpoint_state = np.asarray(endpoint_state, dtype=float)
+    free_residual = np.asarray(free_residual, dtype=float)
+    complementarity = evaluate_dynamic_limit_complementarity(
+        endpoint_state,
+        free_residual,
+        descriptors,
+        modes,
+        state_tolerance=state_tolerance,
+        release_tolerance=release_tolerance,
+    )
+    updated = {
+        descriptor.state_index: _mode_for(modes, descriptor)
+        for descriptor in descriptors
+    }
+    events = []
+    for descriptor in descriptors:
+        state_index = descriptor.state_index
+        mode = updated[state_index]
+        if not descriptor.enabled:
+            updated[state_index] = DynamicLimitMode.FREE
+            continue
+        value = float(endpoint_state[state_index])
+        residual = float(free_residual[state_index])
+        lower = float(descriptor.lower_bound)
+        upper = float(descriptor.upper_bound)
+        side = None
+        action = None
+        bound = None
+        next_mode = mode
+        if mode == DynamicLimitMode.FREE:
+            if value > upper + state_tolerance:
+                side = "upper"
+                action = "activate"
+                bound = upper
+                next_mode = DynamicLimitMode.UPPER_ACTIVE
+            elif value < lower - state_tolerance:
+                side = "lower"
+                action = "activate"
+                bound = lower
+                next_mode = DynamicLimitMode.LOWER_ACTIVE
+        elif (
+            mode == DynamicLimitMode.UPPER_ACTIVE
+            and residual > release_tolerance
+        ):
+            side = "upper"
+            action = "release"
+            bound = upper
+            next_mode = DynamicLimitMode.FREE
+        elif (
+            mode == DynamicLimitMode.LOWER_ACTIVE
+            and residual < -release_tolerance
+        ):
+            side = "lower"
+            action = "release"
+            bound = lower
+            next_mode = DynamicLimitMode.FREE
+        if action is not None:
+            updated[state_index] = next_mode
+            events.append(
+                _event_record(
+                    descriptor,
+                    side=side,
+                    action=action,
+                    bound=bound,
+                    state_before=value,
+                    state_after=value,
+                    free_residual=residual,
+                    time=time,
+                    stage_or_endpoint=stage_or_endpoint,
+                    active_set_iterations=active_set_iterations,
+                )
+            )
+    changed = any(
+        updated[descriptor.state_index] != _mode_for(modes, descriptor)
+        for descriptor in descriptors
+    )
+    return updated, changed, complementarity, events
+
+
+def validate_initial_dynamic_limits(
+    z0,
+    descriptors: Iterable[LimitedStateDescriptor],
+    *,
+    enforce_dynamic_limits: bool,
+    dynamic_limit_tolerance: float,
+    dynamic_limit_release_tolerance: float,
+    max_dynamic_limit_iterations: int,
+) -> dict[str, Any]:
+    """Validate enabled limited states without projecting the initial vector."""
+    z0 = np.asarray(z0, dtype=float)
+    descriptors = list(descriptors)
+    enabled_descriptors = [item for item in descriptors if item.enabled]
+    checked_descriptors = enabled_descriptors if enforce_dynamic_limits else []
+    tolerance = float(dynamic_limit_tolerance)
+    failure_reasons: list[str] = []
+    violations: list[dict[str, Any]] = []
+
+    def record_reason(reason: str) -> None:
+        if reason not in failure_reasons:
+            failure_reasons.append(reason)
+
+    for descriptor in checked_descriptors:
+        lower = float(descriptor.lower_bound)
+        upper = float(descriptor.upper_bound)
+        value = float(z0[descriptor.state_index])
+
+        if not math.isfinite(lower) or not math.isfinite(upper):
+            record_reason("non_finite_bounds")
+            violations.append(
+                _violation_record(
+                    descriptor,
+                    value=value,
+                    side="invalid",
+                    bound=None,
+                    violation=None,
+                )
+            )
+            continue
+        if lower == upper:
+            record_reason("degenerate_bounds")
+            violations.append(
+                _violation_record(
+                    descriptor,
+                    value=value,
+                    side="invalid",
+                    bound=lower,
+                    violation=0.0,
+                )
+            )
+            continue
+        if lower > upper:
+            record_reason("inverted_bounds")
+            violations.append(
+                _violation_record(
+                    descriptor,
+                    value=value,
+                    side="invalid",
+                    bound=None,
+                    violation=lower - upper,
+                )
+            )
+            continue
+        if not math.isfinite(value):
+            record_reason("non_finite_initial_state")
+            violations.append(
+                _violation_record(
+                    descriptor,
+                    value=value,
+                    side="invalid",
+                    bound=None,
+                    violation=None,
+                )
+            )
+            continue
+        if value < lower - tolerance:
+            record_reason("initial_state_below_lower_bound")
+            violations.append(
+                _violation_record(
+                    descriptor,
+                    value=value,
+                    side="lower",
+                    bound=lower,
+                    violation=lower - value,
+                )
+            )
+        elif value > upper + tolerance:
+            record_reason("initial_state_above_upper_bound")
+            violations.append(
+                _violation_record(
+                    descriptor,
+                    value=value,
+                    side="upper",
+                    bound=upper,
+                    violation=value - upper,
+                )
+            )
+
+    diagnostics = {
+        "enabled": bool(enforce_dynamic_limits),
+        "dynamic_limit_tolerance": tolerance,
+        "dynamic_limit_release_tolerance": float(
+            dynamic_limit_release_tolerance
+        ),
+        "max_dynamic_limit_iterations": int(max_dynamic_limit_iterations),
+        "discovered_state_count": len(descriptors),
+        "enabled_state_count": len(enabled_descriptors),
+        "initialization": {
+            "valid": not failure_reasons,
+            "checked_state_count": len(checked_descriptors),
+            "failure_reasons": failure_reasons,
+            "violation_count": len(violations),
+            "violations": violations,
+        },
+        "events": [],
+    }
+    if failure_reasons:
+        raise DynamicLimitError(diagnostics)
+    return diagnostics

--- a/uqgrid/simulation/dynamics.py
+++ b/uqgrid/simulation/dynamics.py
@@ -96,6 +96,16 @@ from uqgrid.simulation.pflow import (
 from uqgrid.simulation.gradients import gradient_p, gradient_xp, gradient_pp
 from uqgrid.simulation.residual import residual_function
 from uqgrid.simulation.herk import integrate_system_herk
+from uqgrid.simulation.dynamic_limits import (
+    DynamicLimitError,
+    DynamicLimitMode,
+    _contextualize_dynamic_limit_runtime_error,
+    collect_limited_state_descriptors,
+    initialize_dynamic_limit_modes,
+    project_limited_derivatives,
+    update_dynamic_limit_active_set,
+    validate_initial_dynamic_limits,
+)
 from uqgrid.simulation.jacobian import residual_jacobian
 from uqgrid.simulation.timing import build_integration_schedule
 from uqgrid.utils.tools import (
@@ -748,6 +758,1085 @@ def function_beuler_wrapper(z, zold, h, psys, theta):
     return F
 
 
+def _assemble_beuler_residual(F, z, zold, h, psys, theta):
+    """Assemble the ordinary backward-Euler endpoint residual in place."""
+    residual_function(F, z, theta, psys)
+    ndiff = psys.num_dof_dif
+    F[:ndiff] = z[:ndiff] - zold[:ndiff] - h * F[:ndiff]
+
+
+def _assemble_cn_residual(
+    F, z, zold, h, start_derivative, psys, theta
+):
+    """Assemble the ordinary Crank-Nicolson endpoint residual in place."""
+    residual_function(F, z, theta, psys)
+    ndiff = psys.num_dof_dif
+    F[:ndiff] = (
+        z[:ndiff]
+        - zold[:ndiff]
+        - 0.5 * h * (start_derivative[:ndiff] + F[:ndiff])
+    )
+
+
+def _effective_cn_start_derivative(
+    zold,
+    theta,
+    psys,
+    descriptors,
+    modes,
+    *,
+    tolerance,
+    time=None,
+):
+    """Return the raw start derivative with inherited outward modes blocked."""
+    raw_derivative = np.empty_like(zold)
+    residual_function(raw_derivative, zold, theta, psys)
+    active_descriptors = [
+        descriptor
+        for descriptor in descriptors
+        if DynamicLimitMode(modes[descriptor.state_index])
+        != DynamicLimitMode.FREE
+    ]
+    effective, _ = project_limited_derivatives(
+        zold,
+        raw_derivative,
+        active_descriptors,
+        tolerance=tolerance,
+        time=time,
+        stage_or_endpoint="start",
+    )
+    return effective
+
+
+def _active_limit_bound(descriptor, mode):
+    mode = DynamicLimitMode(mode)
+    if mode == DynamicLimitMode.UPPER_ACTIVE:
+        return descriptor.upper_bound
+    if mode == DynamicLimitMode.LOWER_ACTIVE:
+        return descriptor.lower_bound
+    return None
+
+
+def _apply_beuler_active_rows(F, J, z, descriptors, modes):
+    """Replace active BE equations with bound equations and identity rows."""
+    diagonal_column = np.zeros(1, dtype=np.int64)
+    diagonal_value = np.ones(1, dtype=np.float64)
+    for descriptor in descriptors:
+        bound = _active_limit_bound(
+            descriptor, modes[descriptor.state_index]
+        )
+        if bound is None:
+            continue
+        state_index = descriptor.state_index
+        F[state_index] = z[state_index] - bound
+        if J is not None:
+            csr_mult_row(J.data, J.indptr, J.indices, state_index, 0.0)
+            diagonal_column[0] = state_index
+            csr_set_row(
+                J.data,
+                J.indptr,
+                J.indices,
+                1,
+                state_index,
+                diagonal_column,
+                diagonal_value,
+            )
+
+
+def _limit_mode_signature(descriptors, modes):
+    return tuple(
+        DynamicLimitMode(modes[item.state_index]).value
+        for item in descriptors
+    )
+
+
+def _json_finite(value):
+    value = float(value)
+    return value if np.isfinite(value) else None
+
+
+def _dynamic_limit_runtime_error(
+    reason,
+    *,
+    method,
+    operation,
+    message,
+    backend,
+    nonlinear_solver,
+    endpoint_time,
+    step_size,
+    active_set_iterations,
+    newton_iterations,
+    residual_norm,
+    descriptors,
+    modes,
+    visited_signatures,
+    complementarity,
+    events,
+    solver_diagnostics=None,
+):
+    solver_diagnostics = dict(solver_diagnostics or {})
+    solver_diagnostics.pop("failure_reason", None)
+    return DynamicLimitError(
+        {
+            "enabled": True,
+            "phase": "runtime",
+            "method": method,
+            "backend": backend,
+            "nonlinear_solver": nonlinear_solver,
+            "operation": operation,
+            "message": message,
+            "failure_reasons": [reason],
+            "time": _json_finite(endpoint_time),
+            "step_size": _json_finite(step_size),
+            "active_set_iterations": int(active_set_iterations),
+            "newton_iterations": int(newton_iterations),
+            "residual_norm": _json_finite(residual_norm),
+            "modes": [
+                {
+                    "state_index": item.state_index,
+                    "mode": DynamicLimitMode(modes[item.state_index]).value,
+                }
+                for item in descriptors
+            ],
+            "visited_mode_signatures": [
+                list(signature) for signature in visited_signatures
+            ],
+            "complementarity": complementarity,
+            "events": list(events),
+            **solver_diagnostics,
+        }
+    )
+
+
+def _solve_beuler_fixed_active_set(
+    zold,
+    theta,
+    h,
+    psys,
+    F,
+    J,
+    *,
+    descriptors,
+    modes,
+    newton_tol,
+    newton_max_iter,
+    verbose=False,
+):
+    """Solve one smooth BE system for a fixed dynamic-limit active set."""
+    z = np.array(zold, dtype=float, copy=True)
+    for descriptor in descriptors:
+        bound = _active_limit_bound(
+            descriptor, modes[descriptor.state_index]
+        )
+        if bound is not None:
+            z[descriptor.state_index] = bound
+
+    _assemble_beuler_residual(F, z, zold, h, psys, theta)
+    _apply_beuler_active_rows(F, None, z, descriptors, modes)
+    residual_norm = np.linalg.norm(F)
+    iteration = 0
+    if verbose:
+        logger.info("Iteration %d. Residual norm: %g", iteration, residual_norm)
+
+    while residual_norm > newton_tol and iteration < newton_max_iter:
+        iteration += 1
+        residual_jacobian(J, z, theta, psys)
+        jacobian_beuler(J, psys.num_dof_dif, h)
+        _apply_beuler_active_rows(F, J, z, descriptors, modes)
+        delta = spsolve(J, F)
+        if not np.all(np.isfinite(delta)):
+            return z, iteration, np.inf, False
+        z = z - delta
+        _assemble_beuler_residual(F, z, zold, h, psys, theta)
+        _apply_beuler_active_rows(F, None, z, descriptors, modes)
+        residual_norm = np.linalg.norm(F)
+        if not np.isfinite(residual_norm):
+            return z, iteration, residual_norm, False
+        if verbose:
+            logger.info(
+                "Iteration %d. Residual norm: %g", iteration, residual_norm
+            )
+
+    return z, iteration, residual_norm, residual_norm <= newton_tol
+
+
+def _integrate_implicit_active_set(
+    zold,
+    theta,
+    h,
+    psys,
+    F,
+    *,
+    descriptors,
+    modes,
+    state_tolerance,
+    release_tolerance,
+    max_active_set_iterations,
+    endpoint_time,
+    fixed_set_solver,
+    assemble_free_residual,
+    method,
+    operation,
+    failure_message,
+    backend,
+    nonlinear_solver,
+    prior_events=(),
+):
+    """Advance one implicit interval with a backend-supplied fixed-set solve."""
+    descriptors = list(descriptors)
+    modes = dict(modes)
+    interval_events = []
+    signature = _limit_mode_signature(descriptors, modes)
+    visited_signatures = [signature]
+    seen_signatures = {signature}
+    complementarity = None
+    residual_norm = np.inf
+    newton_iterations = 0
+    solver_diagnostics = {}
+
+    for active_set_iteration in range(1, max_active_set_iterations + 1):
+        solve_result = fixed_set_solver(modes)
+        if len(solve_result) == 4:
+            z, newton_iterations, residual_norm, converged = solve_result
+            solver_diagnostics = {}
+        else:
+            (
+                z,
+                newton_iterations,
+                residual_norm,
+                converged,
+                solver_diagnostics,
+            ) = solve_result
+        if not converged:
+            raise _dynamic_limit_runtime_error(
+                solver_diagnostics.get(
+                    "failure_reason", "newton_nonconvergence"
+                ),
+                method=method,
+                operation=operation,
+                message=failure_message,
+                backend=backend,
+                nonlinear_solver=nonlinear_solver,
+                endpoint_time=endpoint_time,
+                step_size=h,
+                active_set_iterations=active_set_iteration,
+                newton_iterations=newton_iterations,
+                residual_norm=residual_norm,
+                descriptors=descriptors,
+                modes=modes,
+                visited_signatures=visited_signatures,
+                complementarity=complementarity,
+                events=[*prior_events, *interval_events],
+                solver_diagnostics=solver_diagnostics,
+            )
+
+        free_residual = np.empty_like(F)
+        assemble_free_residual(free_residual, z)
+        try:
+            updated_modes, changed, complementarity, transition_events = (
+                update_dynamic_limit_active_set(
+                    z,
+                    free_residual,
+                    descriptors,
+                    modes,
+                    state_tolerance=state_tolerance,
+                    release_tolerance=release_tolerance,
+                    time=endpoint_time,
+                    stage_or_endpoint="endpoint",
+                    active_set_iterations=active_set_iteration,
+                )
+            )
+        except DynamicLimitError as exc:
+            reasons = exc.diagnostics.get("failure_reasons", [])
+            reason = reasons[0] if reasons else "active_set_evaluation_failed"
+            raise _dynamic_limit_runtime_error(
+                reason,
+                method=method,
+                operation=operation,
+                message=failure_message,
+                backend=backend,
+                nonlinear_solver=nonlinear_solver,
+                endpoint_time=endpoint_time,
+                step_size=h,
+                active_set_iterations=active_set_iteration,
+                newton_iterations=newton_iterations,
+                residual_norm=residual_norm,
+                descriptors=descriptors,
+                modes=modes,
+                visited_signatures=visited_signatures,
+                complementarity=exc.diagnostics,
+                events=[*prior_events, *interval_events],
+                solver_diagnostics=solver_diagnostics,
+            ) from exc
+        for event in transition_events:
+            if event["action"] == "activate":
+                event["state_after"] = event["bound"]
+        interval_events.extend(transition_events)
+
+        if not changed:
+            if complementarity["consistent"]:
+                return z, updated_modes, interval_events
+            raise _dynamic_limit_runtime_error(
+                "inconsistent_active_set",
+                method=method,
+                operation=operation,
+                message=failure_message,
+                backend=backend,
+                nonlinear_solver=nonlinear_solver,
+                endpoint_time=endpoint_time,
+                step_size=h,
+                active_set_iterations=active_set_iteration,
+                newton_iterations=newton_iterations,
+                residual_norm=residual_norm,
+                descriptors=descriptors,
+                modes=updated_modes,
+                visited_signatures=visited_signatures,
+                complementarity=complementarity,
+                events=[*prior_events, *interval_events],
+                solver_diagnostics=solver_diagnostics,
+            )
+
+        signature = _limit_mode_signature(descriptors, updated_modes)
+        if signature in seen_signatures:
+            raise _dynamic_limit_runtime_error(
+                "active_set_cycle",
+                method=method,
+                operation=operation,
+                message=failure_message,
+                backend=backend,
+                nonlinear_solver=nonlinear_solver,
+                endpoint_time=endpoint_time,
+                step_size=h,
+                active_set_iterations=active_set_iteration,
+                newton_iterations=newton_iterations,
+                residual_norm=residual_norm,
+                descriptors=descriptors,
+                modes=updated_modes,
+                visited_signatures=[*visited_signatures, signature],
+                complementarity=complementarity,
+                events=[*prior_events, *interval_events],
+                solver_diagnostics=solver_diagnostics,
+            )
+        seen_signatures.add(signature)
+        visited_signatures.append(signature)
+        modes = updated_modes
+
+    raise _dynamic_limit_runtime_error(
+        "active_set_iteration_limit",
+        method=method,
+        operation=operation,
+        message=failure_message,
+        backend=backend,
+        nonlinear_solver=nonlinear_solver,
+        endpoint_time=endpoint_time,
+        step_size=h,
+        active_set_iterations=max_active_set_iterations,
+        newton_iterations=newton_iterations,
+        residual_norm=residual_norm,
+        descriptors=descriptors,
+        modes=modes,
+        visited_signatures=visited_signatures,
+        complementarity=complementarity,
+        events=[*prior_events, *interval_events],
+        solver_diagnostics=solver_diagnostics,
+    )
+
+
+def _integrate_beuler_with_dynamic_limits(
+    zold,
+    theta,
+    h,
+    psys,
+    F,
+    J,
+    *,
+    descriptors,
+    modes,
+    state_tolerance,
+    release_tolerance,
+    max_active_set_iterations,
+    endpoint_time,
+    newton_tol,
+    newton_max_iter,
+    prior_events=(),
+    verbose=False,
+):
+    """Advance one native BE interval with a directional active set."""
+
+    def solve_fixed_set(current_modes):
+        return _solve_beuler_fixed_active_set(
+            zold,
+            theta,
+            h,
+            psys,
+            F,
+            J,
+            descriptors=descriptors,
+            modes=current_modes,
+            newton_tol=newton_tol,
+            newton_max_iter=newton_max_iter,
+            verbose=verbose,
+        )
+
+    def assemble_free_residual(free_residual, endpoint):
+        _assemble_beuler_residual(
+            free_residual, endpoint, zold, h, psys, theta
+        )
+
+    return _integrate_implicit_active_set(
+        zold,
+        theta,
+        h,
+        psys,
+        F,
+        descriptors=descriptors,
+        modes=modes,
+        state_tolerance=state_tolerance,
+        release_tolerance=release_tolerance,
+        max_active_set_iterations=max_active_set_iterations,
+        endpoint_time=endpoint_time,
+        fixed_set_solver=solve_fixed_set,
+        assemble_free_residual=assemble_free_residual,
+        method="beuler",
+        operation="beuler_active_set",
+        failure_message="Backward-Euler dynamic-limit solve failed",
+        backend="native",
+        nonlinear_solver="scipy_sparse_newton",
+        prior_events=prior_events,
+    )
+
+
+def _petsc_snes_reason_name(PETSc, reason):
+    reason_value = int(reason)
+    for name in dir(PETSc.SNES.ConvergedReason):
+        if not name.isupper():
+            continue
+        if int(getattr(PETSc.SNES.ConvergedReason, name)) == reason_value:
+            return name.lower()
+    return f"unknown_{reason_value}"
+
+
+class _PETScBEActiveSetProblem:
+    """Explicit BE residual and Jacobian callbacks for one SNES workspace."""
+
+    def __init__(self, psys, theta, residual, jacobian):
+        self.psys = psys
+        self.theta = theta
+        self.residual = residual
+        self.jacobian = jacobian
+        self.zold = None
+        self.h = None
+        self.descriptors = ()
+        self.modes = {}
+
+    def set_interval(self, zold, h, descriptors, modes):
+        self.zold = zold
+        self.h = h
+        self.descriptors = descriptors
+        self.modes = modes
+
+    def function(self, snes, x, f):
+        z = np.array(x[:], dtype=float, copy=True)
+        _assemble_beuler_residual(
+            self.residual,
+            z,
+            self.zold,
+            self.h,
+            self.psys,
+            self.theta,
+        )
+        _apply_beuler_active_rows(
+            self.residual,
+            None,
+            z,
+            self.descriptors,
+            self.modes,
+        )
+        f.setArray(np.array(self.residual, copy=True))
+        f.assemble()
+
+    def jacobian_function(self, snes, x, J, P):
+        z = np.array(x[:], dtype=float, copy=True)
+        residual_jacobian(self.jacobian, z, self.theta, self.psys)
+        jacobian_beuler(self.jacobian, self.psys.num_dof_dif, self.h)
+        _apply_beuler_active_rows(
+            self.residual,
+            self.jacobian,
+            z,
+            self.descriptors,
+            self.modes,
+        )
+        P.setValuesCSR(
+            self.jacobian.indptr,
+            self.jacobian.indices,
+            self.jacobian.data,
+        )
+        P.assemble()
+        if J != P:
+            J.setValuesCSR(
+                self.jacobian.indptr,
+                self.jacobian.indices,
+                self.jacobian.data,
+            )
+            J.assemble()
+        return True
+
+
+class _PETScCNActiveSetProblem:
+    """Explicit CN residual and Jacobian callbacks for one SNES workspace."""
+
+    def __init__(self, psys, theta, residual, jacobian):
+        self.psys = psys
+        self.theta = theta
+        self.residual = residual
+        self.jacobian = jacobian
+        self.zold = None
+        self.h = None
+        self.start_derivative = None
+        self.descriptors = ()
+        self.modes = {}
+
+    def set_interval(
+        self, zold, h, descriptors, modes, *, start_derivative
+    ):
+        self.zold = zold
+        self.h = h
+        self.start_derivative = np.array(
+            start_derivative, dtype=float, copy=True
+        )
+        self.start_derivative.setflags(write=False)
+        self.descriptors = descriptors
+        self.modes = modes
+
+    def function(self, snes, x, f):
+        z = np.array(x[:], dtype=float, copy=True)
+        _assemble_cn_residual(
+            self.residual,
+            z,
+            self.zold,
+            self.h,
+            self.start_derivative,
+            self.psys,
+            self.theta,
+        )
+        _apply_beuler_active_rows(
+            self.residual,
+            None,
+            z,
+            self.descriptors,
+            self.modes,
+        )
+        f.setArray(np.array(self.residual, copy=True))
+        f.assemble()
+
+    def jacobian_function(self, snes, x, J, P):
+        z = np.array(x[:], dtype=float, copy=True)
+        residual_jacobian(self.jacobian, z, self.theta, self.psys)
+        jacobian_beuler(
+            self.jacobian, self.psys.num_dof_dif, 0.5 * self.h
+        )
+        _apply_beuler_active_rows(
+            self.residual,
+            self.jacobian,
+            z,
+            self.descriptors,
+            self.modes,
+        )
+        P.setValuesCSR(
+            self.jacobian.indptr,
+            self.jacobian.indices,
+            self.jacobian.data,
+        )
+        P.assemble()
+        if J != P:
+            J.setValuesCSR(
+                self.jacobian.indptr,
+                self.jacobian.indices,
+                self.jacobian.data,
+            )
+            J.assemble()
+        return True
+
+
+_PETSC_VI_SNES_TYPES = {"vinewtonrsls", "vinewtonssls"}
+
+
+class _PETScActiveSetWorkspace:
+    """Reusable ordinary-SNES objects for one limited implicit method."""
+
+    _problem_class = None
+
+    def __init__(
+        self,
+        PETSc,
+        psys,
+        theta,
+        residual,
+        jacobian,
+        *,
+        newton_tol,
+        newton_max_iter,
+    ):
+        self.PETSc = PETSc
+        self.problem = self._problem_class(
+            psys, theta, residual, jacobian
+        )
+        system_size = jacobian.shape[0]
+        communicator = PETSc.COMM_SELF
+
+        self.solution = PETSc.Vec().createSeq(
+            system_size, comm=communicator
+        )
+        self.function_vector = self.solution.duplicate()
+
+        self.matrix = PETSc.Mat()
+        self.matrix.create(comm=communicator)
+        self.matrix.setSizes([system_size, system_size])
+        self.matrix.setType("seqaij")
+        self.matrix.setPreallocationCSR(
+            [jacobian.indptr, jacobian.indices, jacobian.data]
+        )
+        self.matrix.assemblyBegin()
+        self.matrix.assemblyEnd()
+
+        self.snes = PETSc.SNES().create(comm=communicator)
+        self.snes.setType(PETSc.SNES.Type.NEWTONLS)
+        self.snes.setFunction(self.problem.function, self.function_vector)
+        self.snes.setJacobian(
+            self.problem.jacobian_function, self.matrix, self.matrix
+        )
+        self.snes.setTolerances(
+            rtol=0.0,
+            atol=newton_tol,
+            stol=0.0,
+            max_it=newton_max_iter,
+        )
+        self.snes.setFromOptions()
+        self.snes_type = str(self.snes.getType()).lower()
+        try:
+            _validate_petsc_snes_type(self.snes_type)
+        except ValueError:
+            self.destroy()
+            raise
+
+    def solve_fixed_active_set(
+        self, zold, h, descriptors, modes, **interval_data
+    ):
+        guess = np.array(zold, dtype=float, copy=True)
+        for descriptor in descriptors:
+            bound = _active_limit_bound(
+                descriptor, modes[descriptor.state_index]
+            )
+            if bound is not None:
+                guess[descriptor.state_index] = bound
+
+        self.problem.set_interval(
+            zold, h, descriptors, modes, **interval_data
+        )
+        self.solution.setArray(guess)
+        self.solution.assemble()
+        try:
+            self.snes.solve(None, self.solution)
+            reason = int(self.snes.getConvergedReason())
+            iterations = int(self.snes.getIterationNumber())
+            residual_norm = float(self.snes.getFunctionNorm())
+            endpoint = np.array(self.solution[:], dtype=float, copy=True)
+            diagnostics = {
+                "snes_type": self.snes_type,
+                "snes_converged_reason": reason,
+                "snes_converged_reason_name": _petsc_snes_reason_name(
+                    self.PETSc, reason
+                ),
+                "snes_iterations": iterations,
+                "snes_function_norm": _json_finite(residual_norm),
+            }
+            if hasattr(self.snes, "getLinearSolveIterations"):
+                diagnostics["snes_linear_iterations"] = int(
+                    self.snes.getLinearSolveIterations()
+                )
+            if reason <= 0:
+                diagnostics["failure_reason"] = "snes_nonconvergence"
+            return (
+                endpoint,
+                iterations,
+                residual_norm,
+                reason > 0,
+                diagnostics,
+            )
+        except self.PETSc.Error as exc:
+            return (
+                guess,
+                0,
+                np.inf,
+                False,
+                {
+                    "failure_reason": "snes_nonconvergence",
+                    "snes_type": self.snes_type,
+                    "snes_converged_reason": None,
+                    "snes_converged_reason_name": "petsc_error",
+                    "snes_iterations": 0,
+                    "snes_function_norm": None,
+                    "snes_error": str(exc),
+                },
+            )
+
+    def destroy(self):
+        for obj in (
+            getattr(self, "snes", None),
+            getattr(self, "matrix", None),
+            getattr(self, "function_vector", None),
+            getattr(self, "solution", None),
+        ):
+            if obj is not None:
+                obj.destroy()
+
+
+class _PETScBEActiveSetWorkspace(_PETScActiveSetWorkspace):
+    """Reusable ordinary-SNES objects for limited PETSc backward Euler."""
+
+    _problem_class = _PETScBEActiveSetProblem
+
+
+class _PETScCNActiveSetWorkspace(_PETScActiveSetWorkspace):
+    """Reusable ordinary-SNES objects for limited PETSc Crank-Nicolson."""
+
+    _problem_class = _PETScCNActiveSetProblem
+
+
+def _validate_petsc_snes_type(snes_type):
+    snes_type = str(snes_type).lower()
+    if snes_type in _PETSC_VI_SNES_TYPES:
+        raise ValueError(
+            "PETSc variational-inequality SNES types are unsupported for "
+            "hard dynamic limits. Use ordinary SNES/Newton options; UQGrid "
+            "manages the active set explicitly."
+        )
+    return snes_type
+
+
+def _integrate_petsc_beuler_with_dynamic_limits(
+    zold,
+    theta,
+    h,
+    psys,
+    F,
+    J,
+    *,
+    workspace,
+    descriptors,
+    modes,
+    state_tolerance,
+    release_tolerance,
+    max_active_set_iterations,
+    endpoint_time,
+    newton_tol,
+    newton_max_iter,
+    prior_events=(),
+    verbose=False,
+):
+    """Advance one PETSc SNES BE interval with a directional active set."""
+
+    def solve_fixed_set(current_modes):
+        return workspace.solve_fixed_active_set(
+            zold, h, descriptors, current_modes
+        )
+
+    def assemble_free_residual(free_residual, endpoint):
+        _assemble_beuler_residual(
+            free_residual, endpoint, zold, h, psys, theta
+        )
+
+    return _integrate_implicit_active_set(
+        zold,
+        theta,
+        h,
+        psys,
+        F,
+        descriptors=descriptors,
+        modes=modes,
+        state_tolerance=state_tolerance,
+        release_tolerance=release_tolerance,
+        max_active_set_iterations=max_active_set_iterations,
+        endpoint_time=endpoint_time,
+        fixed_set_solver=solve_fixed_set,
+        assemble_free_residual=assemble_free_residual,
+        method="beuler",
+        operation="beuler_active_set",
+        failure_message="Backward-Euler dynamic-limit solve failed",
+        backend="petsc",
+        nonlinear_solver="petsc_snes",
+        prior_events=prior_events,
+    )
+
+
+def _integrate_petsc_cn_with_dynamic_limits(
+    zold,
+    theta,
+    h,
+    psys,
+    F,
+    J,
+    *,
+    workspace,
+    descriptors,
+    modes,
+    state_tolerance,
+    release_tolerance,
+    max_active_set_iterations,
+    endpoint_time,
+    newton_tol,
+    newton_max_iter,
+    prior_events=(),
+    verbose=False,
+):
+    """Advance one PETSc SNES CN interval with a directional active set."""
+    start_time = endpoint_time - h
+    try:
+        start_derivative = _effective_cn_start_derivative(
+            zold,
+            theta,
+            psys,
+            descriptors,
+            modes,
+            tolerance=state_tolerance,
+            time=start_time,
+        )
+    except DynamicLimitError as exc:
+        raise _contextualize_dynamic_limit_runtime_error(
+            exc,
+            method="cn",
+            backend="petsc",
+            time=start_time,
+            stage_or_endpoint="start",
+            prior_events=prior_events,
+        ) from exc
+    start_derivative.setflags(write=False)
+
+    def solve_fixed_set(current_modes):
+        return workspace.solve_fixed_active_set(
+            zold,
+            h,
+            descriptors,
+            current_modes,
+            start_derivative=start_derivative,
+        )
+
+    def assemble_free_residual(free_residual, endpoint):
+        _assemble_cn_residual(
+            free_residual,
+            endpoint,
+            zold,
+            h,
+            start_derivative,
+            psys,
+            theta,
+        )
+
+    return _integrate_implicit_active_set(
+        zold,
+        theta,
+        h,
+        psys,
+        F,
+        descriptors=descriptors,
+        modes=modes,
+        state_tolerance=state_tolerance,
+        release_tolerance=release_tolerance,
+        max_active_set_iterations=max_active_set_iterations,
+        endpoint_time=endpoint_time,
+        fixed_set_solver=solve_fixed_set,
+        assemble_free_residual=assemble_free_residual,
+        method="cn",
+        operation="cn_active_set",
+        failure_message="Crank-Nicolson dynamic-limit solve failed",
+        backend="petsc",
+        nonlinear_solver="petsc_snes",
+        prior_events=prior_events,
+    )
+
+
+def _integrate_system_petsc_implicit_limits(
+    PETSc,
+    psys,
+    config,
+    theta,
+    z0,
+    tvec,
+    schedule,
+    fault,
+    residual,
+    jacobian,
+    descriptors,
+    dynamic_limit_diagnostics,
+    *,
+    workspace_class,
+    interval_stepper,
+    method,
+):
+    """Run one limited PETSc implicit method over the shared schedule."""
+    workspace = workspace_class(
+        PETSc,
+        psys,
+        theta,
+        residual,
+        jacobian,
+        newton_tol=config.newton_tol,
+        newton_max_iter=config.newton_max_iter,
+    )
+    modes = initialize_dynamic_limit_modes(descriptors)
+    history = np.zeros((z0.size, len(tvec)))
+    z = np.array(z0, dtype=float, copy=True)
+    history[:, 0] = z
+
+    try:
+        for i in range(1, len(tvec)):
+            h_step = tvec[i] - tvec[i - 1]
+            if config.verbose:
+                logger.info(
+                    "PETSc SNES %s step: %i. Time: %g (sec)",
+                    method,
+                    i,
+                    tvec[i],
+                )
+            z, modes, events = interval_stepper(
+                z,
+                theta,
+                h_step,
+                psys,
+                residual,
+                jacobian,
+                workspace=workspace,
+                descriptors=descriptors,
+                modes=modes,
+                state_tolerance=config.dynamic_limit_tolerance,
+                release_tolerance=config.dynamic_limit_release_tolerance,
+                max_active_set_iterations=config.max_dynamic_limit_iterations,
+                endpoint_time=tvec[i],
+                newton_tol=config.newton_tol,
+                newton_max_iter=config.newton_max_iter,
+                prior_events=dynamic_limit_diagnostics["events"],
+                verbose=config.verbose,
+            )
+            dynamic_limit_diagnostics["events"].extend(events)
+
+            if i == schedule.fault_on_index:
+                if config.verbose:
+                    logger.info("Apply fault")
+                fault.apply()
+                z, _, _, _ = integrate(
+                    z,
+                    theta,
+                    0.0,
+                    psys,
+                    residual,
+                    jacobian,
+                    None,
+                    verbose=config.verbose,
+                    fsolve=False,
+                    newton_tol=config.newton_tol,
+                    newton_max_iter=config.newton_max_iter,
+                    uold=None,
+                    vold=None,
+                    mold=None,
+                )
+            if i == schedule.fault_off_index:
+                if config.verbose:
+                    logger.info("Remove fault")
+                fault.remove()
+                z, _, _, _ = integrate(
+                    z,
+                    theta,
+                    0.0,
+                    psys,
+                    residual,
+                    jacobian,
+                    None,
+                    verbose=config.verbose,
+                    fsolve=False,
+                    newton_tol=config.newton_tol,
+                    newton_max_iter=config.newton_max_iter,
+                    uold=None,
+                    vold=None,
+                    mold=None,
+                )
+            history[:, i] = z
+    finally:
+        if fault is not None:
+            fault.remove()
+        workspace.destroy()
+
+    return history
+
+
+def _integrate_system_petsc_beuler_limits(
+    PETSc,
+    psys,
+    config,
+    theta,
+    z0,
+    tvec,
+    schedule,
+    fault,
+    residual,
+    jacobian,
+    descriptors,
+    dynamic_limit_diagnostics,
+):
+    """Run limited PETSc BE directly over the normalized shared schedule."""
+    return _integrate_system_petsc_implicit_limits(
+        PETSc,
+        psys,
+        config,
+        theta,
+        z0,
+        tvec,
+        schedule,
+        fault,
+        residual,
+        jacobian,
+        descriptors,
+        dynamic_limit_diagnostics,
+        workspace_class=_PETScBEActiveSetWorkspace,
+        interval_stepper=_integrate_petsc_beuler_with_dynamic_limits,
+        method="beuler",
+    )
+
+
+def _integrate_system_petsc_cn_limits(
+    PETSc,
+    psys,
+    config,
+    theta,
+    z0,
+    tvec,
+    schedule,
+    fault,
+    residual,
+    jacobian,
+    descriptors,
+    dynamic_limit_diagnostics,
+):
+    """Run limited PETSc CN directly over the normalized shared schedule."""
+    return _integrate_system_petsc_implicit_limits(
+        PETSc,
+        psys,
+        config,
+        theta,
+        z0,
+        tvec,
+        schedule,
+        fault,
+        residual,
+        jacobian,
+        descriptors,
+        dynamic_limit_diagnostics,
+        workspace_class=_PETScCNActiveSetWorkspace,
+        interval_stepper=_integrate_petsc_cn_with_dynamic_limits,
+        method="cn",
+    )
+
+
 def function_beuler_latin_wrapper(z, zold, h, psys, theta):
     NDIFFEQ = psys.num_dof_dif
     F = np.zeros(len(z))
@@ -1008,6 +2097,41 @@ def _initialize_system_from_config(psys: Psystem, config: IntegrationConfig):
             raise PowerFlowValidationError(pf_solution.validation)
     z0, theta = initialize_system(psys, pf_solution)
     return pf_solution, z0, theta
+
+
+def _initialize_integration_state(
+    psys: Psystem,
+    config: IntegrationConfig,
+    ctx: Optional[IntegrationCtx] = None,
+):
+    """Initialize, apply caller overrides, and validate hard state limits."""
+    pf_solution, z0, theta = _initialize_system_from_config(psys, config)
+
+    z0_user = ctx.z0_user if ctx is not None else getattr(config, "z0_user", None)
+    theta_user = (
+        ctx.theta_user if ctx is not None else getattr(config, "theta_user", None)
+    )
+    if z0_user is not None:
+        if z0_user.shape[0] != z0.shape[0]:
+            raise ValueError("Provided initial state does not match system size.")
+        z0 = z0_user
+    if theta_user is not None:
+        if theta_user.shape[0] != theta.shape[0]:
+            raise ValueError("Provided theta does not match system parameters.")
+        theta = theta_user
+
+    descriptors = collect_limited_state_descriptors(psys, theta)
+    dynamic_limit_diagnostics = validate_initial_dynamic_limits(
+        z0,
+        descriptors,
+        enforce_dynamic_limits=config.enforce_dynamic_limits,
+        dynamic_limit_tolerance=config.dynamic_limit_tolerance,
+        dynamic_limit_release_tolerance=(
+            config.dynamic_limit_release_tolerance
+        ),
+        max_dynamic_limit_iterations=config.max_dynamic_limit_iterations,
+    )
+    return pf_solution, z0, theta, dynamic_limit_diagnostics
 
 
 def initialize_sensitivities(volt, p_inj, psys, z, u, v):
@@ -1668,23 +2792,21 @@ def integrate_system(
     psys.power_injection=power_injection
 
     # retrieve parameters
-    pf_solution, z0, theta = _initialize_system_from_config(psys, config)
+    pf_solution, z0, theta, dynamic_limit_diagnostics = (
+        _initialize_integration_state(psys, config, ctx)
+    )
+    results["dynamic_limit_diagnostics"] = dynamic_limit_diagnostics
     if pf_solution.validation is not None:
         results["power_flow_diagnostics"] = pf_solution.validation
 
-    # Use context if provided, otherwise fallback to config attributes
-    z0_user = ctx.z0_user if ctx is not None else getattr(config, 'z0_user', None)
-    theta_user = ctx.theta_user if ctx is not None else getattr(config, 'theta_user', None)
-
-    if z0_user is not None:
-        if z0_user.shape[0] != z0.shape[0]:
-            raise ValueError("Provided initial state does not match system size.")
-        z0 = z0_user
-
-    if theta_user is not None:
-        if theta_user.shape[0] != theta.shape[0]:
-            raise ValueError("Provided theta does not match system parameters.")
-        theta = theta_user
+    limit_descriptors = []
+    if config.enforce_dynamic_limits:
+        limit_descriptors = [
+            descriptor
+            for descriptor in collect_limited_state_descriptors(psys, theta)
+            if descriptor.enabled
+        ]
+    limit_modes = initialize_dynamic_limit_modes(limit_descriptors)
 
     system_size = z0.shape[0]
     jacobian = preallocate_jacobian(psys)
@@ -1756,7 +2878,37 @@ def integrate_system(
 
     PETSc = _get_petsc_for_config(config)
 
-    if PETSc is not None:
+    if PETSc is not None and method == "beuler" and limit_descriptors:
+        history = _integrate_system_petsc_beuler_limits(
+            PETSc,
+            psys,
+            config,
+            theta,
+            z0,
+            tvec,
+            schedule,
+            fault,
+            residual,
+            jacobian,
+            limit_descriptors,
+            dynamic_limit_diagnostics,
+        )
+    elif PETSc is not None and method == "cn" and limit_descriptors:
+        history = _integrate_system_petsc_cn_limits(
+            PETSc,
+            psys,
+            config,
+            theta,
+            z0,
+            tvec,
+            schedule,
+            fault,
+            residual,
+            jacobian,
+            limit_descriptors,
+            dynamic_limit_diagnostics,
+        )
+    elif PETSc is not None:
         if verbose:
             logger.info("Convert objects to PETSc format")
         nsize = jacobian.shape[0]
@@ -2016,53 +3168,83 @@ def integrate_system(
     else:
         history = np.zeros((system_size, len(tvec)))
         history[:, 0] = np.copy(z)
-        for i in range(1, len(tvec)):
-            t_start = tvec[i - 1]
-            h_step = tvec[i] - t_start
-            if verbose:
-                logger.info("Step: %i. Time: %g (sec)", i, tvec[i])
-            if psys.signal_injectors:
-                for inj in psys.signal_injectors:
-                    inj.update(t_start, theta, psys)
-            z, u, v, m = integrate(z,
-                                theta,
-                                h_step,
-                                psys,
-                                residual,
-                                jacobian,
-                                None,
-                                verbose=verbose,
-                                fsolve=fsolve,
-                                newton_tol=newton_tol,
-                                newton_max_iter=newton_max_iter,
-                                uold=None,
-                                vold=None,
-                                mold=None)
+        try:
+            for i in range(1, len(tvec)):
+                t_start = tvec[i - 1]
+                h_step = tvec[i] - t_start
+                if verbose:
+                    logger.info("Step: %i. Time: %g (sec)", i, tvec[i])
+                if psys.signal_injectors:
+                    for inj in psys.signal_injectors:
+                        inj.update(t_start, theta, psys)
+                if limit_descriptors:
+                    z, limit_modes, limit_events = (
+                        _integrate_beuler_with_dynamic_limits(
+                            z,
+                            theta,
+                            h_step,
+                            psys,
+                            residual,
+                            jacobian,
+                            descriptors=limit_descriptors,
+                            modes=limit_modes,
+                            state_tolerance=config.dynamic_limit_tolerance,
+                            release_tolerance=(
+                                config.dynamic_limit_release_tolerance
+                            ),
+                            max_active_set_iterations=(
+                                config.max_dynamic_limit_iterations
+                            ),
+                            endpoint_time=tvec[i],
+                            newton_tol=newton_tol,
+                            newton_max_iter=newton_max_iter,
+                            prior_events=dynamic_limit_diagnostics["events"],
+                            verbose=verbose,
+                        )
+                    )
+                    dynamic_limit_diagnostics["events"].extend(limit_events)
+                else:
+                    z, u, v, m = integrate(
+                        z,
+                        theta,
+                        h_step,
+                        psys,
+                        residual,
+                        jacobian,
+                        None,
+                        verbose=verbose,
+                        fsolve=fsolve,
+                        newton_tol=newton_tol,
+                        newton_max_iter=newton_max_iter,
+                        uold=None,
+                        vold=None,
+                        mold=None,
+                    )
 
-            if i == schedule.fault_on_index:
-                if verbose:
-                    logger.info("Apply fault")
-                fault.apply()
-                z, _, _, _ = integrate(
-                    z, theta, 0.0, psys, residual, jacobian, None,
-                    verbose=verbose, fsolve=False,
-                    newton_tol=newton_tol, newton_max_iter=newton_max_iter,
-                    uold=None, vold=None, mold=None,
-                )
-            if i == schedule.fault_off_index:
-                if verbose:
-                    logger.info("Remove fault")
+                if i == schedule.fault_on_index:
+                    if verbose:
+                        logger.info("Apply fault")
+                    fault.apply()
+                    z, _, _, _ = integrate(
+                        z, theta, 0.0, psys, residual, jacobian, None,
+                        verbose=verbose, fsolve=False,
+                        newton_tol=newton_tol, newton_max_iter=newton_max_iter,
+                        uold=None, vold=None, mold=None,
+                    )
+                if i == schedule.fault_off_index:
+                    if verbose:
+                        logger.info("Remove fault")
+                    fault.remove()
+                    z, _, _, _ = integrate(
+                        z, theta, 0.0, psys, residual, jacobian, None,
+                        verbose=verbose, fsolve=False,
+                        newton_tol=newton_tol, newton_max_iter=newton_max_iter,
+                        uold=None, vold=None, mold=None,
+                    )
+                history[:, i] = np.copy(z)
+        finally:
+            if fault is not None:
                 fault.remove()
-                z, _, _, _ = integrate(
-                    z, theta, 0.0, psys, residual, jacobian, None,
-                    verbose=verbose, fsolve=False,
-                    newton_tol=newton_tol, newton_max_iter=newton_max_iter,
-                    uold=None, vold=None, mold=None,
-                )
-            history[:, i] = np.copy(z)
-
-        if fault is not None:
-            fault.remove()
 
     # pack results into dict
     results["tvec"] = tvec

--- a/uqgrid/simulation/herk.py
+++ b/uqgrid/simulation/herk.py
@@ -1,7 +1,8 @@
 """Half-explicit Runge-Kutta integrator for UQGrid.
 
 Heun (HERK2) and classical RK4 (HERK4) are wired through
-``integrate_system``.
+``integrate_system``. Enabled hard state limits are projected at each stage
+and accepted endpoint while the raw device equations remain unchanged.
 """
 
 from __future__ import annotations
@@ -9,6 +10,15 @@ from __future__ import annotations
 import numpy as np
 from scipy.sparse.linalg import spsolve
 
+from uqgrid.simulation.dynamic_limits import (
+    DynamicLimitError,
+    _contextualize_dynamic_limit_runtime_error,
+    collect_limited_state_descriptors,
+    initialize_dynamic_limit_modes,
+    project_limited_derivatives,
+    project_limited_states,
+    update_explicit_dynamic_limit_modes,
+)
 from uqgrid.simulation.residual import residual_function
 from uqgrid.simulation.jacobian import residual_jacobian
 from uqgrid.simulation.timing import build_integration_schedule
@@ -80,11 +90,29 @@ def solve_stage_algebraic(X_i, y0, v0, theta, psys, F_full, J_full,
 # ---------------------------------------------------------------------------
 
 
-def herk_step(z_old, theta, h, psys, A, b, c, F, J, tol, max_iter):
-    """Advance one HERK step from ``z_old`` by ``h``.
+def _herk_step_with_limits(
+    z_old,
+    theta,
+    h,
+    psys,
+    A,
+    b,
+    c,
+    F,
+    J,
+    tol,
+    max_iter,
+    *,
+    limit_descriptors=(),
+    limit_tolerance=0.0,
+    limit_modes=None,
+    t_start=0.0,
+):
+    """Advance one HERK step and return limiter state and events."""
+    limit_descriptors = list(limit_descriptors)
+    if limit_modes is None:
+        limit_modes = initialize_dynamic_limit_modes(limit_descriptors)
 
-    Returns the new combined state vector ``z_new = [x_new; y_new; v_new]``.
-    """
     NDIFFEQ = psys.num_dof_dif
     alg_size = psys.num_dof_alg
     s = len(b)
@@ -95,6 +123,7 @@ def herk_step(z_old, theta, h, psys, A, b, c, F, J, tol, max_iter):
 
     K = np.zeros((s, NDIFFEQ))
     Y_last, V_last = y_prev, v_prev
+    events = []
 
     for i in range(s):
         X_i = x_n.copy()
@@ -103,20 +132,99 @@ def herk_step(z_old, theta, h, psys, A, b, c, F, J, tol, max_iter):
             if a_ij != 0.0:
                 X_i += h * a_ij * K[j]
 
+        stage_time = t_start + c[i] * h
+        stage_name = f"stage_{i + 1}"
+        if limit_descriptors:
+            X_i, projection_events = project_limited_states(
+                X_i,
+                limit_descriptors,
+                time=stage_time,
+                stage_or_endpoint=stage_name,
+            )
+            events.extend(projection_events)
+
         Y_i, V_i, _ = solve_stage_algebraic(
             X_i, Y_last, V_last, theta, psys, F, J, tol, max_iter)
         Y_last, V_last = Y_i, V_i
 
         z_stage = np.concatenate([X_i, Y_i, V_i])
         residual_function(F, z_stage, theta, psys)
-        K[i] = F[:NDIFFEQ].copy()
+        raw_derivative = F[:NDIFFEQ].copy()
+        if limit_descriptors:
+            K[i], _ = project_limited_derivatives(
+                X_i,
+                raw_derivative,
+                limit_descriptors,
+                tolerance=limit_tolerance,
+                time=stage_time,
+                stage_or_endpoint=stage_name,
+            )
+            limit_modes, _, transition_events = (
+                update_explicit_dynamic_limit_modes(
+                    X_i,
+                    raw_derivative,
+                    limit_descriptors,
+                    limit_modes,
+                    tolerance=limit_tolerance,
+                    time=stage_time,
+                    stage_or_endpoint=stage_name,
+                )
+            )
+            events.extend(transition_events)
+        else:
+            K[i] = raw_derivative
 
     x_new = x_n + h * (b @ K)
+    endpoint_time = t_start + h
+    if limit_descriptors:
+        x_new, projection_events = project_limited_states(
+            x_new,
+            limit_descriptors,
+            time=endpoint_time,
+            stage_or_endpoint="endpoint",
+        )
+        events.extend(projection_events)
 
     Y_new, V_new, _ = solve_stage_algebraic(
         x_new, Y_last, V_last, theta, psys, F, J, tol, max_iter)
+    z_new = np.concatenate([x_new, Y_new, V_new])
 
-    return np.concatenate([x_new, Y_new, V_new])
+    if limit_descriptors:
+        residual_function(F, z_new, theta, psys)
+        raw_derivative = F[:NDIFFEQ].copy()
+        limit_modes, _, transition_events = update_explicit_dynamic_limit_modes(
+            x_new,
+            raw_derivative,
+            limit_descriptors,
+            limit_modes,
+            tolerance=limit_tolerance,
+            time=endpoint_time,
+            stage_or_endpoint="endpoint",
+        )
+        events.extend(transition_events)
+
+    return z_new, limit_modes, events
+
+
+def herk_step(z_old, theta, h, psys, A, b, c, F, J, tol, max_iter):
+    """Advance one unconstrained HERK step from ``z_old`` by ``h``.
+
+    Returns the new combined state vector ``z_new = [x_new; y_new; v_new]``.
+    """
+    z_new, _, _ = _herk_step_with_limits(
+        z_old,
+        theta,
+        h,
+        psys,
+        A,
+        b,
+        c,
+        F,
+        J,
+        tol,
+        max_iter,
+    )
+    return z_new
 
 
 # ---------------------------------------------------------------------------
@@ -129,10 +237,11 @@ def integrate_system_herk(psys, config, ctx=None):
 
     Only the no-PETSc, no-sensitivity, no-fsolve, no-ARKIMEX,
     no-Jacobian-check path is supported. Fault on/off events are handled
-    between steps via an algebraic resolve.
+    between steps via an algebraic resolve. Enabled hard limits are enforced
+    at RK stages and weighted endpoints without changing the time grid.
     """
     from uqgrid.simulation.dynamics import (
-        _initialize_system_from_config,
+        _initialize_integration_state,
         preallocate_jacobian,
     )
 
@@ -157,18 +266,17 @@ def integrate_system_herk(psys, config, ctx=None):
 
     psys.power_injection = config.power_injection
 
-    pf_solution, z0, theta = _initialize_system_from_config(psys, config)
-
-    z0_user = ctx.z0_user if ctx is not None else getattr(config, "z0_user", None)
-    theta_user = ctx.theta_user if ctx is not None else getattr(config, "theta_user", None)
-    if z0_user is not None:
-        if z0_user.shape[0] != z0.shape[0]:
-            raise ValueError("Provided initial state does not match system size.")
-        z0 = z0_user
-    if theta_user is not None:
-        if theta_user.shape[0] != theta.shape[0]:
-            raise ValueError("Provided theta does not match system parameters.")
-        theta = theta_user
+    pf_solution, z0, theta, dynamic_limit_diagnostics = (
+        _initialize_integration_state(psys, config, ctx)
+    )
+    limit_descriptors = []
+    if config.enforce_dynamic_limits:
+        limit_descriptors = [
+            descriptor
+            for descriptor in collect_limited_state_descriptors(psys, theta)
+            if descriptor.enabled
+        ]
+    limit_modes = initialize_dynamic_limit_modes(limit_descriptors)
 
     system_size = z0.shape[0]
     J = preallocate_jacobian(psys)
@@ -198,37 +306,69 @@ def integrate_system_herk(psys, config, ctx=None):
     NDIFFEQ = psys.num_dof_dif
     alg_size = psys.num_dof_alg
 
-    for i in range(1, len(tvec)):
-        t_start = tvec[i - 1]
-        h_step = tvec[i] - t_start
-        if psys.signal_injectors:
-            for inj in psys.signal_injectors:
-                inj.update(t_start, theta, psys)
-        z = herk_step(z, theta, h_step, psys, A, b, c, F, J, tol, max_iter)
+    try:
+        for i in range(1, len(tvec)):
+            t_start = tvec[i - 1]
+            h_step = tvec[i] - t_start
+            if psys.signal_injectors:
+                for inj in psys.signal_injectors:
+                    inj.update(t_start, theta, psys)
+            try:
+                z, limit_modes, limit_events = _herk_step_with_limits(
+                    z,
+                    theta,
+                    h_step,
+                    psys,
+                    A,
+                    b,
+                    c,
+                    F,
+                    J,
+                    tol,
+                    max_iter,
+                    limit_descriptors=limit_descriptors,
+                    limit_tolerance=config.dynamic_limit_tolerance,
+                    limit_modes=limit_modes,
+                    t_start=t_start,
+                )
+            except DynamicLimitError as exc:
+                raise _contextualize_dynamic_limit_runtime_error(
+                    exc,
+                    method=method,
+                    backend="native",
+                    time=tvec[i],
+                    stage_or_endpoint="endpoint",
+                    prior_events=dynamic_limit_diagnostics["events"],
+                ) from exc
+            dynamic_limit_diagnostics["events"].extend(limit_events)
 
-        if i == schedule.fault_on_index:
-            fault.apply()
-            x = z[:NDIFFEQ]
-            y = z[NDIFFEQ:NDIFFEQ + alg_size]
-            v = z[NDIFFEQ + alg_size:]
-            y_new, v_new, _ = solve_stage_algebraic(
-                x, y, v, theta, psys, F, J, tol, max_iter)
-            z = np.concatenate([x, y_new, v_new])
+            if i == schedule.fault_on_index:
+                fault.apply()
+                x = z[:NDIFFEQ]
+                y = z[NDIFFEQ:NDIFFEQ + alg_size]
+                v = z[NDIFFEQ + alg_size:]
+                y_new, v_new, _ = solve_stage_algebraic(
+                    x, y, v, theta, psys, F, J, tol, max_iter)
+                z = np.concatenate([x, y_new, v_new])
 
-        if i == schedule.fault_off_index:
+            if i == schedule.fault_off_index:
+                fault.remove()
+                x = z[:NDIFFEQ]
+                y = z[NDIFFEQ:NDIFFEQ + alg_size]
+                v = z[NDIFFEQ + alg_size:]
+                y_new, v_new, _ = solve_stage_algebraic(
+                    x, y, v, theta, psys, F, J, tol, max_iter)
+                z = np.concatenate([x, y_new, v_new])
+            history[:, i] = z
+    finally:
+        if fault is not None:
             fault.remove()
-            x = z[:NDIFFEQ]
-            y = z[NDIFFEQ:NDIFFEQ + alg_size]
-            v = z[NDIFFEQ + alg_size:]
-            y_new, v_new, _ = solve_stage_algebraic(
-                x, y, v, theta, psys, F, J, tol, max_iter)
-            z = np.concatenate([x, y_new, v_new])
-        history[:, i] = z
 
-    if fault is not None:
-        fault.remove()
-
-    results = {"tvec": tvec, "history": history}
+    results = {
+        "tvec": tvec,
+        "history": history,
+        "dynamic_limit_diagnostics": dynamic_limit_diagnostics,
+    }
     if pf_solution.validation is not None:
         results["power_flow_diagnostics"] = pf_solution.validation
     return results


### PR DESCRIPTION
## Summary

Adds directional, non-windup EMIN/EMAX enforcement for SEXS Efd states across UQGrid's supported production integrators.

- enables valid finite SEXS limits parsed from DYR files;
- validates enabled limited states before time stepping;
- enforces stage and endpoint projection for HERK2/HERK4;
- adds fixed-active-set backward Euler solves for native Newton and PETSc SNES;
- adds an explicit trapezoidal active-set path for PETSc Crank-Nicolson;
- preserves the raw SEXS residual and Jacobian equations.

Hard dynamic limits default to enabled. Setting `enforce_dynamic_limits=false` preserves the legacy unconstrained behavior.

## Solver behavior

- HERK2/HERK4 project tentative stages and weighted endpoints, solve algebraics after projection, block only outward Efd derivatives, and release immediately for inward motion.
- Native and PETSc backward Euler replace active Efd rows with exact bound equations and use discarded free residuals for directional release.
- Limited PETSc BE and CN use ordinary SNES managed by UQGrid
- Limited PETSc CN fixes the directionally blocked starting derivative across endpoint active-set retries.
- Limiter transitions occur at stages or normalized endpoints without event localization or additional timestamps.

ARKIMEX, sensitivities, and the legacy fsolve path require `enforce_dynamic_limits=false`.

## Diagnostics and safety

Adds JSON-safe limited-state descriptors, initialization and runtime diagnostics, and a common event schema containing device identity, side, action, time, stage/endpoint context, state values, bounds, derivatives/residuals, and active-set iterations.

Initialization and runtime failures are classified separately by the scenario generator. Native BE, HERK, and limited PETSc paths restore fault topology after normal completion or failure.

## Validation

Tests use model-agnostic two-bus and IEEE-9 fixtures. The dedicated IEEE-9 SEXS fixture contains three enabled exciters with deterministic narrow effective limits and opposing drives. Every supported integrator is required to activate all three expected upper/lower/upper limits, reach the exact bounds, remain pinned under outward drive, and preserve algebraic consistency.

Additional coverage includes:

- upper/lower activation, persistent pinning, and inward release;
- simultaneous limited exciters;
- initial-state and malformed-bound rejection;
- native/PETSc BE trajectory and event agreement;
- PETSc CN residuals, starting-derivative blocking, and smooth-region convergence;
- aligned and off-grid fault transitions;
- no-fault flat trajectories and decreasing-step cross-integrator convergence;
- runtime error classification and fault cleanup after failures;
- a standard IEEE-9 negative control with no SEXS descriptors.

Full suite: `348 passed, 2 skipped`.

